### PR TITLE
fix wavelengths shahpe

### DIFF
--- a/toolbox/io/in_fopen_nirs_brs.m
+++ b/toolbox/io/in_fopen_nirs_brs.m
@@ -178,8 +178,13 @@ if iscell(nirs.SD.Lambda) % Hb measures
     measure_type = 'Hb';
     ChannelMat.Nirs.Hb = nirs.SD.Lambda;
 else
+    
     measure_type = 'WL';
-    ChannelMat.Nirs.Wavelengths = nirs.SD.Lambda;
+    if( size(nirs.SD.Lambda,1) > 1) % Wavelengths have to be stored as a line vector
+        ChannelMat.Nirs.Wavelengths = nirs.SD.Lambda';
+    else
+        ChannelMat.Nirs.Wavelengths = nirs.SD.Lambda;
+    end
 end
 
 %% Channel information


### PR DESCRIPTION
This commit ensure that wavelengths are stored in a line vector when importing nirs files as it is assumed by nistorm. 