### PR TITLE
Added new default sorted L->R avg ref EEG montage

### DIFF
--- a/toolbox/core/bst_figures.m
+++ b/toolbox/core/bst_figures.m
@@ -403,7 +403,7 @@ function UpdateFigureName(hFig)
             TsInfo = getappdata(hFig, 'TsInfo');
             if isempty(TsInfo) || isempty(TsInfo.MontageName) || ~isempty(TsInfo.RowNames)
                 strMontage = 'All';
-            elseif strcmpi(TsInfo.MontageName, 'Average reference') || ~isempty(strfind(TsInfo.MontageName, '(local average ref)'))
+            elseif ~isempty(strfind(TsInfo.MontageName, 'Average reference')) || ~isempty(strfind(TsInfo.MontageName, '(local average ref)'))
                 strMontage = 'AvgRef';
             elseif strcmpi(TsInfo.MontageName, 'Bad channels')
                 strMontage = 'Bad';
@@ -471,7 +471,7 @@ function UpdateFigureName(hFig)
                             TsInfo = getappdata(hFig, 'TsInfo');
                             if isempty(TsInfo) || isempty(TsInfo.MontageName) || ~isempty(TsInfo.RowNames)
                                 strMontage = 'All';
-                            elseif strcmpi(TsInfo.MontageName, 'Average reference') || ~isempty(strfind(TsInfo.MontageName, '(local average ref)'))
+                            elseif ~isempty(strfind(TsInfo.MontageName, 'Average reference')) || ~isempty(strfind(TsInfo.MontageName, '(local average ref)'))
                                 strMontage = 'AvgRef';
                             elseif strcmpi(TsInfo.MontageName, 'Bad channels')
                                 strMontage = 'Bad';

--- a/toolbox/gui/panel_montage.m
+++ b/toolbox/gui/panel_montage.m
@@ -2262,13 +2262,31 @@ function [letters, number] = GetEeg1020ChannelParts(channelName)
     end
 end
 
-%% ===== CHECK IF CHANNEL SETUP IS EEG 10-20 =====
+%% ===== CHECK IF CHANNEL SETUP IS EEG 10-10/20 =====
 function is1020Setup = Is1020Setup(channelNames)
+    % Lists the 10-10 setup channel names (includes 10-20 channels)
+    bstDefaults = bst_get('EegDefaults');
+    chans1020 = [];
+    for iDir = 1:length(bstDefaults)
+        fList = bstDefaults(iDir).contents;
+        for iFile = 1:length(fList)
+            if strcmpi(fList(iFile).name, '10-10 65')
+                ChannelFile = fList(iFile).fullpath;
+                ChannelMat = in_bst_channel(ChannelFile);
+                chans1020 = {ChannelMat.Channel.Name};
+                break;
+            end
+        end
+    end
+    if isempty(chans1020)
+        error('Could not find EEG default 10-10 channels.');
+    end
+
+    % Go through active channels and look for 10-10 names
     numChannels = length(channelNames);
     num1020Channels = 0;
-    
     for iChannel = 1:numChannels
-        if ~isempty(GetEeg1020ChannelParts(channelNames{iChannel}))
+        if ismember(channelNames{iChannel}, chans1020)
             num1020Channels = num1020Channels + 1;
         end
     end

--- a/toolbox/gui/panel_record.m
+++ b/toolbox/gui/panel_record.m
@@ -683,6 +683,8 @@ function UpdateDisplayOptions(hFig)
         % Average reference
         elseif strcmpi(TsInfo.MontageName, 'Average reference')
             DispName = 'Avg Ref';
+        elseif strcmpi(TsInfo.MontageName, 'Average reference (L -> R)')
+            DispName = 'Avg Ref LR';
         % Regular montages
         else
             DispName = TsInfo.MontageName;

--- a/toolbox/gui/view_erpimage.m
+++ b/toolbox/gui/view_erpimage.m
@@ -122,7 +122,7 @@ switch (FileType)
         % Apply to the data
         if ~isempty(TsInfo.MontageName) && ~isempty(sMontage)
             % Get channel indices in the figure montage
-            if isequal(sMontage.Name, 'Average reference') || strcmpi(sMontage.Type, 'selection')
+            if ~isempty(strfind(sMontage.Name, 'Average reference')) || strcmpi(sMontage.Type, 'selection')
                 [iChanSel, iMatrixChan, iMatrixDisp] = panel_montage('GetMontageChannels', sMontage, RowNames);
             else
                 [iChanSel, iMatrixChan, iMatrixDisp] = panel_montage('GetMontageChannels', sMontage, RowNames, ChannelFlag);

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -115,7 +115,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             % Load input file 
             DataMat = in_bst_data(sInputs(iInput).FileName);
             % Build average reference
-            if (strcmpi(sMontage.Name, 'Average reference'))
+            if ~isempty(strfind(sMontage.Name, 'Average reference'))
                 sMontage = panel_montage('GetMontageAvgRef', sMontage, ChannelMat.Channel, DataMat.ChannelFlag, 0);
             elseif ~isempty(strfind(sMontage.Name, '(local average ref)'))
                 sMontage = panel_montage('GetMontageAvgRef', sMontage, ChannelMat.Channel, DataMat.ChannelFlag, 1);


### PR DESCRIPTION
RE: issue #52.
Added a new default montage called "Average reference (L -> R)" or "Avg Ref LR" shortened that serves the same purpose as "Average reference" but sorts channels from left to right based on their EEG position in their name.
![montage_lr](https://user-images.githubusercontent.com/9253273/41982861-7ce21438-79fa-11e8-9291-31532c375b85.png)
![montage_lr2](https://user-images.githubusercontent.com/9253273/41982951-b4096f42-79fa-11e8-8749-8701ba937879.png)
After meeting with Jeremy, it was clarified that the current "Average reference" default montage should be kept as is, and that sorting using the original index is sufficient once sorted by left, mid and right.