### PR TITLE
Added HeadModel info to connectivity outputs

### DIFF
--- a/toolbox/anatomy/results_vertconn.m
+++ b/toolbox/anatomy/results_vertconn.m
@@ -41,17 +41,13 @@ switch (file_gettype(ResultsFile))
         HeadModelType = ResultsMat.HeadModelType;
     case 'timefreq'
         ResultsMat = in_bst_timefreq(ResultsFile, 0, 'SurfaceFile', 'GridLoc', 'GridAtlas');
-        HeadModelType = [];
-end
-
-if isempty(HeadModelType)
-    if ~isempty(ResultsMat.GridAtlas)
-        HeadModelType = 'mixed';
-    elseif ~isempty(ResultsMat.GridLoc)
-        HeadModelType = 'volume';
-    else
-        HeadModelType = 'surface';
-    end
+        if ~isempty(ResultsMat.GridAtlas)
+            HeadModelType = 'mixed';
+        elseif ~isempty(ResultsMat.GridLoc)
+            HeadModelType = 'volume';
+        else
+            HeadModelType = 'surface';
+        end
 end
 
 % Get grid points and vertex-vertex connectivity matrix

--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -664,6 +664,14 @@ function NewFile = SaveFile(R, iOutputStudy, DataFile, sInputA, sInputB, Comment
     FileMat.Method    = OPTIONS.Method;
     FileMat.DataFile  = file_win2unix(DataFile);
     FileMat.nAvg      = nAvg;
+    % Head model
+    if isfield(sInputA, 'HeadModelFile') && ~isempty(sInputA.HeadModelFile)
+        FileMat.HeadModelFile = sInputA.HeadModelFile;
+        FileMat.HeadModelType = sInputA.HeadModelType;
+    elseif isfield(sInputB, 'HeadModelFile') && ~isempty(sInputB.HeadModelFile)
+        FileMat.HeadModelFile = sInputB.HeadModelFile;
+        FileMat.HeadModelType = sInputB.HeadModelType;
+    end
     % Time vector
     if strcmpi(OPTIONS.Method, 'plvt')
         FileMat.Time      = sInputB.Time;

--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -22,7 +22,7 @@ function OutputFiles = bst_connectivity(FilesA, FilesB, OPTIONS)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2012-2015
+% Authors: Francois Tadel, 2012-2015; Martin Cousineau, 2017
 
 
 %% ===== DEFAULT OPTIONS =====

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -1932,6 +1932,14 @@ function [sInput, nSignals, iRows] = LoadInputFile(FileName, Target, TimeWindow,
                     sInput.Atlas = [];
                     sInput.RowNames = AllRowNames(iRows);
                 end
+                % Copy head model if it exists
+                if isfield(sMat, 'HeadModelFile') && ~isempty(sMat.HeadModelFile)
+                    sInput.HeadModelFile = sMat.HeadModelFile;
+                    sInput.HeadModelType = sMat.HeadModelType;
+                else
+                    sInput.HeadModelFile = [];
+                    sInput.HeadModelType = [];
+                end
                 
             case 'timefreq'
                 % Find target rows

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -31,7 +31,7 @@ function varargout = bst_process( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2010-2016
+% Authors: Francois Tadel, 2010-2016; Martin Cousineau, 2017
 
 eval(macro_method);
 end


### PR DESCRIPTION
RE: Beth issue. I also reverted the temporary change when results type files did not have a HeadModelType, since this is not a normal state, as discussed.

I'm assuming here the following. Correct me if that is not ok.
1. there is a 1-to-1 relation between HeadModelFile and HeadModelType fields (when one is populated, so is the other one).
2. Populating the HeadModelFile and HeadModelType fields when possible in the LoadInputFile() bst_process has no unforeseen consequences.
