### PR TITLE
Chosen measure display option of timeseries is now saved

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -181,6 +181,7 @@ function [argout1, argout2, argout3, argout4, argout5] = bst_get( varargin )
 %    - bst_get('ResizeFunction')          : Get the appropriate resize function
 %    - bst_get('groot')                   : Get the root graphic object
 %    - bst_get('JFrame', hFig)            : Get the underlying java frame for a Matlab figure
+%    - bst_get('DisplayMeasure')          : Display option of measure for time series (log, power, magnitude, etc.)
 %
 % SEE ALSO bst_set
 
@@ -202,7 +203,7 @@ function [argout1, argout2, argout3, argout4, argout5] = bst_get( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2008-2016
+% Authors: Francois Tadel, 2008-2016; Martin Cousineau, 2017
 
 %% ==== PARSE INPUTS ====
 global GlobalData;
@@ -2890,7 +2891,14 @@ switch contextName
             argout1 = GlobalData.DataBase.isReadOnly;
         else
             argout1 = 0;
-        end 
+        end
+        
+    case 'DisplayMeasure'
+        if isfield(GlobalData, 'Preferences') && isfield(GlobalData.Preferences, 'DisplayMeasure')
+            argout1 = GlobalData.Preferences.DisplayMeasure;
+        else
+            argout1 = [];
+        end
         
         
 %% ===== FILE FILTERS =====

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -181,7 +181,7 @@ function [argout1, argout2, argout3, argout4, argout5] = bst_get( varargin )
 %    - bst_get('ResizeFunction')          : Get the appropriate resize function
 %    - bst_get('groot')                   : Get the root graphic object
 %    - bst_get('JFrame', hFig)            : Get the underlying java frame for a Matlab figure
-%    - bst_get('DisplayMeasure')          : Display option of measure for time series (log, power, magnitude, etc.)
+%    - bst_get('LastPsdDisplayFunction')  : Display option of measure for spectrum (log, power, magnitude, etc.)
 %
 % SEE ALSO bst_set
 
@@ -2893,9 +2893,9 @@ switch contextName
             argout1 = 0;
         end
         
-    case 'DisplayMeasure'
-        if isfield(GlobalData, 'Preferences') && isfield(GlobalData.Preferences, 'DisplayMeasure')
-            argout1 = GlobalData.Preferences.DisplayMeasure;
+    case 'LastPsdDisplayFunction'
+        if isfield(GlobalData, 'Preferences') && isfield(GlobalData.Preferences, 'LastPsdDisplayFunction')
+            argout1 = GlobalData.Preferences.LastPsdDisplayFunction;
         else
             argout1 = [];
         end

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -69,7 +69,7 @@ function bst_set( varargin )
 %    - bst_set('CustomColormaps',       CustomColormaps)
 %    - bst_set('DigitizeOptions',       DigitizeOptions)
 %    - bst_set('ReadOnly',              ReadOnly)
-%    - bst_set('DisplayMeasure',        DisplayMeasure)
+%    - bst_set('LastPsdDisplayFunction', LastPsdDisplayFunction)
 %
 % SEE ALSO bst_get
 
@@ -240,7 +240,7 @@ switch contextName
           'StatThreshOptions', 'ContactSheetOptions', 'ProcessOptions', 'BugReportOptions', 'DefaultSurfaceDisplay', ...
           'MagneticExtrapOptions', 'MriOptions', 'NodelistOptions', 'IgnoreMemoryWarnings', ...
           'TimefreqOptions_morlet', 'TimefreqOptions_hilbert', 'TimefreqOptions_fft', 'TimefreqOptions_psd', 'TimefreqOptions_plv', ...
-          'OpenMEEGOptions', 'DigitizeOptions', 'CustomColormaps', 'FieldTripDir', 'GridOptions_headmodel', 'GridOptions_dipfit', 'DisplayMeasure'}
+          'OpenMEEGOptions', 'DigitizeOptions', 'CustomColormaps', 'FieldTripDir', 'GridOptions_headmodel', 'GridOptions_dipfit', 'LastPsdDisplayFunction'}
         GlobalData.Preferences.(contextName) = contextValue;
 
     case 'ReadOnly'

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -69,6 +69,7 @@ function bst_set( varargin )
 %    - bst_set('CustomColormaps',       CustomColormaps)
 %    - bst_set('DigitizeOptions',       DigitizeOptions)
 %    - bst_set('ReadOnly',              ReadOnly)
+%    - bst_set('DisplayMeasure',        DisplayMeasure)
 %
 % SEE ALSO bst_get
 
@@ -90,7 +91,7 @@ function bst_set( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2008-2016
+% Authors: Francois Tadel, 2008-2016; Martin Cousineau, 2017
 
 global GlobalData;
 
@@ -239,7 +240,7 @@ switch contextName
           'StatThreshOptions', 'ContactSheetOptions', 'ProcessOptions', 'BugReportOptions', 'DefaultSurfaceDisplay', ...
           'MagneticExtrapOptions', 'MriOptions', 'NodelistOptions', 'IgnoreMemoryWarnings', ...
           'TimefreqOptions_morlet', 'TimefreqOptions_hilbert', 'TimefreqOptions_fft', 'TimefreqOptions_psd', 'TimefreqOptions_plv', ...
-          'OpenMEEGOptions', 'DigitizeOptions', 'CustomColormaps', 'FieldTripDir', 'GridOptions_headmodel', 'GridOptions_dipfit'}
+          'OpenMEEGOptions', 'DigitizeOptions', 'CustomColormaps', 'FieldTripDir', 'GridOptions_headmodel', 'GridOptions_dipfit', 'DisplayMeasure'}
         GlobalData.Preferences.(contextName) = contextValue;
 
     case 'ReadOnly'

--- a/toolbox/gui/figure_timefreq.m
+++ b/toolbox/gui/figure_timefreq.m
@@ -23,7 +23,7 @@ function varargout = figure_timefreq( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2010-2016
+% Authors: Francois Tadel, 2010-2016; Martin Cousineau, 2017
 
 eval(macro_method);
 end
@@ -856,6 +856,9 @@ function [Time, Freqs, TfInfo, TF, RowNames, FullTimeVector, DataType, LowFreq, 
     TfInfo = getappdata(hFig, 'Timefreq');
     if isempty(TfInfo)
         return
+    elseif ~isempty(bst_get('DisplayMeasure'))
+        TfInfo.Function = bst_get('DisplayMeasure');
+        setappdata(hFig, 'Timefreq', TfInfo);
     end
     % Get data description
     [iDS, iTimefreq] = bst_memory('GetDataSetTimefreq', TfInfo.FileName);

--- a/toolbox/gui/figure_timefreq.m
+++ b/toolbox/gui/figure_timefreq.m
@@ -23,7 +23,7 @@ function varargout = figure_timefreq( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2010-2016; Martin Cousineau, 2017
+% Authors: Francois Tadel, 2010-2016
 
 eval(macro_method);
 end
@@ -856,9 +856,6 @@ function [Time, Freqs, TfInfo, TF, RowNames, FullTimeVector, DataType, LowFreq, 
     TfInfo = getappdata(hFig, 'Timefreq');
     if isempty(TfInfo)
         return
-    elseif ~isempty(bst_get('DisplayMeasure'))
-        TfInfo.Function = bst_get('DisplayMeasure');
-        setappdata(hFig, 'Timefreq', TfInfo);
     end
     % Get data description
     [iDS, iTimefreq] = bst_memory('GetDataSetTimefreq', TfInfo.FileName);

--- a/toolbox/gui/panel_display.m
+++ b/toolbox/gui/panel_display.m
@@ -589,7 +589,11 @@ function SetDisplayOptions(sOptions)
         end
         if ~strcmpi(TfInfo.Function, 'other')
             TfInfo.Function = sOptions.Function;
-            bst_set('DisplayMeasure', sOptions.Function);
+            
+            % Remember option for spectrum figures.
+            if strcmpi(GlobalData.DataSet(iDS).Figure(iFig).Id.Type, 'Spectrum')
+                bst_set('LastPsdDisplayFunction', sOptions.Function);
+            end
         end
         TfInfo.HideEdgeEffects = sOptions.HideEdgeEffects;
         TfInfo.HighResolution  = sOptions.HighResolution;

--- a/toolbox/gui/panel_display.m
+++ b/toolbox/gui/panel_display.m
@@ -26,7 +26,7 @@ function varargout = panel_display(varargin)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2010-2016
+% Authors: Francois Tadel, 2010-2016; Martin Cousineau, 2017
 
 eval(macro_method);
 end
@@ -589,6 +589,7 @@ function SetDisplayOptions(sOptions)
         end
         if ~strcmpi(TfInfo.Function, 'other')
             TfInfo.Function = sOptions.Function;
+            bst_set('DisplayMeasure', sOptions.Function);
         end
         TfInfo.HideEdgeEffects = sOptions.HideEdgeEffects;
         TfInfo.HighResolution  = sOptions.HighResolution;

--- a/toolbox/gui/view_spectrum.m
+++ b/toolbox/gui/view_spectrum.m
@@ -36,7 +36,7 @@ function [hFig, iDS, iFig] = view_spectrum(TimefreqFile, DisplayMode, RowName, i
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2012
+% Authors: Francois Tadel, 2012; Martin Cousineau, 2017
 
 
 %% ===== INITIALIZATION =====
@@ -114,7 +114,11 @@ TfMethod = lower(GlobalData.DataSet(iDS).Timefreq(iTimefreq).Method);
 if strcmpi(GlobalData.DataSet(iDS).Timefreq(iTimefreq).Measure, 'other')
     TfInfo.Function = 'other';
 elseif ismember(TfMethod, {'fft', 'psd'})
-    TfInfo.Function = 'log';
+    if ~isempty(bst_get('LastPsdDisplayFunction'))
+        TfInfo.Function = bst_get('LastPsdDisplayFunction');
+    else
+        TfInfo.Function = 'log';
+    end
 else
     TfInfo.Function = process_tf_measure('GetDefaultFunction', GlobalData.DataSet(iDS).Timefreq(iTimefreq));
 end


### PR DESCRIPTION
As requested by Sylvain via email:

> I am looking at a lot of power spectra these days with BST and it is annoying that the display options (log(power), magnitude or power) are not consistent across displays (cortical maps or spectra) or remembered by BST when opening a new file. For instance, the default is always log(power). Can you please look into how to make it the last selected display option by the user? 