### PR TITLE
Bugfix for EDF+ export (multi-epoched events + fractional records)

### DIFF
--- a/toolbox/io/out_fopen_edf.m
+++ b/toolbox/io/out_fopen_edf.m
@@ -63,15 +63,43 @@ header.nrec       = ceil(header.nrec / header.reclen);
 if ~isempty(sFileIn.events)
     header.nsignal     = header.nsignal + 1;
     header.annotchan   = header.nsignal;
-    
-    global nextEdfEvent;
-    nextEdfEvent = struct('event', -1, 'annot', [], 'epoch', -1);
 
     % Some EDF+ fields are required by strict viewers such as EDFbrowser
     header.unknown1    = 'EDF+C';
     header.patient_id  = 'UNKNOWN M 01-JAN-1900 Unknown_Patient';
     header.rec_id      = ['Startdate ', upper(datestr(date, 'dd-mmm-yyyy')), ...
                           ' Unknown_Hospital Unknown_Technician Unknown_Equipment'];
+
+    % Compute annotations
+    header.annotations = {};
+    maxAnnotLength     = 0;
+    
+    for iEvt = 1:numel(sFileIn.events)
+        event       = sFileIn.events(iEvt);
+        hasDuration = numel(event.epochs) ~= numel(event.times);
+        
+        for iEpc = 1:numel(event.epochs)
+            if hasDuration
+                startTime = event.times(2 * iEpc - 1);
+            else
+                startTime = event.times(iEpc);
+            end
+            
+            annot = sprintf('+%f', startTime);
+            
+            if hasDuration
+                duration = event.times(2 * iEpc) - startTime;
+                annot    = [annot, sprintf('%c%f', char(21), duration)];
+            end
+            
+            annot = [annot, sprintf('%c%s%c%c', char(20), event.label, char(20), char(0))];
+            header.annotations{end + 1} = annot;
+            
+            if length(annot) > maxAnnotLength
+                maxAnnotLength = length(annot);
+            end
+        end
+    end
 else
     header.annotchan   = -1;
     header.unknown1    = '';
@@ -94,24 +122,8 @@ for i = 1:header.nsignal
     if i == header.annotchan
         header.signal(i).label    = 'EDF Annotations';
         header.signal(i).type     = '';
-        header.signal(i).nsamples = 12 * header.nrec; % For first annotation of each record
-        maxEventSize              = 0;
-        
-        for j = 1:length(sFileIn.events)
-            eventSize = length(sFileIn.events(j).label) + 25;
-            header.signal(i).nsamples = header.signal(i).nsamples + eventSize * numel(sFileIn.events(j).epochs);
-            
-            if eventSize > maxEventSize
-                maxEventSize = eventSize;
-            end
-        end
-        header.signal(i).nsamples = int64(header.signal(i).nsamples / header.nrec);
-        
-        % The annotation record cannot be smaller than the largest event
-        % plus the first annotation (12 bytes) of the record
-        if header.signal(i).nsamples < maxEventSize + 12
-            header.signal(i).nsamples = maxEventSize + 12;
-        end
+        eventsPerRecord           = ceil(numel(header.annotations) / header.nrec);
+        header.signal(i).nsamples = eventsPerRecord * maxAnnotLength + 15; % For first annotation of each record
         
         % Convert chars (1-byte) to 2-byte integers, the size of a sample
         header.signal(i).nsamples = int64((header.signal(i).nsamples + 1) / 2);

--- a/toolbox/io/out_fopen_edf.m
+++ b/toolbox/io/out_fopen_edf.m
@@ -99,7 +99,7 @@ for i = 1:header.nsignal
         
         for j = 1:length(sFileIn.events)
             eventSize = length(sFileIn.events(j).label) + 25;
-            header.signal(i).nsamples = header.signal(i).nsamples + eventSize;
+            header.signal(i).nsamples = header.signal(i).nsamples + eventSize * numel(sFileIn.events(j).epochs);
             
             if eventSize > maxEventSize
                 maxEventSize = eventSize;

--- a/toolbox/io/out_fwrite_edf.m
+++ b/toolbox/io/out_fwrite_edf.m
@@ -77,7 +77,7 @@ nSamplesPerRecord = sFile.prop.sfreq * sFile.header.reclen;
 nRecords          = ceil((SamplesBounds(2) - SamplesBounds(1)) / nSamplesPerRecord);
 ncount            = 0;
 bounds            = [1, nSamplesPerRecord];
-timeOffset        = SamplesBounds(1) / nSamplesPerRecord;
+timeOffset        = SamplesBounds(1) / sFile.prop.sfreq;
 
 for iRec = 1:nRecords
     % Special case when we don't have enough data to fill the last record

--- a/toolbox/io/out_fwrite_edf.m
+++ b/toolbox/io/out_fwrite_edf.m
@@ -21,6 +21,15 @@ function out_fwrite_edf(sFile, sfid, SamplesBounds, ChannelsRange, F)
 %
 % Authors: Martin Cousineau, 2017
 
+% ===== PARSE INPUTS =====
+[nSignals, nSamples] = size(F);
+if isempty(SamplesBounds)
+    SamplesBounds = [0, nSamples];
+end
+if isempty(ChannelsRange)
+    ChannelsRange = [1, nSignals];
+end
+
 fseek(sfid, 0, 'eof');
 
 % Convert V to uV to avoid precision loss
@@ -34,25 +43,46 @@ F(negF) = bitcmp(abs(F(negF))) + 1;
 % Prepare annotations if any.
 if sFile.header.annotchan >= 0
     annotations    = 1;
-    nextEvent      = 1;
-    nextAnnot      = [];
     nEvents        = length(sFile.events);
     nSamplesAnnots = sFile.header.signal(sFile.header.annotchan).nsamples;
+
+    global nextEdfEvent;
+    if nextEdfEvent.event < 0
+        nextEdfEvent.event = 1;
+        nextEdfEvent.epoch = 1;
+        nextEdfEvent.annot = [];
+    end
 else
     annotations = 0;
 end
 
 % Write to file record per record
-nSamplesPerRecord    = sFile.prop.sfreq * sFile.header.reclen;
-nRecords             = int16(sFile.header.nrec);
-[nSignals, nSamples] = size(F);
-ncount               = 0;
-bounds               = [1, nSamplesPerRecord];
-timeOffset           = 0.0;
+nSamplesPerRecord = sFile.prop.sfreq * sFile.header.reclen;
+nRecords          = ceil((SamplesBounds(2) - SamplesBounds(1)) / nSamplesPerRecord);
+ncount            = 0;
+bounds            = [1, nSamplesPerRecord];
+timeOffset        = SamplesBounds(1) / nSamplesPerRecord;
 
 for iRec = 1:nRecords
-    for iSig = 1:nSignals
+    % Special case when we don't have enough data to fill the last record
+    if bounds(2) > nSamples
+        if iRec ~= nRecords
+            error('Ran out of data before last record.');
+        end
+        writeZeros = bounds(2) - nSamples;
+        bounds(2)  = nSamples;
+    else
+        writeZeros = 0;
+    end
+
+    % Write data
+    for iSig = ChannelsRange(1):ChannelsRange(2)
         ncount = ncount + fwrite(sfid, F(iSig, bounds(1):bounds(2)), 'int16');
+        
+        % Fill rest of the record with 0s if required
+        if writeZeros
+            fwrite(sfid, zeros(writeZeros, 1), 'int16');
+        end
     end
     
     % Write annotations if any, split by records
@@ -63,29 +93,38 @@ for iRec = 1:nRecords
         bytesLeft = bytesLeft - fprintf(sfid, '+%f%c%c%c', timeOffset, char(20), char(20), char(0));
         
         % Write as many annotations as possible in current record
-        while bytesLeft >= length(nextAnnot)
-            if ~isempty(nextAnnot)
-                bytesLeft = bytesLeft - fprintf(sfid, '%s', nextAnnot);
+        while bytesLeft >= length(nextEdfEvent.annot)
+            if ~isempty(nextEdfEvent.annot)
+                bytesLeft = bytesLeft - fprintf(sfid, '%s', nextEdfEvent.annot);
             end
             
-            if nextEvent > nEvents
-                nextAnnot = [];
+            if nextEdfEvent.event > nEvents
+                nextEdfEvent.annot = [];
                 break;
             end
             
             % Prepare the next annotation string
-            event = sFile.events(nextEvent);
-            startTime = event.times(1);
-            nextAnnot = sprintf('+%f', startTime);
+            event = sFile.events(nextEdfEvent.event);
+            startTime = event.times(nextEdfEvent.epoch);
+            nextEdfEvent.annot = sprintf('+%f', startTime);
 
             % Add duration if specified.
-            if length(event.times) > 1
-                duration = event.times(2) - startTime;
-                nextAnnot = [nextAnnot sprintf('%c%f', char(21), duration)];
+            if numel(event.epochs) ~= numel(event.times)
+                nextEdfEvent.epoch = nextEdfEvent.epoch + 1;
+                duration = event.times(nextEdfEvent.epoch) - startTime;
+                nextEdfEvent.annot = [nextEdfEvent.annot, ...
+                    sprintf('%c%f', char(21), duration)];
             end
 
-            nextAnnot = [nextAnnot sprintf('%c%s%c%c', char(20), event.label, char(20), char(0))];
-            nextEvent = nextEvent + 1;
+            nextEdfEvent.epoch = nextEdfEvent.epoch + 1;
+            nextEdfEvent.annot = [nextEdfEvent.annot, ...
+                sprintf('%c%s%c%c', char(20), event.label, char(20), char(0))];
+
+            % If this is the last epoch of the event, go to next event
+            if nextEdfEvent.epoch > numel(event.times)
+                nextEdfEvent.event = nextEdfEvent.event + 1;
+                nextEdfEvent.epoch = 1;
+            end
         end
         
         % Fill remaining of record with 0-bytes.


### PR DESCRIPTION
I do not have access to the master so I'm creating a new PR. I get now what you meant with the bug on record length, I now allow records not completely filled and pad the last record with zero like you suggested. Multi-epoched events were also not supported so I fixed that.

It seems that for some situations, out_fwrite_edf() is called multiple times for the same file. That causes issues with my code because I need to save the nextEvent (annotation) but that information is lost at the next call. I cannot save it in the file header because a struct is passed by value in Matlab. I didn't feel like making major changes to out_fwrite() by adding a return value or something, so I just used a Matlab global variable. Maybe there's a way to set a "Brainstorm" global variable. If so, let me know, I'll do it this way.