### PR TITLE
ICA component sorting & change to projector computation

### DIFF
--- a/toolbox/process/functions/process_ica.m
+++ b/toolbox/process/functions/process_ica.m
@@ -71,6 +71,10 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.sensortypes.Comment = 'Sensor types or names (empty=all): ';
     sProcess.options.sensortypes.Type    = 'text';
     sProcess.options.sensortypes.Value   = 'EEG';
+    % Select components
+    sProcess.options.icasort.Comment = 'Sort components based on correlation with (empty=none):';
+    sProcess.options.icasort.Type    = 'text';
+    sProcess.options.icasort.Value   = 'EOG, ECG';    
     % Use existing SSPs
     sProcess.options.usessp.Comment = 'Compute using existing SSP/ICA projectors';
     sProcess.options.usessp.Type    = 'checkbox';

--- a/toolbox/process/functions/process_ssp2.m
+++ b/toolbox/process/functions/process_ssp2.m
@@ -1012,13 +1012,13 @@ function Projector = BuildProjector(ListProj, ProjStatus) %#ok<*DEFNU>
             % Get selected channels (find the non-zero channels)
             iChan = find(any(ListProj(i).Components ~= 0, 2));
             % Get selected components
-            iComp = find(ListProj(i).CompMask == 0);
+            iComp = find(ListProj(i).CompMask == 1);
             % Initialize projector
             P = eye(size(ListProj(i).Components,1));
             % Compute projector
             W = ListProj(i).Components(iChan,:)';
             Winv = pinv(W);
-            P(iChan,iChan) = Winv(:,iComp) * W(iComp,:);
+            P(iChan,iChan) = eye(size(W,2)) - Winv(:,iComp) * W(iComp,:);
             % Check if there are any complex values in the projector
             if any(~isreal(P))
                 warning('WARNING: ICA components contain complex values. Something went wrong in their computation.');


### PR DESCRIPTION
Hi, there are two different parts to this pull request. Probably should be split, but I wanted some feedback

1) I added an option to the ICA process to sort ICA components based on their correlation with a selection of 'reference' channels (default: ECG & EOG). The sorting is based on the maximum correlation of a given ICA time-series with any of the reference channels. It would be easy to add an option to set a correlation threshold where all components above that will be automatically selected. For now I didn't add that, since I don't have a suggestion for a default value.. I think it would depend on the frequency band used (higher frequencies lower correlation?). For people to be able to set a threshold, we would have to be able to display the correlations through the GUI (just as the %variance for the SSP components). I don't know where to save those correlation values, since the field 'SingVal' in the projector structure is used in other places, to check whether this is an ICA decomposition.

2) In process_ssp2, line 989, all the 'good' ICA components are selected and a projector is computed that reconstructs the signal based on only the good components (Winv_good * W_good). This means, that when you choose to compute a limited number of ICA components e.g. 40, the cleaned MEG data (e.g. 270 channels) will only have a rank of (40-nBad), so we throw away a lot of dimensions. With the change I made, the bad components are projected away (eye() - Winv_bad * W_bad), so the rank is gonna be (270-nBad). This relates probably more to situations where you have a lot of channels (MEG) and you don't wanna compute the full ICA decomposition. But since we select the 'bad' components by clicking in the GUI, I find it more intuitive to get rid of those components rather than keeping only the 'good' components that are left unchecked. Does this make sense?