### PR TITLE
Fix line coloring for NIRS topography

### DIFF
--- a/toolbox/gui/figure_topo.m
+++ b/toolbox/gui/figure_topo.m
@@ -175,9 +175,13 @@ function UpdateTopoPlot(iDS, iFig)
         iDataCmap(iDataCmap > size(sColormap.CMap,1)) = size(sColormap.CMap,1);
         dataRGB = sColormap.CMap(iDataCmap, :);
         % Set lines colors
-        if (length(TopoHandles.hLines) == 1)
+        if iscell(TopoHandles.hLines) && length(TopoHandles.hLines) == 1
             for i = 1:length(TopoHandles.hLines{1})
                 set(TopoHandles.hLines{1}(i), 'Color', dataRGB(i,:));
+            end
+        elseif (length(TopoHandles.hLines) >= 1)
+            for i = 1:size(TopoHandles.hLines, 1)
+                set(TopoHandles.hLines(i), 'Color', dataRGB(i,:));
             end
         end
     end

--- a/toolbox/gui/figure_topo.m
+++ b/toolbox/gui/figure_topo.m
@@ -179,7 +179,7 @@ function UpdateTopoPlot(iDS, iFig)
             for i = 1:length(TopoHandles.hLines{1})
                 set(TopoHandles.hLines{1}(i), 'Color', dataRGB(i,:));
             end
-        elseif (length(TopoHandles.hLines) >= 1)
+        else
             for i = 1:size(TopoHandles.hLines, 1)
                 set(TopoHandles.hLines(i), 'Color', dataRGB(i,:));
             end


### PR DESCRIPTION
There is an issue with line colors that are not updated in topography when viewing NIRS data.

[This previous commit](https://github.com/brainstorm-tools/brainstorm3/commit/e24ff6c83deab434c8569612711a408f98e5bad0#diff-953276eb98a4ae071e2464b4033e98bcR178) changed  TopoHandles.hLines which seems to be a cell array now. However, for NIRS data, it still is an array of Line.

This commit preserves the new behavior and reenables the previous way of parsing TopoHandles.hLines.