### PR TITLE
Add the possibility to keep the common word around the kept segments

### DIFF
--- a/toolbox/misc/str_remove_common.m
+++ b/toolbox/misc/str_remove_common.m
@@ -1,6 +1,13 @@
-function [strList, commonBegin, commonEnd] = str_remove_common( strList )
+function [strList, commonBegin, commonEnd] = str_remove_common( strList, keepWord, wordSeparator)
 % STR_REMOVE_COMMON: Identify and remove everything that is common to a cell array of strings
-
+%
+% Can keep words around the non-common segments using keepWord=1:
+%    Example: str_remove_common({'new sig1_g', 'new sig2_g'}, 1)
+%             returns: {'sig1', 'sig2'}
+%
+% Default word separators are : {' ', '_', '=', '(', ')', '[', ']', '|'}
+%    They can be customized using wordSeparator
+%
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
@@ -30,6 +37,28 @@ if ~iscell(strList)
 elseif isempty(strList)
     return;
 end
+
+if nargin < 2
+    keepWord = 0;
+end
+if ~isnumeric(keepWord) || ~(keepWord==0 || keepWord==1)
+    error('keepWord must be either 0 or 1');
+end
+
+if nargin < 3
+    wordSeparator = {' ', '_', '=', '(', ')', '[', ']', '|'};
+else
+    if ischar(wordSeparator)
+        if length(wordSeparator)==1
+            wordSeparator = {wordSeparator};
+        else
+            error('wordSeparator must either be a single char or a cell array of single char');
+        end
+    elseif ~iscell(wordSeparator) || ~all(cellfun(@(c) ischar(c) & length(c)==1, wordSeparator))
+        error('wordSeparator must either be a single char or a cell array of single char');
+    end
+end
+
 % If all the strings are equal: remove everything
 if all(cellfun(@(c)isequal(c,strList{1}), strList))
     commonBegin = strList{1};
@@ -63,5 +92,33 @@ if (iEnd > 1)
     commonEnd = strList{1}(end-iEnd+2:end);
     strList = cellfun(@(c)c(1:end-iEnd+1), strList, 'UniformOutput', 0);
 end
+
+if keepWord
+    icb = length(commonBegin)+1;
+    while(icb-1 >= 1 && ~ismember(commonBegin(icb-1), wordSeparator))
+        icb = icb - 1;
+    end
+    
+    ica = 0;
+    nbc = length(commonEnd);
+    while(ica+1 <= nbc && ~ismember(commonEnd(ica+1), wordSeparator))
+        ica = ica + 1;
+    end 
+    
+    strList = cellfun(@(c) [commonBegin(icb:end) c commonEnd(1:ica)], strList, 'UniformOutput', 0);
+    commonBegin = commonBegin(1:(icb-1));
+    commonEnd = commonEnd(ica+1:end);
+    
+    if isempty(commonBegin)
+        commonBegin = '';
+    end
+    if isempty(commonEnd)
+        commonEnd = '';
+    end
+    
+end
+
+end
+
 
 


### PR DESCRIPTION
With patterns like 
```matlab
list = {'filtered sig1', 'filtered sig2', 'filtered sig3'}
```
The default behaviour of the function str_remove_common returns:
```matlab
{'1', '2', '3'}
```
Which might not be informative enough.
The proposed addition allows to keep the common word around the varying segments:
```matlab 
str_remove_common(list, 1)
```
Returns:
```matlab 
{'sig1', 'sig2', 'sig3'}
```
 
The default behavior is kept. Word separators can be customized.