### PR TITLE
ICA component selection bug

### DIFF
--- a/toolbox/process/functions/process_ssp2.m
+++ b/toolbox/process/functions/process_ssp2.m
@@ -763,7 +763,7 @@ function OutputFiles = Run(sProcess, sInputsA, sInputsB)
     if ~isempty(icaSort)
         y = W * F;
         C = bst_corrn(Fref, y);
-        [corrs, iSort] = sort(max(abs(C)), 'descend');
+        [corrs, iSort] = sort(max(abs(C),[],1), 'descend');
         proj.Components = proj.Components(:,iSort);
     end
     


### PR DESCRIPTION
This fix is needed when only one reference channel is selected. See http://neuroimage.usc.edu/forums/t/ica-sort-components-based-on-correlation-results-in-only-one-component/6497