### PR TITLE
Made Grid and Log buttons consistent when switching display modes.

### DIFF
--- a/toolbox/gui/figure_spectrum.m
+++ b/toolbox/gui/figure_spectrum.m
@@ -1080,16 +1080,8 @@ function UpdateFigurePlot(hFig, isForced)
     if TsInfo.ShowXGrid
         set(hAxes, 'XGrid', 'on');
         set(hAxes, 'XMinorGrid', 'on');
-        
-        % No YGrid for Column mode, otherwise force YGrid
-        if strcmpi(TsInfo.DisplayMode, 'column')
-            TsInfo.ShowYGrid = 0;
-        else
-            TsInfo.ShowYGrid = 1;
-        end
-        setappdata(hFig, 'TsInfo', TsInfo);
     end
-    if TsInfo.ShowYGrid
+    if TsInfo.ShowYGrid && ~strcmpi(TsInfo.DisplayMode, 'column')
         set(hAxes, 'YGrid', 'on');
         set(hAxes, 'YMinorGrid', 'on'); 
     end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -2606,16 +2606,8 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
     if TsInfo.ShowXGrid
         set(hAxes, 'XGrid',      'on', ...
                    'XMinorGrid', 'on');
-        
-        % No YGrid for Column mode, otherwise force YGrid
-        if strcmpi(TsInfo.DisplayMode, 'column')
-            TsInfo.ShowYGrid = 0;
-        else
-            TsInfo.ShowYGrid = 1;
-        end
-        setappdata(hAxes.Parent, 'TsInfo', TsInfo);
     end
-    if TsInfo.ShowYGrid
+    if TsInfo.ShowYGrid && ~strcmpi(TsInfo.DisplayMode, 'column')
         set(hAxes, 'YGrid',      'on', ...
                    'YMinorGrid', 'on');
     end
@@ -3348,12 +3340,12 @@ function ShowGrids(jButton, hFig)
     TsInfo = getappdata(hFig, 'TsInfo');
     hAxes = findobj(hFig, '-depth', 1, 'tag', 'AxesGraph');
     TsInfo.ShowXGrid = isSel;
+    TsInfo.ShowYGrid = isSel;
     set(hAxes, 'XGrid', toggle);
     set(hAxes, 'XMinorGrid', toggle);
     
     % Only add XGrid for butterfly view.
     if ~isSel || ~strcmpi(TsInfo.DisplayMode, 'column');
-        TsInfo.ShowYGrid = isSel;
         set(hAxes, 'YGrid', toggle);
         set(hAxes, 'YMinorGrid', toggle);
     end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -2417,6 +2417,12 @@ function isOk = PlotFigure(iDS, iFig, F, TimeVector, isFastUpdate, Std)
         set(PlotHandles(1).hColumnScale, 'Visible', 'off');
         cla(PlotHandles(1).hColumnScale);
     end
+    if ~isfield(TsInfo, 'XScale')
+        TsInfo.XScale = 'linear';
+        setappdata(hFig, 'TsInfo', TsInfo);
+    else
+        set(hAxes, 'XScale', TsInfo.XScale);
+    end
     % Create scale buttons
     if ~isFastUpdate && isempty(findobj(hFig, 'Tag', 'ButtonGainPlus'))
         CreateScaleButtons(iDS, iFig);
@@ -2600,6 +2606,14 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
     if TsInfo.ShowXGrid
         set(hAxes, 'XGrid',      'on', ...
                    'XMinorGrid', 'on');
+        
+        % No YGrid for Column mode, otherwise force YGrid
+        if strcmpi(TsInfo.DisplayMode, 'column')
+            TsInfo.ShowYGrid = 0;
+        else
+            TsInfo.ShowYGrid = 1;
+        end
+        setappdata(hAxes.Parent, 'TsInfo', TsInfo);
     end
     if TsInfo.ShowYGrid
         set(hAxes, 'YGrid',      'on', ...
@@ -3144,6 +3158,9 @@ function CreateScaleButtons(iDS, iFig)
     % Select buttons
     j4.setSelected(TsInfo.AutoScaleY);
     j5.setSelected(TsInfo.FlipYAxis);
+    j8.setSelected(strcmp(TsInfo.XScale, 'log'));
+    j9.setSelected((TsInfo.ShowXGrid & TsInfo.ShowYGrid) || ...
+        (strcmpi(TsInfo.DisplayMode, 'column') & TsInfo.ShowXGrid));
     % Add associated button to container when needed
     set(h8, 'UserData', j8);
     set(h9, 'UserData', j9);
@@ -3310,8 +3327,11 @@ function ToggleLogLinearScale(jButton, hFig)
     end
     
     % Update figure structure
+    TsInfo = getappdata(hFig, 'TsInfo');
+    TsInfo.XScale = scale;
     hAxes = findobj(hFig, '-depth', 1, 'tag', 'AxesGraph');
-    set(hAxes, 'XScale', scale)
+    set(hAxes, 'XScale', scale);
+    setappdata(hFig, 'TsInfo', TsInfo);
 end
 
 
@@ -3325,11 +3345,20 @@ function ShowGrids(jButton, hFig)
     end
     
     % Update figure structure
+    TsInfo = getappdata(hFig, 'TsInfo');
     hAxes = findobj(hFig, '-depth', 1, 'tag', 'AxesGraph');
+    TsInfo.ShowXGrid = isSel;
     set(hAxes, 'XGrid', toggle);
     set(hAxes, 'XMinorGrid', toggle);
-    set(hAxes, 'YGrid', toggle);
-    set(hAxes, 'YMinorGrid', toggle);
+    
+    % Only add XGrid for butterfly view.
+    if ~isSel || ~strcmpi(TsInfo.DisplayMode, 'column');
+        TsInfo.ShowYGrid = isSel;
+        set(hAxes, 'YGrid', toggle);
+        set(hAxes, 'YMinorGrid', toggle);
+    end
+    
+    setappdata(hFig, 'TsInfo', TsInfo);
 end
 
 


### PR DESCRIPTION
1. Fixed memory leak in PSD figures that would create new button elements every time you would change display modes.
2. Made both Grid and Log buttons to keep their selection & properties when switching between display modes.
3. Made Show Grid button to only display the X grid of plots in columns mode.