### PR TITLE
Process Extract Time now properly works when extracting a single time point

### DIFF
--- a/toolbox/process/functions/process_extract_time.m
+++ b/toolbox/process/functions/process_extract_time.m
@@ -100,6 +100,10 @@ function sInput = Run(sProcess, sInput) %#ok<DEFNU>
         sInput = [];
         return;
     end
+    % If a single time point was requested, duplicate it
+    if length(iTime) == 1
+        iTime = [iTime, iTime];
+    end
     % Keep only those indices
     sInput.A          = sInput.A(:, iTime, :);
     sInput.TimeVector = sInput.TimeVector(iTime);


### PR DESCRIPTION
Bug reported here: http://neuroimage.usc.edu/forums/t/extract-time-file-does-not-have-correct-time-definition/2996/2

I copied the behavior from the Average Time process.