### PR TITLE
Use default filtering options

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -433,12 +433,12 @@ for iFile = 1:length(FilesA)
             % Loop on each frequency band
             for iBand = 1:nFreqBands
                 % Band-pass filter in one frequency band + Apply Hilbert transform
-                DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), [], OPTIONS.isMirror);
+                DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2));
                 HA = hilbert_fcn(DataAband')';                
                 if isConnNN
                     HB = HA;
                 else
-                    DataBband = process_bandpass('Compute', sInputB.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), [], OPTIONS.isMirror);
+                    DataBband = process_bandpass('Compute', sInputB.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2));
                     HB = hilbert_fcn(DataBband')';
                 end
                 if OPTIONS.isOrth

--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -433,12 +433,12 @@ for iFile = 1:length(FilesA)
             % Loop on each frequency band
             for iBand = 1:nFreqBands
                 % Band-pass filter in one frequency band + Apply Hilbert transform
-                DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
+                DataAband = process_bandpass('Compute', sInputA.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), [], OPTIONS.isMirror);
                 HA = hilbert_fcn(DataAband')';                
                 if isConnNN
                     HB = HA;
                 else
-                    DataBband = process_bandpass('Compute', sInputB.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), 'bst-fft-fir', OPTIONS.isMirror);
+                    DataBband = process_bandpass('Compute', sInputB.Data, sfreq, BandBounds(iBand,1), BandBounds(iBand,2), [], OPTIONS.isMirror);
                     HB = hilbert_fcn(DataBband')';
                 end
                 if OPTIONS.isOrth

--- a/toolbox/process/functions/process_aec1.m
+++ b/toolbox/process/functions/process_aec1.m
@@ -48,10 +48,6 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.freqbands.Comment = 'Frequency bands for the Hilbert transform:';
     sProcess.options.freqbands.Type    = 'groupbands';
     sProcess.options.freqbands.Value   = bst_get('DefaultFreqBands');
-    % === Mirror
-    sProcess.options.mirror.Comment = 'Mirror signal before filtering (not recommended)';
-    sProcess.options.mirror.Type    = 'checkbox';
-    sProcess.options.mirror.Value   = 0;
     % === Orthogonalize pairs of signals
     sProcess.options.isorth.Comment = 'Orthogonalize signal pairs before envelope computation';
     sProcess.options.isorth.Type    = 'checkbox';
@@ -83,7 +79,6 @@ function OutputFiles = Run(sProcess, sInputA) %#ok<DEFNU>
     OPTIONS.Method = 'aec';
     % Hilbert and frequency bands options
     OPTIONS.Freqs = sProcess.options.freqbands.Value;
-    OPTIONS.isMirror = sProcess.options.mirror.Value;
     OPTIONS.isOrth = sProcess.options.isorth.Value;
     
     % Compute metric

--- a/toolbox/process/functions/process_aec1n.m
+++ b/toolbox/process/functions/process_aec1n.m
@@ -49,10 +49,6 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.freqbands.Comment = 'Frequency bands for the Hilbert transform:';
     sProcess.options.freqbands.Type    = 'groupbands';
     sProcess.options.freqbands.Value   = bst_get('DefaultFreqBands');
-    % === Mirror
-    sProcess.options.mirror.Comment = 'Mirror signal before filtering (not recommended)';
-    sProcess.options.mirror.Type    = 'checkbox';
-    sProcess.options.mirror.Value   = 0;
     % === KEEP TIME
     sProcess.options.isorth.Comment = 'Orthogonalize signal pairs before envelope computation';
     sProcess.options.isorth.Type    = 'checkbox';


### PR DESCRIPTION
I changed the AEC method to use the new filter implementation and also removed the mirroring option (email this morning). That way it simply follows the recommended procedures as in the filtering tutorial.

I didn't change the PLV yet, since it has been in the software much longer, so I thought there should be an option to use the old implementation..