### PR TITLE
work around beep bug in Matlab 2018b

### DIFF
--- a/toolbox/sensors/panel_digitize.m
+++ b/toolbox/sensors/panel_digitize.m
@@ -1424,6 +1424,7 @@ function BytesAvailable_Callback(h, ev) %#ok<INUSD>
         if exist('isdeployed', 'builtin') && isdeployed && (Digitize.Mode ~= 8)
             sound(Digitize.BeepWav(6000:2:16000,1), 22000);
         else
+            beep on;
             beep();
         end
     end


### PR DESCRIPTION
The bug is that beep is turned off in some callback functions.  I've already reported it to Matlab and they've confirmed it.  We simply need to turn it back on before calling beep.