### PR TITLE
Added STD/SEM option to Cluster time series

### DIFF
--- a/toolbox/gui/panel_cluster.m
+++ b/toolbox/gui/panel_cluster.m
@@ -63,6 +63,8 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
             % Menu: Set cluster function
             jMenuTs = gui_component('Menu', jMenu, [], 'Set cluster function', IconLoader.ICON_PROPERTIES, [], []);
                 gui_component('MenuItem', jMenuTs, [], 'Mean',    [], [], @(h,ev)SetClusterFunction('Mean'));
+                gui_component('MenuItem', jMenuTs, [], 'Mean+Std',    [], [], @(h,ev)SetClusterFunction('Mean+Std'));
+                gui_component('MenuItem', jMenuTs, [], 'Mean+StdErr',    [], [], @(h,ev)SetClusterFunction('Mean+StdErr'));
                 gui_component('MenuItem', jMenuTs, [], 'PCA',     [], [], @(h,ev)SetClusterFunction('PCA'));
                 gui_component('MenuItem', jMenuTs, [], 'FastPCA', [], [], @(h,ev)SetClusterFunction('FastPCA'));
                 gui_component('MenuItem', jMenuTs, [], 'Max',     [], [], @(h,ev)SetClusterFunction('Max'));

--- a/toolbox/gui/view_clusters.m
+++ b/toolbox/gui/view_clusters.m
@@ -89,6 +89,7 @@ if (length(DataFiles) == 1)
 end
 % Initialize data to display
 clustersActivity = cell(length(DataFiles), length(iClusters));
+clustersStd      = cell(length(DataFiles), length(iClusters));
 clustersLabels   = cell(length(DataFiles), length(iClusters));
 axesLabels       = cell(length(DataFiles), length(iClusters));
 % Process each Data file
@@ -146,7 +147,17 @@ for iFile = 1:length(DataFiles)
         else
             ClusterFunction = 'stat';
         end
+        separator = strfind(ClusterFunction, '+');
+        if ~isempty(separator)
+            StdFunction     = ClusterFunction(separator+1:end);
+            ClusterFunction = ClusterFunction(1:separator-1);
+        else
+            StdFunction = [];
+        end
         clustersActivity{iFile,k} = bst_scout_value(DataToPlot, ClusterFunction);
+        if ~isempty(StdFunction)
+            clustersStd{iFile, k} = bst_scout_value(DataToPlot, StdFunction);
+        end
 
         % === AXES LABELS ===
         % Format: SubjectName/Cond1/.../CondN/(DataComment)/(ClusterName)
@@ -187,6 +198,7 @@ if ((max(nbTimes) > 2) && any(nbTimes == 2))
     iCellToExtend = find(nbTimes == 2);
     for i = 1:length(iCellToExtend)
         clustersActivity{iCellToExtend(i)} = repmat(clustersActivity{iCellToExtend(i)}(:,1), [1,max(nbTimes)]);
+        clustersStd{iCellToExtend(i)} = repmat(clustersStd{iCellToExtend(i)}(:,1), [1,max(nbTimes)]);
     end
 end
 
@@ -200,6 +212,7 @@ if (~ClustersOptions.overlayClusters && ~ClustersOptions.overlayConditions)
     % One graph for each line => Ngraph, Nclusters*Ncond
     % Clusters activity = cell-array {1, Ngraph} of doubles [1,Nt]
     clustersActivity = clustersActivity(:)';
+    clustersStd = clustersStd(:)';
     % Axes labels (subj/cond) = cell-array of strings {1, Ngraph}
     axesLabels = axesLabels(:)';
     % Clusters labels = cell-array of strings {1, Ngraph}
@@ -213,6 +226,7 @@ elseif (ClustersOptions.overlayClusters && ClustersOptions.overlayConditions)
     nbTraces = numel(clustersActivity);
     % Clusters activity = double [Nlines, Nt] 
     clustersActivity = cat(1, clustersActivity{:});
+    clustersStd = cat(1, clustersStd{:});
     % Clusters labels = cell-array {Nlines}
     % => "clusterName @ subject/condition"
     for iTrace = 1:nbTraces
@@ -235,8 +249,10 @@ elseif ClustersOptions.overlayClusters
     % Clusters activity = cell-array {1, Ncond} of doubles [Nclusters, Nt]
     for i = 1:size(clustersActivity,1)
         clustersActivityTmp(i) = {cat(1, clustersActivity{i,:})};
+        clustersStdTmp(i) = {cat(1, clustersStd{i,:})};
     end
     clustersActivity = clustersActivityTmp;
+    clustersStd = clustersStdTmp;
     % Axes labels (subj/cond) = cell-array of strings {1, Ncond} 
     axesLabels   = axesLabels(:,1)';
     % Clusters labels = cell-array of strings {Ncluster, Ncond} 
@@ -249,8 +265,10 @@ elseif ClustersOptions.overlayConditions
     % Clusters activity = cell-array {1, Ncluster} of doubles [Ncond, Nt]
     for j = 1:size(clustersActivity,2)
         clustersActivityTmp(j) = {cat(1, clustersActivity{:,j})};
+        clustersStdTmp(j) = {cat(1, clustersStd{:,j})};
     end
     clustersActivity = clustersActivityTmp;
+    clustersStd = clustersStdTmp;
     % Axes labels (cluster names @ common_subject/cond part) = cell-array of strings {1, Ncluster} 
     tmpAxesLabels = axesLabels;
     axesLabels = clustersLabels(1,:);
@@ -265,7 +283,7 @@ end
  
 %% ===== CALL DISPLAY FUNCTION ====
 % Plot time series
-hFig = view_timeseries_matrix(DataFiles{1}, clustersActivity, [], ['$' Modality], axesLabels, clustersLabels, clustersColors, hFig);
+hFig = view_timeseries_matrix(DataFiles{1}, clustersActivity, [], ['$' Modality], axesLabels, clustersLabels, clustersColors, hFig, clustersStd);
 % Store results files in figure appdata
 setappdata(hFig, 'DataFiles', DataFiles);
 setappdata(hFig, 'iClusters', iClusters);


### PR DESCRIPTION
It was requested in person to add Standard error to the cluster time series, so I added Mean+Std and Mean+StdErr as two new cluster functions. However, I am not sure if this would break something else, I've only ever used cluster functions from the Cluster tab.

![image](https://user-images.githubusercontent.com/9253273/41053888-d8e27d48-698a-11e8-8a51-a0d3e511ce87.png)
![image](https://user-images.githubusercontent.com/9253273/41053931-f66f83ba-698a-11e8-864a-409293e41356.png)
