### PR TITLE
Fix OutChannelFlag variable assignment

### DIFF
--- a/toolbox/process/bst_avg_files.m
+++ b/toolbox/process/bst_avg_files.m
@@ -485,7 +485,7 @@ if strcmpi(matName, 'F')
     OutChannelFlag  = ones(NbChannels, 1);
     OutChannelFlag(MeanBadChannels) = -1;
 else
-    OutChannelFlag = [];
+    OutChannelFlag = ChannelFlag;
 end
 
 % === FINALIZE COMPUTATION ===


### PR DESCRIPTION
Fixed OutChannelFlag variable assignment in order to be able to run a paired ttest between two datasets. Before this modification, the Stat.ChannelFlag structure  was set to empty, resulting with a "Index exceed matrix dimension" error.
