### PR TITLE
Aec connect

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -428,27 +428,27 @@ for iFile = 1:length(FilesA)
             nFreqBands = size(OPTIONS.Freqs, 1);
             BandBounds = process_tf_bands('GetBounds', OPTIONS.Freqs);
 
-            % Intitialize returned matrix
+            % Initialize returned matrix
             R = zeros(size(sInputA.Data,1), size(sInputB.Data,1), nFreqBands);
             % Loop on each frequency band
             for iBand = 1:nFreqBands
                 % Band-pass filter in one frequency band + Apply Hilbert transform
+                DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
+                HA = hilbert_fcn(DataAband')';                
                 if isConnNN
-                    DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
-                    HA = hilbert_fcn(DataAband')';
                     HB = HA;
                 else
-                    DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
                     DataBband = process_bandpass('Compute', sInputB.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
-                    HA = hilbert_fcn(DataAband')';
                     HB = hilbert_fcn(DataBband')';
                 end
                 if OPTIONS.isOrth
                     if isConnNN
                         for iSeed = 1:size(HA,1)
                             % Orthogonalize complex coefficients, based on Hipp et al. 2012
+                            % HBo is the amplitude of the component orthogonal to HA                            
                             HBo = imag(bsxfun(@times, HB, conj(HA(iSeed,:))./abs(HA(iSeed,:))));
-%                             HBos = real(HBo .* ((1i*HA)./abs(HA))); % for generating the time-series
+                            % The orthogonalized signal can be computed like this (not necessary here):
+                            % HBos = real(HBo .* ((1i*HA)./abs(HA)));
                             % avoid rounding errors
                             HBo(abs(HBo./abs(HB))<2*eps)=0;
                             % Compute correlation coefficients

--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -420,6 +420,64 @@ for iFile = 1:length(FilesA)
                 Comment = sprintf('SpGranger(%1.1fHz): ', OPTIONS.Freqs(2)-OPTIONS.Freqs(1));
             end
             
+        % ==== AEC ====
+        case 'aec'
+            bst_progress('text', sprintf('Calculating: AEC [%dx%d]...', size(sInputA.Data,1), size(sInputB.Data,1)));
+            Comment = 'AEC: ';
+            % Get frequency bands
+            nFreqBands = size(OPTIONS.Freqs, 1);
+            BandBounds = process_tf_bands('GetBounds', OPTIONS.Freqs);
+
+            % Intitialize returned matrix
+            R = zeros(size(sInputA.Data,1), size(sInputB.Data,1), nFreqBands);
+            % Loop on each frequency band
+            for iBand = 1:nFreqBands
+                % Band-pass filter in one frequency band + Apply Hilbert transform
+                if isConnNN
+                    DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
+                    HA = hilbert_fcn(DataAband')';
+                    HB = HA;
+                else
+                    DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
+                    DataBband = process_bandpass('Compute', sInputB.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
+                    HA = hilbert_fcn(DataAband')';
+                    HB = hilbert_fcn(DataBband')';
+                end
+                if OPTIONS.isOrth
+                    if isConnNN
+                        for iSeed = 1:size(HA,1)
+                            % Orthogonalize complex coefficients, based on Hipp et al. 2012
+                            HBo = imag(bsxfun(@times, HB, conj(HA(iSeed,:))./abs(HA(iSeed,:))));
+%                             HBos = real(HBo .* ((1i*HA)./abs(HA))); % for generating the time-series
+                            % avoid rounding errors
+                            HBo(abs(HBo./abs(HB))<2*eps)=0;
+                            % Compute correlation coefficients
+                            R(iSeed,:,iBand) = correlate_dims(abs(HBo), abs(HA(iSeed,:)), 2);
+                        end
+                        % average the two "directions"
+                        R(:,:,iBand) = (R(:,:,iBand)+R(:,:,iBand)')/2;
+                    else
+                        for iSeed = 1:size(HA,1)
+                            HAo = imag(bsxfun(@times, HA(iSeed,:), conj(HB)./abs(HB)));
+                            HBo = imag(bsxfun(@times, HB, conj(HA(iSeed,:))./abs(HA(iSeed,:))));
+                            % avoid rounding errors
+                            HAo(abs(bsxfun(@rdivide,HAo,abs(HA)))<2*eps)=0;
+                            HBo(abs(HBo./abs(HB))<2*eps)=0;
+                            % Compute correlation coefficients
+                            r1 = correlate_dims(abs(HA(iSeed,:)), abs(HBo), 2);
+                            r2 = correlate_dims(abs(HB), abs(HAo), 2);
+                            R(iSeed,:,iBand) = (r1+r2)/2;
+                        end
+                    end
+                else
+                    ampA = abs(HA);
+                    ampB = abs(HB);
+                    R(:,:,iBand) = corr(ampA',ampB');
+                end
+            end
+            % We don't want to compute again the frequency bands
+            FreqBands = [];            
+            
         % ==== PLV ====
         case 'plv'
             bst_progress('text', sprintf('Calculating: PLV [%dx%d]...', size(sInputA.Data,1), size(sInputB.Data,1)));
@@ -743,5 +801,16 @@ function [sConcat, sAverage] = LoadAll(FileNames, Target, TimeWindow, LoadOption
     end
 end
 
+function R = correlate_dims(A, B, dim)
+    A = bsxfun( @minus, A, mean( A, dim) );
+    B = bsxfun( @minus, B, mean( B, dim) );
+    A = normr(A);
+    B = normr(B);
+    R = sum(bsxfun(@times, A, B), dim);
+end
 
-
+function x = normr(x)
+    n = sqrt(sum(x.^2,2));
+    x(n~=0,:) = bst_bsxfun(@rdivide, x(n~=0,:), n(n~=0));
+    x(n==0,:) = 1 ./ sqrt(size(x,2));
+end

--- a/toolbox/gui/figure_connect.m
+++ b/toolbox/gui/figure_connect.m
@@ -2266,7 +2266,7 @@ function UpdateColormap(hFig)
     ThresholdMinMax = getappdata(hFig, 'ThresholdMinMax');
     % === COLORMAP LIMITS ===
     % Units type
-    if ismember(Method, {'granger', 'spgranger', 'plv', 'plvt'})
+    if ismember(Method, {'granger', 'spgranger', 'plv', 'plvt', 'aec'})
         UnitsType = 'timefreq';
     else
         UnitsType = 'connect';
@@ -2274,7 +2274,7 @@ function UpdateColormap(hFig)
     % Get colormap bounds
     if strcmpi(sColormap.MaxMode, 'custom')
         CLim = [sColormap.MinValue, sColormap.MaxValue];
-    elseif ismember(Method, {'granger', 'spgranger', 'plv', 'plvt', 'cohere'})
+    elseif ismember(Method, {'granger', 'spgranger', 'plv', 'plvt', 'aec', 'cohere'})
         CLim = [DataMinMax(1) DataMinMax(2)];
     elseif ismember(Method, {'corr'})
         if strcmpi(sColormap.MaxMode, 'local')

--- a/toolbox/process/functions/process_aec1.m
+++ b/toolbox/process/functions/process_aec1.m
@@ -1,0 +1,91 @@
+function varargout = process_aec1( varargin )
+% PROCESS_PLV1: Compute amplitude envelope correlation between one signal and all the others, in one file.
+
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% http://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2016 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Francois Tadel, 2012-2014
+%          Peter Donhauser, 2017
+
+eval(macro_method);
+end
+
+
+%% ===== GET DESCRIPTION =====
+function sProcess = GetDescription() %#ok<DEFNU>
+    % Description the process
+    sProcess.Comment     = 'Amplitude Envelope Correlation 1xN';
+    sProcess.Category    = 'Custom';
+    sProcess.SubGroup    = 'Connectivity';
+    sProcess.Index       = 661;
+    sProcess.Description = 'http://neuroimage.usc.edu/brainstorm/Tutorials/Connectivity';
+    % Definition of the input accepted by this process
+    sProcess.InputTypes  = {'data',     'results',  'matrix'};
+    sProcess.OutputTypes = {'timefreq', 'timefreq', 'timefreq'};
+    sProcess.nInputs     = 1;
+    sProcess.nMinFiles   = 1;
+
+    % === CONNECT INPUT
+    sProcess = process_corr1n('DefineConnectOptions', sProcess, 0);
+    % === FREQ BANDS
+    sProcess.options.label2.Comment = '<BR><U><B>Estimator options</B></U>:';
+    sProcess.options.label2.Type    = 'label';
+    sProcess.options.freqbands.Comment = 'Frequency bands for the Hilbert transform:';
+    sProcess.options.freqbands.Type    = 'groupbands';
+    sProcess.options.freqbands.Value   = bst_get('DefaultFreqBands');
+    % === Mirror
+    sProcess.options.mirror.Comment = 'Mirror signal before filtering (not recommended)';
+    sProcess.options.mirror.Type    = 'checkbox';
+    sProcess.options.mirror.Value   = 0;
+    % === Orthogonalize pairs of signals
+    sProcess.options.isorth.Comment = 'Orthogonalize signal pairs before envelope computation';
+    sProcess.options.isorth.Type    = 'checkbox';
+    sProcess.options.isorth.Value   = 0;
+    % === OUTPUT MODE
+    sProcess.options.label3.Comment = '<BR><U><B>Output configuration</B></U>:';
+    sProcess.options.label3.Type    = 'label';
+    sProcess.options.outputmode.Comment = {'Save individual results (one file per input file)', 'Concatenate input files before processing (one file)', 'Save average connectivity matrix (one file)'};
+    sProcess.options.outputmode.Type    = 'radio';
+    sProcess.options.outputmode.Value   = 1;
+end
+
+
+%% ===== FORMAT COMMENT =====
+function Comment = FormatComment(sProcess) %#ok<DEFNU>
+    Comment = sProcess.Comment;
+end
+
+
+%% ===== RUN =====
+function OutputFiles = Run(sProcess, sInputA) %#ok<DEFNU>
+    % Input options
+    OPTIONS = process_corr1n('GetConnectOptions', sProcess, sInputA);
+    if isempty(OPTIONS)
+        OutputFiles = {};
+        return
+    end
+
+    OPTIONS.Method = 'aec';
+    % Hilbert and frequency bands options
+    OPTIONS.Freqs = sProcess.options.freqbands.Value;
+    OPTIONS.isMirror = sProcess.options.mirror.Value;
+    OPTIONS.isOrth = sProcess.options.isorth.Value;
+    
+    % Compute metric
+    OutputFiles = bst_connectivity({sInputA.FileName}, {sInputA.FileName}, OPTIONS);
+end

--- a/toolbox/process/functions/process_aec1n.m
+++ b/toolbox/process/functions/process_aec1n.m
@@ -1,0 +1,92 @@
+function varargout = process_aec1n( varargin )
+% PROCESS_PLV1N: Compute amplitude envelope correlation between all the pairs of signals, in one file.
+
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% http://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2016 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Francois Tadel, 2012-2014
+%          Peter Donhauser, 2017
+
+eval(macro_method);
+end
+
+
+%% ===== GET DESCRIPTION =====
+function sProcess = GetDescription() %#ok<DEFNU>
+    % Description the process
+    sProcess.Comment     = 'Amplitude Envelope Correlation NxN';
+    sProcess.Category    = 'Custom';
+    sProcess.SubGroup    = 'Connectivity';
+    sProcess.Index       = 662;
+    sProcess.Description = 'http://neuroimage.usc.edu/brainstorm/Tutorials/Connectivity';
+    % Definition of the input accepted by this process
+    sProcess.InputTypes  = {'data',     'results',  'matrix'};
+    sProcess.OutputTypes = {'timefreq', 'timefreq', 'timefreq'};
+    sProcess.nInputs     = 1;
+    sProcess.nMinFiles   = 1;
+    sProcess.isSeparator = 1;
+
+    % === CONNECT INPUT
+    sProcess = process_corr1n('DefineConnectOptions', sProcess, 1);
+    % === FREQ BANDS
+    sProcess.options.label2.Comment = '<BR><U><B>Estimator options</B></U>:';
+    sProcess.options.label2.Type    = 'label';
+    sProcess.options.freqbands.Comment = 'Frequency bands for the Hilbert transform:';
+    sProcess.options.freqbands.Type    = 'groupbands';
+    sProcess.options.freqbands.Value   = bst_get('DefaultFreqBands');
+    % === Mirror
+    sProcess.options.mirror.Comment = 'Mirror signal before filtering (not recommended)';
+    sProcess.options.mirror.Type    = 'checkbox';
+    sProcess.options.mirror.Value   = 0;
+    % === KEEP TIME
+    sProcess.options.isorth.Comment = 'Orthogonalize signal pairs before envelope computation';
+    sProcess.options.isorth.Type    = 'checkbox';
+    sProcess.options.isorth.Value   = 0;
+    % === OUTPUT
+    sProcess.options.label3.Comment = '<BR><U><B>Output configuration</B></U>:';
+    sProcess.options.label3.Type    = 'label';
+    % === OUTPUT MODE
+    sProcess.options.outputmode.Comment = {'Save individual results (one file per input file)', 'Concatenate input files before processing (one file)', 'Save average connectivity matrix (one file)'};
+    sProcess.options.outputmode.Type    = 'radio';
+    sProcess.options.outputmode.Value   = 1;
+end
+
+
+%% ===== FORMAT COMMENT =====
+function Comment = FormatComment(sProcess) %#ok<DEFNU>
+    Comment = sProcess.Comment;
+end
+
+
+%% ===== RUN =====
+function OutputFiles = Run(sProcess, sInputA) %#ok<DEFNU>
+    % Input options
+    OPTIONS = process_corr1n('GetConnectOptions', sProcess, sInputA);
+    if isempty(OPTIONS)
+        OutputFiles = {};
+        return
+    end
+    OPTIONS.Method = 'aec';
+    % Filtering bands options
+    OPTIONS.Freqs = sProcess.options.freqbands.Value;
+    OPTIONS.isMirror = sProcess.options.mirror.Value;
+    OPTIONS.isOrth = sProcess.options.isorth.Value;
+    
+    % Compute metric
+    OutputFiles = bst_connectivity({sInputA.FileName}, [], OPTIONS);
+end


### PR DESCRIPTION
Hi Francois, this is implementing amplitude envelope correlation (AEC) as an additional connectivity metric in BST. It's very similar to the method used in e.g. 

Hipp, Joerg F., et al. "Large-scale cortical correlation structure of spontaneous oscillatory activity." Nature neuroscience 15.6 (2012): 884-890.

It computes the correlation between the band-limited envelopes, and the user has the option to orthogonalize the source time-series before computing the envelopes. This is a way of excluding zero-phase interactions that could be due to fieldspread.

I thought it would be useful for the main distribution, let me know what you think. I have some example scripts here: https://github.com/pwdonh/bst_scripts