### PR TITLE
Real-time head alignment bug fixes

### DIFF
--- a/toolbox/gui/view_channels.m
+++ b/toolbox/gui/view_channels.m
@@ -113,7 +113,7 @@ else
 end
 
 % ===== LOAD CHANNEL FILE IF NOT DONE =====
-if isempty(GlobalData.DataSet(iDS).ChannelFile) || isempty(GlobalData.DataSet(iDS).Channel)
+if isempty(GlobalData.DataSet(iDS).ChannelFile) || isempty(GlobalData.DataSet(iDS).Channel) || ~strcmpi(GlobalData.DataSet(iDS).ChannelFile, ChannelFile)
     % Load channel file
     ChannelMat = in_bst_channel(ChannelFile);
     % Copy information in memory

--- a/toolbox/gui/view_channels.m
+++ b/toolbox/gui/view_channels.m
@@ -113,7 +113,11 @@ else
 end
 
 % ===== LOAD CHANNEL FILE IF NOT DONE =====
-if isempty(GlobalData.DataSet(iDS).ChannelFile) || isempty(GlobalData.DataSet(iDS).Channel) || ~strcmpi(GlobalData.DataSet(iDS).ChannelFile, ChannelFile)
+% Also check if we are processing the same channel file, which can be
+% different when doing real-time head position alignment (2 helmets from
+% different datasets in the same figure).
+if isempty(GlobalData.DataSet(iDS).ChannelFile) || isempty(GlobalData.DataSet(iDS).Channel) || ...
+    ~strcmpi(GlobalData.DataSet(iDS).ChannelFile, ChannelFile)
     % Load channel file
     ChannelMat = in_bst_channel(ChannelFile);
     % Copy information in memory

--- a/toolbox/math/bst_project_2d.m
+++ b/toolbox/math/bst_project_2d.m
@@ -31,7 +31,13 @@ end
 % Different projection methods
 switch (Method)
     case '2dcap'
-        % Spheric coordinates
+        % Subtract mean in case points are not in SCS coordinates, which is
+        % the case e.g. when doing real-time head position display (dewar
+        % coordinates).
+        x = x - mean(x);
+        y = y - mean(y);
+        z = z - mean(z);
+        % Spherical coordinates
         [TH,PHI,R] = cart2sph(x, y, z);
         % Flat projection
         R = 1 - PHI ./ pi*2;
@@ -39,7 +45,7 @@ switch (Method)
         [X,Y] = pol2cart(TH,R);
 
     case '2dlayout'
-        % Spheric coordinates
+        % Spherical coordinates
         z = z - max(z);
         [TH,PHI,R] = cart2sph(x, y, z);
         % Remove the too smal values for PHI
@@ -52,7 +58,7 @@ switch (Method)
         %     figure; 
         %     plot3(x, y, 1 + 0.2 .* (z ./ param.minZ).^2, 'Marker', '+', 'LineStyle', 'none', 'Color', [0 1 0]); axis equal; rotate3d
 
-            % Spheric coordinates
+            % Spherical coordinates
             [TH,PHI,R] = cart2sph(x, y, z);
             % Flat projection
             R = 1 - PHI ./ pi*2;

--- a/toolbox/math/bst_project_2d.m
+++ b/toolbox/math/bst_project_2d.m
@@ -31,12 +31,6 @@ end
 % Different projection methods
 switch (Method)
     case '2dcap'
-        % Subtract mean in case points are not in SCS coordinates, which is
-        % the case e.g. when doing real-time head position display (dewar
-        % coordinates).
-        x = x - mean(x);
-        y = y - mean(y);
-        z = z - mean(z);
         % Spherical coordinates
         [TH,PHI,R] = cart2sph(x, y, z);
         % Flat projection

--- a/toolbox/realtime/bst_headtracking.m
+++ b/toolbox/realtime/bst_headtracking.m
@@ -342,6 +342,7 @@ end
 % Display current position helmet
 colorInd = 1;
 % Display CTF helmet
+
 view_helmet(SensorPositionFile, hFig);
 % Get the helmet patch
 hHelmetPatch = findobj(hFig, 'Tag', 'HelmetPatch');

--- a/toolbox/realtime/bst_headtracking.m
+++ b/toolbox/realtime/bst_headtracking.m
@@ -342,7 +342,6 @@ end
 % Display current position helmet
 colorInd = 1;
 % Display CTF helmet
-
 view_helmet(SensorPositionFile, hFig);
 % Get the helmet patch
 hHelmetPatch = findobj(hFig, 'Tag', 'HelmetPatch');

--- a/toolbox/sensors/channel_tesselate.m
+++ b/toolbox/sensors/channel_tesselate.m
@@ -35,8 +35,6 @@ if (nargin < 2) || isempty(isPerimThresh)
 end
 
 % === TESSELATE ===
-% 2D Projection
-[X,Y] = bst_project_2d(Vertices(:,1), Vertices(:,2), Vertices(:,3), '2dcap');
 % Compute best fitting sphere
 bfs_center = bst_bfs(Vertices)';
 % Center Vertices on BFS center
@@ -47,10 +45,14 @@ coordC = bst_bsxfun(@rdivide, coordC, sqrt(sum(coordC.^2,2)));
 % Tesselation of the sensor array
 Faces = convhulln(coordC);
 
-
 % === REMOVE UNNECESSARY TRIANGLES ===
 % For instance: the holes for the ears on high-density EEG caps
 if isPerimThresh
+    % 2D Projection   
+    % Use centered points in case points are not in SCS coordinates, which
+    % is the case e.g. when doing real-time head position display (dewar
+    % coordinates).
+    [X,Y] = bst_project_2d(coordC(:,1), coordC(:,2), coordC(:,3), '2dcap');
     % Get border of the representation
     border = convhull(X,Y);
     % Keep Faces inside the border

--- a/toolbox/sensors/channel_tesselate.m
+++ b/toolbox/sensors/channel_tesselate.m
@@ -35,6 +35,8 @@ if (nargin < 2) || isempty(isPerimThresh)
 end
 
 % === TESSELATE ===
+% 2D Projection
+[X,Y] = bst_project_2d(Vertices(:,1), Vertices(:,2), Vertices(:,3), '2dcap');
 % Compute best fitting sphere
 bfs_center = bst_bfs(Vertices)';
 % Center Vertices on BFS center
@@ -45,14 +47,10 @@ coordC = bst_bsxfun(@rdivide, coordC, sqrt(sum(coordC.^2,2)));
 % Tesselation of the sensor array
 Faces = convhulln(coordC);
 
+
 % === REMOVE UNNECESSARY TRIANGLES ===
 % For instance: the holes for the ears on high-density EEG caps
 if isPerimThresh
-    % 2D Projection   
-    % Use centered points in case points are not in SCS coordinates, which
-    % is the case e.g. when doing real-time head position display (dewar
-    % coordinates).
-    [X,Y] = bst_project_2d(coordC(:,1), coordC(:,2), coordC(:,3), '2dcap');
     % Get border of the representation
     border = convhull(X,Y);
     % Keep Faces inside the border


### PR DESCRIPTION
First bug would not load the second helmet (from a second dataset) into the same figure, but would reuse the first helmet/dataset.
Second bug would fail to properly find the helmet edge when the helmet points were in dewar coordinates.  That fix might affect other figures, maybe we should only adjust z, like in the 2dlayout method?