### PR TITLE
EDF Reader: added case where channel names have spaces around dash.

### DIFF
--- a/toolbox/io/in_fopen_edf.m
+++ b/toolbox/io/in_fopen_edf.m
@@ -203,16 +203,17 @@ sFile.channelflag = ones(hdr.nsignal,1);
 SplitType = repmat({''}, 1, hdr.nsignal);
 SplitName = repmat({''}, 1, hdr.nsignal);
 for i = 1:hdr.nsignal
+    signalLabel = strrep(hdr.signal(i).label, ' - ', '-');
     % Find space chars (label format "Type Name")
-    iSpace = find(hdr.signal(i).label == ' ');
+    iSpace = find(signalLabel == ' ');
     % Only if there is one space only
     if (length(iSpace) == 1) && (iSpace >= 3)
-        SplitName{i} = hdr.signal(i).label(iSpace+1:end);
-        SplitType{i} = hdr.signal(i).label(1:iSpace-1);
+        SplitName{i} = signalLabel(iSpace+1:end);
+        SplitType{i} = signalLabel(1:iSpace-1);
     % Accept also 2 spaces
     elseif (length(iSpace) == 2) && (iSpace(1) >= 3)
-        SplitName{i} = strrep(hdr.signal(i).label(iSpace(1)+1:end), ' ', '_');
-        SplitType{i} = hdr.signal(i).label(1:iSpace(1)-1);
+        SplitName{i} = strrep(signalLabel(iSpace(1)+1:end), ' ', '_');
+        SplitType{i} = signalLabel(1:iSpace(1)-1);
     end
 end
 % Remove the classification if it makes some names non unique


### PR DESCRIPTION
Here was the issue: the channels were named "EEG XX - Pz". The current code worked fine without the spaces around the dash ("EEG XX-Pz") and properly used Pz as ref and extracted XX. I added a case where " - " would be present and first replace it by "-". This is the simplest fix in my opinion, but once again if you think this is too specific to this user feel free to reject.