### PR TITLE
Fixed minimum values in Find maximum in time process

### DIFF
--- a/toolbox/process/functions/process_extract_max.m
+++ b/toolbox/process/functions/process_extract_max.m
@@ -19,7 +19,7 @@ function varargout = process_extract_max( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2016
+% Authors: Francois Tadel, 2016; Martin Cousineau, 2017
 
 eval(macro_method);
 end
@@ -113,25 +113,26 @@ function sInput = Run(sProcess, sInput) %#ok<DEFNU>
     end
     
     % Preprocess values to detect the correct peaks
+    minmaxFunc = @max;
     switch (Method)
         case 'absmax'
             sInput.A = abs(sInput.A);
         case 'max'
             % nothing to change
         case 'min'
-            sInput.A = -sInput.A;
+            minmaxFunc = @min;
     end
     % Find maximum in time
-    [Max, iMax] = max(sInput.A(:,iTime,:), [], 2);
+    [MinMax, iMinMax] = minmaxFunc(sInput.A(:,iTime,:), [], 2);
     % Save the expected value
     switch (Output)
         case 'amplitude'
-            sInput.A = Max;
+            sInput.A = MinMax;
             % Time vector: First and last time values
             sInput.TimeVector = [sInput.TimeVector(iTime(1)), sInput.TimeVector(iTime(end))];
             strMethod = '';
         case 'latency'
-            sInput.A = reshape(sInput.TimeVector(iTime(iMax)), size(iMax));
+            sInput.A = reshape(sInput.TimeVector(iTime(iMinMax)), size(iMinMax));
             % Time vector: First and last time values
             sInput.TimeVector = [sInput.TimeVector(iTime(1)), sInput.TimeVector(iTime(end))];
             strMethod = ', latency';
@@ -143,16 +144,16 @@ function sInput = Run(sProcess, sInput) %#ok<DEFNU>
                 return;
             end
             % Detect the maximum amplitude across signals
-            [SigMax, iSigMax] = max(Max, [], 1);
+            [SigMax, iSigMax] = max(MinMax, [], 1);
             % Set all the other values to zero
-            sInput.A = zeros(size(Max));
+            sInput.A = zeros(size(MinMax));
             sInput.A(iSigMax) = SigMax;
             % Time vector: Latency of the maximum
             T = sInput.TimeVector(2) - sInput.TimeVector(1);
             if (T > 0.100)
                 T = 0.001;
             end
-            sInput.TimeVector = sInput.TimeVector(iTime(iMax(iSigMax))) + [0,T];
+            sInput.TimeVector = sInput.TimeVector(iTime(iMinMax(iSigMax))) + [0,T];
             strMethod = ', global';
     end
     

--- a/toolbox/process/functions/process_extract_maxfreq.m
+++ b/toolbox/process/functions/process_extract_maxfreq.m
@@ -19,7 +19,7 @@ function varargout = process_extract_maxfreq( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2016
+% Authors: Francois Tadel, 2016; Martin Cousineau, 2017
 
 eval(macro_method);
 end
@@ -152,23 +152,24 @@ function OutputFile = Run(sProcess, sInput) %#ok<DEFNU>
     
     % ===== FIND MAXIMUM =====
     % Preprocess values to detect the correct peaks
+    minmaxFunc = @max;
     switch (Method)
         case 'absmax'
             TimefreqMat.TF = abs(TimefreqMat.TF);
         case 'max'
             % nothing to change
         case 'min'
-            TimefreqMat.TF = -TimefreqMat.TF;
+            minmaxFunc = @min;
     end
     % Find maximum in frequency
-    [Max, iMax] = max(TimefreqMat.TF, [], 3);
+    [MinMax, iMinMax] = minmaxFunc(TimefreqMat.TF, [], 3);
     % Save the expected value
     switch (Output)
         case 'amplitude'
-            TimefreqMat.TF = Max;
+            TimefreqMat.TF = MinMax;
             strMethod = '';
         case 'frequency'
-            TimefreqMat.TF = reshape(FreqVector(iMax), size(iMax));
+            TimefreqMat.TF = reshape(FreqVector(iMinMax), size(iMinMax));
             strMethod = ', frequency';
             TimefreqMat.DisplayUnits = 'Hz';
             TimefreqMat.Measure = 'frequency';


### PR DESCRIPTION
RE: http://neuroimage.usc.edu/forums/t/find-maximum-in-time-does-not-give-the-minimum-value/2947

I found it kind of silly to do -max(-x) so I changed it to min(x). Let me know if there was a good reason to do it with the max.