### PR TITLE
Bugfix of strange cursor issue in time series figures.

### DIFF
--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -635,16 +635,9 @@ end
 function X = GetMouseTime(hFig, hAxes)
     % Get current point in axes
     X = get(hAxes, 'CurrentPoint');
-    X = X(1,1);
     XLim = get(hAxes, 'XLim');
-    % Weird bugfix where sometimes the cursor coordinates are flipped in
-    % the negative
-    if X < -0.5
-        % 0.68 is the width of the right border of the figure
-        X = X + XLim(2) + 0.68;
-    end
     % Check whether cursor is out of display time bounds
-    X = bst_saturate(X, XLim);
+    X = bst_saturate(X(1,1), XLim);
     % Get the time vector
     TimeVector = getappdata(hFig, 'TimeVector');
     % Select the closest point in time vector

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -635,9 +635,16 @@ end
 function X = GetMouseTime(hFig, hAxes)
     % Get current point in axes
     X = get(hAxes, 'CurrentPoint');
+    X = X(1,1);
     XLim = get(hAxes, 'XLim');
+    % Weird bugfix where sometimes the cursor coordinates are flipped in
+    % the negative
+    if X < -0.5
+        % 0.68 is the width of the right border of the figure
+        X = X + XLim(2) + 0.68;
+    end
     % Check whether cursor is out of display time bounds
-    X = bst_saturate(X(1,1), XLim);
+    X = bst_saturate(X, XLim);
     % Get the time vector
     TimeVector = getappdata(hFig, 'TimeVector');
     % Select the closest point in time vector

--- a/toolbox/gui/gui_layout.m
+++ b/toolbox/gui/gui_layout.m
@@ -658,8 +658,20 @@ function PositionFigure(hFigure, figArea, decorationSize)
 %     if (length(ScreenDef) > 1) && (figDim(1) >= ScreenDef(1).matlabPos(1) + ScreenDef(1).matlabPos(3)) && (ScreenDef(1).matlabPos(4) ~= ScreenDef(2).matlabPos(4))
 %         figDim(2) = figDim(2) - ScreenDef(2).matlabPos(4) + ScreenDef(1).matlabPos(4);
 %     end
+
+    % In some setups, resizing the figure will position it in an invalid
+    % state and making it invisible and visible again will fix it.
+    isVisible = get(hFigure, 'Visible');
+    if isVisible
+        set(hFigure, 'Visible', 'off');
+    end
+
     % Apply position to figure
     set(hFigure, 'Position', figDim);
+
+    if isVisible
+        set(hFigure, 'Visible', 'on');
+    end
 end
 
 

--- a/toolbox/gui/gui_layout.m
+++ b/toolbox/gui/gui_layout.m
@@ -618,7 +618,6 @@ end
 
 %% ===== POSITION FIGURES =====
 function PositionFigure(hFigure, figArea, decorationSize)
-    drawnow
     if ~ishandle(hFigure)
         return
     end
@@ -667,6 +666,7 @@ function PositionFigure(hFigure, figArea, decorationSize)
     end
 
     % Apply position to figure
+    drawnow;
     set(hFigure, 'Position', figDim);
 
     if isVisible


### PR DESCRIPTION
See issue #51. I could only reproduce it on Jeremy's computer. Essentially, get(hAxes, 'CurrentPoint') sometimes returns negative X coordinates, which get remapped to 0. I think it's related to having multiple screens. However, I could not find any documentation about it online. In that state, 0 is the rightest position on the figure, and everything to its left is negative. Since it includes the right "border" of the figure, I had to hardcore its seemingly fixed value. See screenshot below for what I'm referring for.
![time_series_right_border](https://user-images.githubusercontent.com/9253273/33861974-6d1e53e6-deae-11e7-924e-663a499099e2.png)

If you think of a better way to fix this, or feel this issue is too specific, feel free to comment.
