### PR TITLE
Added basic boolean logic in filter search box

### DIFF
--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -903,6 +903,7 @@ function [res, isWord] = ParseFilterTree(root)
         for iChild = 1:length(root.children)
             node = root.children(iChild);
             [word, isWord] = ParseFilterTree(node);
+            % Add implicit AND if no operator between two tags specified
             if lastChildIsWord && isWord
                 res = [res ' &&'];
             end

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -884,7 +884,7 @@ function res = ParseFilterTree(root)
     % Change reserved words to symbol
     if isempty(root.word)
         res = '';
-    elseif any(strcmpi({'and', '&', '&&'}, root.word))
+    elseif any(strcmpi({'and', '&', '&&', '+'}, root.word))
         res = '&&';
     elseif any(strcmpi({'or', '|', '||'}, root.word))
         res = '||';

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -899,6 +899,10 @@ function res = ParseFilterTree(root)
     if isfield(root, 'children')
         for iChild = 1:length(root.children)
             node = root.children(iChild);
+            % Add implicit AND if no operator between two tags specified
+            if (iChild >= 2) && ~any(strcmpi({'and', '&', '&&', 'or', '|', '||', 'not'}, root.children(iChild-1)))
+                res = [res ' &&'];
+            end
             if isfield(node, 'children') && ~isempty(node.children)
                 res = [res ' (' ParseFilterTree(node) ')'];
             else

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -900,7 +900,9 @@ function res = ParseFilterTree(root)
         for iChild = 1:length(root.children)
             node = root.children(iChild);
             % Add implicit AND if no operator between two tags specified
-            if (iChild >= 2) && ~any(strcmpi({'and', '&', '&&', 'or', '|', '||', 'not'}, root.children(iChild-1)))
+            if (iChild >= 2) && ~isempty(root.children(iChild-1).word) && ~isempty(root.children(iChild).word) ...
+                    && ~any(strcmpi({'and', '&', '&&', '+', 'or', '|', '||', 'not'}, root.children(iChild-1).word)) ...
+                    && ~any(strcmpi({'and', '&', '&&', 'or', '+', '|', '||', 'not'}, root.children(iChild).word))
                 res = [res ' &&'];
             end
             if isfield(node, 'children') && ~isempty(node.children)

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -85,6 +85,8 @@ if ~isempty(NodelistOptions)
     else
         % Options
         NodelistOptions.isSelect  = strcmpi(NodelistOptions.Action, 'Select');
+        % Make search case insensitive
+        NodelistOptions.String = lower(NodelistOptions.String);
         % Create filter eval expression
         NodelistOptions.Eval = CreateFilterEvalExpression(NodelistOptions.String);
     end

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -899,10 +899,6 @@ function res = ParseFilterTree(root)
     if isfield(root, 'children')
         for iChild = 1:length(root.children)
             node = root.children(iChild);
-            % Add implicit AND if no operator between two tags specified
-            if (iChild >= 2) && ~any(strcmpi({'and', '&', '&&', 'or', '|', '||', 'not'}, root.children(iChild-1)))
-                res = [res ' &&'];
-            end
             if isfield(node, 'children') && ~isempty(node.children)
                 res = [res ' (' ParseFilterTree(node) ')'];
             else

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -900,9 +900,7 @@ function res = ParseFilterTree(root)
         for iChild = 1:length(root.children)
             node = root.children(iChild);
             % Add implicit AND if no operator between two tags specified
-            if (iChild >= 2) && ~isempty(root.children(iChild-1).word) && ~isempty(root.children(iChild).word) ...
-                    && ~any(strcmpi({'and', '&', '&&', '+', 'or', '|', '||', 'not'}, root.children(iChild-1).word)) ...
-                    && ~any(strcmpi({'and', '&', '&&', 'or', '+', '|', '||', 'not'}, root.children(iChild).word))
+            if (iChild >= 2) && ~any(strcmpi({'and', '&', '&&', 'or', '|', '||', 'not'}, root.children(iChild-1)))
                 res = [res ' &&'];
             end
             if isfield(node, 'children') && ~isempty(node.children)


### PR DESCRIPTION
As suggested by issue #68. I parse the string expression using a structure tree, then go through the tree and replace keywords to produce an eval().

Perhaps not the best way to handle errors at the moment: I just force it to an exclude all expression. I would add some sort of dialog to warn user, but somehow tree_dependencies is called multiple times so the user would get spammed. Please advise.