### PR TITLE
bug fix, missing index, gave error when scout size > 1

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -461,7 +461,7 @@ for iFile = 1:length(FilesA)
                             HAo = imag(bsxfun(@times, HA(iSeed,:), conj(HB)./abs(HB)));
                             HBo = imag(bsxfun(@times, HB, conj(HA(iSeed,:))./abs(HA(iSeed,:))));
                             % avoid rounding errors
-                            HAo(abs(bsxfun(@rdivide,HAo,abs(HA)))<2*eps)=0;
+                            HAo(abs(bsxfun(@rdivide,HAo,abs(HA(iSeed,:))))<2*eps)=0;
                             HBo(abs(HBo./abs(HB))<2*eps)=0;
                             % Compute correlation coefficients
                             r1 = correlate_dims(abs(HA(iSeed,:)), abs(HBo), 2);


### PR DESCRIPTION
This gave an error in process_aec1.m when the seed scout for 1xN connectivity analysis had more than one vertex. 