### PR TITLE
 Added option to copy file list in script format from process box to clipboard.

### DIFF
--- a/toolbox/gui/panel_nodelist.m
+++ b/toolbox/gui/panel_nodelist.m
@@ -125,7 +125,8 @@ function nodelist = CreatePanel(nodelistName, nodelistComment, listType) %#ok<DE
             % Create popup menu
             jPopup = java_create('javax.swing.JPopupMenu');
             % Menu "Copy file list"
-            gui_component('MenuItem', jPopup, [], 'Copy to clipboard as input list', IconLoader.ICON_COPY, [], @(h,ev)CopyPathList());
+            gui_component('MenuItem', jPopup, [], 'Copy list to clipboard', IconLoader.ICON_COPY, [], @(h,ev)CopyPathList());
+            jPopup.addSeparator();
             % Menu "Remove from list"
             gui_component('MenuItem', jPopup, [], 'Clear list', IconLoader.ICON_DELETE, [], @(h,ev)ResetAllLists());
             % Show popup menu

--- a/toolbox/gui/panel_nodelist.m
+++ b/toolbox/gui/panel_nodelist.m
@@ -124,6 +124,8 @@ function nodelist = CreatePanel(nodelistName, nodelistComment, listType) %#ok<DE
         if (ev.getButton() == ev.BUTTON3) && ev.getSource().isEnabled()
             % Create popup menu
             jPopup = java_create('javax.swing.JPopupMenu');
+            % Menu "Copy file list"
+            gui_component('MenuItem', jPopup, [], 'Copy to clipboard as input list', IconLoader.ICON_COPY, [], @(h,ev)CopyPathList());
             % Menu "Remove from list"
             gui_component('MenuItem', jPopup, [], 'Clear list', IconLoader.ICON_DELETE, [], @(h,ev)ResetAllLists());
             % Show popup menu
@@ -248,6 +250,20 @@ function ResetAllLists()
     for i = 1:length(GlobalData.Program.GUI.nodelists)
         GlobalData.Program.GUI.nodelists(i).jTree.removeAllNodes();
     end
+end
+
+
+%% ===== COPY PATH LIST TO CLIPBOARD  =====
+function CopyPathList()
+     % Get selected process panel
+    jTabProcess = bst_get('PanelContainer', 'process');
+    selPanel = char(jTabProcess.getTitleAt(jTabProcess.getSelectedIndex()));
+    % Get files
+    sFiles = panel_nodelist('GetFiles', selPanel);
+    % Concatenate file paths in one multiline string
+    str = panel_process_select('WriteFileNames', sFiles, 'sFiles', 1);
+    % Copy to clipboard
+    clipboard('copy', str);
 end
 
 

--- a/toolbox/gui/panel_nodelist.m
+++ b/toolbox/gui/panel_nodelist.m
@@ -258,10 +258,19 @@ function CopyPathList()
      % Get selected process panel
     jTabProcess = bst_get('PanelContainer', 'process');
     selPanel = char(jTabProcess.getTitleAt(jTabProcess.getSelectedIndex()));
-    % Get files
-    sFiles = panel_nodelist('GetFiles', selPanel);
-    % Concatenate file paths in one multiline string
-    str = panel_process_select('WriteFileNames', sFiles, 'sFiles', 1);
+    if strcmpi(selPanel, 'Process1')
+        % Get files
+        sFiles = panel_nodelist('GetFiles', selPanel);
+        % Concatenate file paths in one multiline string
+        str = panel_process_select('WriteFileNames', sFiles, 'sFiles', 1);
+    else
+        % Get files
+        sFilesA = panel_nodelist('GetFiles', [selPanel 'A']);
+        sFilesB = panel_nodelist('GetFiles', [selPanel 'B']);
+        strA = panel_process_select('WriteFileNames', sFilesA, 'sFiles', 1);
+        strB = panel_process_select('WriteFileNames', sFilesB, 'sFiles2', 1);
+        str = [strA 10 strB];
+    end
     % Copy to clipboard
     clipboard('copy', str);
 end


### PR DESCRIPTION
A lot of people are requesting this. If you want to make a Brainstorm matlab script with the data you dragged in the process box, you need to add a "mock" process and mutliple clicks are required to do Generate script to only copy paste the sFiles input part.
Instead, I added a right click menu option (next to Clear box). Hopefully the text is clear enough, I did not want it to be long.

![copy_process_list](https://user-images.githubusercontent.com/9253273/33295371-f54a44b2-d3a2-11e7-91c1-86cba3277a8c.png)
