### PR TITLE
Improved channel_average

### DIFF
--- a/toolbox/db/db_combine_channel.m
+++ b/toolbox/db/db_combine_channel.m
@@ -1,5 +1,5 @@
 function [isNewFile, Message] = db_combine_channel( iSrcStudies, iDestStudy, UserConfirm, NoWarning )
-% DB_COMBINE_CHANNEL: Create a channel file for a study that do not have one yet. 
+% DB_COMBINE_CHANNEL: Create a channel file for a study that does not have one yet. 
 %
 % USAGE:  db_combine_channel( iSrcStudies, iDestStudy, UserConfirm, NoWarning )
 %         db_combine_channel( iSrcStudies, iDestStudy, UserConfirm )
@@ -19,7 +19,7 @@ function [isNewFile, Message] = db_combine_channel( iSrcStudies, iDestStudy, Use
 % DESCRIPTION: 
 %     - Create a channel coherent with other input studies.
 %     - Do not replace any previous channel file.
-%     - If more than one source channel file, the channels locations are averaged.
+%     - If more than one source channel file, the channel locations are averaged.
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -61,6 +61,7 @@ end
 % Get protocol directories
 ProtocolInfo = bst_get('ProtocolInfo');
 ChannelMats = {};
+iAvgStudies = [];
 
 %% ===== LOAD CHANNEL FILES =====
 for i = 1:length(iSrcStudies)
@@ -75,6 +76,7 @@ for i = 1:length(iSrcStudies)
     ChannelFile = bst_fullfile(ProtocolInfo.STUDIES, sStudy.Channel.FileName);
     % Load channel file
     ChannelMats{end + 1} = in_bst_channel(ChannelFile);
+    iAvgStudies(end + 1) = iStudy;
 end
 
 % If no valid source channel files
@@ -83,7 +85,7 @@ if isempty(ChannelMats)
 end
     
 %% ===== COMPUTE CHANNEL MEAN =====
-[MeanChannelMat, Message] = channel_average(ChannelMats);
+[MeanChannelMat, Message] = channel_average(ChannelMats, iAvgStudies, 'all');
 % An error occurred 
 if isempty(MeanChannelMat) 
     if ~NoWarning

--- a/toolbox/gui/figure_topo.m
+++ b/toolbox/gui/figure_topo.m
@@ -317,7 +317,7 @@ function [F, Time, selChan, overlayLabels, dispNames, StatThreshUnder, StatThres
                         F{iFile} = sqrt(F2.^2 + F3.^2);
                         % Error if montages are applied on this
                         if ~isempty(TsInfo.MontageName)
-                            error('You cannot apply a montagne when displaying the norm of the gradiometers.');
+                            error('You cannot apply a montage when displaying the norm of the gradiometers.');
                         end
                     % Regular recordings
                     else

--- a/toolbox/io/file_short.m
+++ b/toolbox/io/file_short.m
@@ -1,5 +1,5 @@
 function [FileName, FileType, isAnatomy] = file_short( FileName )
-% FILE_SHORT: Return the full filename from a relative filename
+% FILE_SHORT: Return a relative filename from the full filename 
 % 
 % USAGE:  [FileName, FileType, isAnatomy] = file_short( FileName )
 %         [FileName, FileType, isAnatomy] = file_short( FileNames )

--- a/toolbox/process/bst_avg_files.m
+++ b/toolbox/process/bst_avg_files.m
@@ -196,13 +196,6 @@ for iFile = 1:nFiles
     % Get values to process
     matValues = double(sMat.(matName));
     TimeVector = sMat.Time;
-    % Count number of previous averages for weighted average
-    if isWeighted
-        nAvg = sMat.nAvg;
-    else
-        nAvg = 1;
-    end
-    nAvgTotal = nAvgTotal + nAvg;
     
     % Apply default measure to TF values
     if strcmpi(matName, 'TF') && ~isreal(matValues)
@@ -443,6 +436,15 @@ for iFile = 1:nFiles
             iGoodRows = true(size(matValues,1), 1);
         end
     end
+    
+    % Add to count after all checks where we skip a file.
+    % Count number of previous averages for weighted average
+    if isWeighted
+        nAvg = sMat.nAvg;
+    else
+        nAvg = 1;
+    end
+    nAvgTotal = nAvgTotal + nAvg;
     % Count good channels
     nGoodSamples(iGoodRows) = nGoodSamples(iGoodRows) + nAvg;
     % Add file to the list of files used in the average

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -1658,6 +1658,10 @@ function [sStudy, iStudy, Comment, uniqueDataFile] = GetOutputStudy(sProcess, sI
         if ~isempty(Message)
             bst_report('Warning', sProcess, sInputs, Message);
         end
+        if isNewFile
+            % Refresh study with new channel file info.
+            sStudy = bst_get('Study', iStudy);
+        end
     end
 end
 

--- a/toolbox/process/functions/process_stdchan.m
+++ b/toolbox/process/functions/process_stdchan.m
@@ -42,7 +42,8 @@ function sProcess = GetDescription() %#ok<DEFNU>
     % === WARNING
     sProcess.options.warning.Comment = ['<B>Warning</B>: This process will standardize all the recordings<BR>' ...
                                         'in all the selected folders, not only the files you selected<BR>' ...
-                                        'in the Process1 tab. Note it cannot process links to raw files.<BR><BR>' ...
+                                        'in the Process1 tab. Note it cannot process links to raw files.<BR>' ...
+                                        'Removing channels will also remove associated projectors.<BR><BR>' ...
                                         'This proces may damage your database if not used properly.<BR>' ...
                                         'Backup your database before running it.<BR><BR>'];
     sProcess.options.warning.Type    = 'label';
@@ -127,15 +128,15 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     end
     % Check that there is something to process
     if isempty(sInputs)
-        bst_report('Error', sProcess, [], 'No data files to process.');
+        bst_report('Warning', sProcess, [], 'No data files to process.');
         return;
     elseif (length(ChannelFiles) == 1)
-        bst_report('Error', sProcess, sInputs, 'All the input files share the same channel file, nothing to register.');
+        bst_report('Info', sProcess, sInputs, 'All the input files share the same channel file, nothing to register.');
         return;
     end
     % Check if there any difference in the channel names
     if all(isEqualChan)
-        bst_report('Error', sProcess, sInputs, 'All the input files have identical channel names.');
+        bst_report('Info', sProcess, sInputs, 'All the input files have identical channel names.');
         return;
     end
     % Check if there are channels left
@@ -263,25 +264,37 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         tmpChanMat.Channel(iChanDest{iFile}) = ChannelMats{iFile}.Channel(iChanSrc{iFile});
         % Update MegRefCoef
         if isfield(tmpChanMat, 'MegRefCoef') && ~isempty(tmpChanMat.MegRefCoef)
-            % Check that number of MEG sensors did not change, if not reset MegRefCoef
-            iMegSrc  = good_channel(ChannelMats{iFile}.Channel, [], {'MEG', 'MEG REF'});
-            iMegDest = good_channel(tmpChanMat.Channel, [], {'MEG', 'MEG REF'});
+            % Check that number of MEG references did not change, otherwise reset MegRefCoef
+            iMegSrc  = find(strcmpi({ChannelMats{iFile}.Channel.Type}, 'MEG REF'));
+            iMegDest = find(strcmpi({tmpChanMat.Channel.Type}, 'MEG REF'));
             if (length(iMegSrc) ~= length(iMegDest))
-                bst_report('Warning', sProcess, sInputs, 'Number of Meg channels changed. Removing CTF compensation matrix from channel file.');
+                bst_report('Warning', sProcess, sInputs, 'Number of Meg reference channels changed. Removing CTF compensation matrix from channel file.');
                 tmpChanMat.MegRefCoef = [];
+            else
+                % Adjust channel rows.  If some are added, they are empty
+                % and of type "added", so no need to add rows.
+                iRemMeg = intersect(iRemChan, find(strcmpi({ChannelMats{iFile}.Channel.Type}, 'MEG')));
+                tmpChanMat.MegRefCoef(iRemMeg, :) = [];
             end
         end
         % Update Projectors
         if isfield(tmpChanMat, 'Projector') && ~isempty(tmpChanMat.Projector)
-            for iProj = 1:length(tmpChanMat.Projector)
-                % New form: decomposed
-                if ~isempty(tmpChanMat.Projector(iProj).CompMask)
-                    tmpChanMat.Projector(iProj).Components = zeros(length(ChanList), size(ChannelMats{iFile}.Projector(iProj).Components,2));
-                    tmpChanMat.Projector(iProj).Components(iChanDest{iFile},:) = ChannelMats{iFile}.Projector(iProj).Components(iChanSrc{iFile},:);
-                % Old form: I-UUt
+            for iProj = length(tmpChanMat.Projector):-1:1 % reverse because of potential removal
+                % Find channels involved.  If any are removed, the
+                % projector is no longer valid and removed as well.
+                iProjChan = find(any(ChannelMats{iFile}.Projector(iProj).Components(iChanSrc{iFile},:) ~= 0, 2));
+                if ~isempty(intersect(iProjChan, iRemChan))
+                    tmpChanMat.Projector(iProj) = [];
                 else
-                    tmpChanMat.Projector(iProj).Components = zeros(length(ChanList));
-                    tmpChanMat.Projector(iProj).Components(iChanDest{iFile},iChanDest{iFile}) = ChannelMats{iFile}.Projector(iProj).Components(iChanSrc{iFile},iChanSrc{iFile});
+                    % New form: decomposed
+                    if ~isempty(tmpChanMat.Projector(iProj).CompMask)
+                        tmpChanMat.Projector(iProj).Components = zeros(length(ChanList), size(ChannelMats{iFile}.Projector(iProj).Components,2));
+                        tmpChanMat.Projector(iProj).Components(iChanDest{iFile},:) = ChannelMats{iFile}.Projector(iProj).Components(iChanSrc{iFile},:);
+                        % Old form: I-UUt
+                    else
+                        tmpChanMat.Projector(iProj).Components = zeros(length(ChanList));
+                        tmpChanMat.Projector(iProj).Components(iChanDest{iFile},iChanDest{iFile}) = ChannelMats{iFile}.Projector(iProj).Components(iChanSrc{iFile},iChanSrc{iFile});
+                    end
                 end
             end
         end
@@ -293,7 +306,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     end
     % No files processed: exit
     if isempty(iFileToProcess)
-        bst_report('Error', sProcess, sInputs, 'All channel files are similar.');
+        bst_report('Info', sProcess, sInputs, 'All channel files are similar.');
         return;
     end
 

--- a/toolbox/sensors/channel_average.m
+++ b/toolbox/sensors/channel_average.m
@@ -296,6 +296,7 @@ function [MeanChannelMat, Message] = channel_average(ChannelMats, iStudies, Meth
         
         % Match channels by name.
         [Unused, iMean, iChans] = intersect(KeepChans, {ChannelMats{i}.Channel.Name}, 'stable'); % Stable keeps the order of CommonChans.
+        % KeepChans(iMean) == {ChannelMats{i}.Channel.Name}(iChans)
         
         % Sum EEG channel locations
         [Unused, iiChan] = setdiff(iMean', iMegRef);
@@ -304,14 +305,14 @@ function [MeanChannelMat, Message] = channel_average(ChannelMats, iStudies, Meth
             if isempty(ChannelMats{i}.Channel(iChans(c)).Loc)
                 continue;
                 % Check the size of Loc matrix and the values of Weights matrix
-            elseif isempty(MeanChannelMat.Channel(iChans(c)).Loc)
+            elseif isempty(MeanChannelMat.Channel(iMean(c)).Loc)
                 MeanChannelMat.Channel(iMean(c)).Loc = ChannelMats{i}.Channel(iChans(c)).Loc;
                 Dist{iMean(c)} = sqrt(sum(ChannelMats{i}.Channel(iChans(c)).Loc.^2, 1));
                 MeanChannelMat.Channel(iMean(c)).Orient = ChannelMats{i}.Channel(iChans(c)).Orient;
                 nAvg(iMean(c)) = nAvg(iMean(c)) + 1;
             elseif ~isequal(size(MeanChannelMat.Channel(iMean(c)).Loc), size(ChannelMats{i}.Channel(iChans(c)).Loc))
-                Message = ['A channel does not have the same location structure between studies.' 10 ...
-                    'Cannot create a common channel file.'];
+                Message = sprintf(['A channel does not have the same location structure between studies. (file %d, chan %d)' 10 ...
+                    'Cannot create a common channel file.'], i, iChans(c));
                 MeanChannelMat = [];
                 return;
             else

--- a/toolbox/sensors/channel_average.m
+++ b/toolbox/sensors/channel_average.m
@@ -1,101 +1,416 @@
-function [MeanChannelMat, Message] = channel_average(ChannelMats)
-% CHANNEL_AVERAGE: Averages positions of MEG/EEG sensors.
-%
-% INPUT:
-%     - ChannelMats : Cell array of channel.mat structures
-% OUPUT:
-%     - MeanChannelMat : Average channel mat
-
-% @=============================================================================
-% This function is part of the Brainstorm software:
-% https://neuroimage.usc.edu/brainstorm
-% 
-% Copyright (c)2000-2019 University of Southern California & McGill University
-% This software is distributed under the terms of the GNU General Public License
-% as published by the Free Software Foundation. Further details on the GPLv3
-% license can be found at http://www.gnu.org/copyleft/gpl.html.
-% 
-% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
-% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
-% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
-% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
-% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
-%
-% For more information type "brainstorm license" at command prompt.
-% =============================================================================@
-%
-% Authors: Francois Tadel, 2012-2018
-
-Message = [];
-
-% Detect device
-[DeviceTag, DeviceName] = channel_detect_device(ChannelMats{1});
-% CTF/4D files: take the center of the coil closer to the head
-if any(strcmpi(DeviceName, {'CTF', '4D', 'KRISS'}))
-    iChanInteg = [];
-    for i = 1:length(ChannelMats)
-        for iChan = 1:length(ChannelMats{i}.Channel)
-            nCoils = size(ChannelMats{i}.Channel(iChan).Loc,2);
-            % DO NOT PROCESS REF NOW, THIS WILL MAYBE HAVE TO BE CHANGED
-            %if any(strcmpi(ChannelMats{i}.Channel(iChan).Type, {'MEG','MEG REF'}))
-            if any(strcmpi(ChannelMats{i}.Channel(iChan).Type, {'MEG'})) && (nCoils >= 4)
-                if (i == 1)
-                    iChanInteg(end+1) = iChan;
-                end
-                ChannelMats{i}.Channel(iChan).Loc = mean(ChannelMats{i}.Channel(iChan).Loc(:,1:4), 2);
-            end
-        end
+function [MeanChannelMat, Message] = channel_average(ChannelMats, iStudies, Method)
+    % CHANNEL_AVERAGE: Averages positions of MEG/EEG sensors.
+    %
+    % INPUT:
+    %     - ChannelMats: Cell array of channel.mat structures
+    %     - iStudies: Array of indices of input studies
+    %     - Method: 'common', 'all' (default), or 'first'
+    % OUPUT:
+    %     - MeanChannelMat: Average channel mat
+    
+    % @=============================================================================
+    % This function is part of the Brainstorm software:
+    % https://neuroimage.usc.edu/brainstorm
+    %
+    % Copyright (c)2000-2019 University of Southern California & McGill University
+    % This software is distributed under the terms of the GNU General Public License
+    % as published by the Free Software Foundation. Further details on the GPLv3
+    % license can be found at http://www.gnu.org/copyleft/gpl.html.
+    %
+    % FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+    % UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+    % WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+    % MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+    % LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+    %
+    % For more information type "brainstorm license" at command prompt.
+    % =============================================================================@
+    %
+    % Authors: Francois Tadel 2012-2018, Marc Lalancette 2019
+    
+    % To do: reorder the channels in 'all' method.
+    
+    if nargin < 3 || isempty(Method)
+        Method = 'all';
     end
-end
-
-% Check the coherence between all the channel files
-MeanChannelMat = ChannelMats{1};
-nAvg = ones(1, length(MeanChannelMat.Channel));
-% Loop on all the 
-for i = 2:length(ChannelMats)
-    % Check number of channels
-    if (length(ChannelMats{i}.Channel) ~= length(MeanChannelMat.Channel))
-        Message = ['The channels files from the different studies do not have the same number of channels.' 10 ...
-                   'Cannot create a common channel file.'];
+    if nargin < 2 || isempty(iStudies)
+        iStudies = [];
+    elseif numel(iStudies) ~= numel(ChannelMats)
+        Message = 'Error: iStudies should be same length as ChannelMats';
+        MeanChannelMat = [];
+        return
+    end
+    Message = [];
+    
+    nFiles = numel(ChannelMats);
+    MeanChannelMat = ChannelMats{1};
+    if ~isempty(iStudies) && numel(unique(iStudies)) == 1
+        % Only one input, no need to process further.
+        return;
+    end
+    
+    switch lower(Method)
+        case 'common'
+            % Find common channels from all files.
+            for i = 1:nFiles
+                if i == 1
+                    KeepChans = {ChannelMats{i}.Channel.Name};
+                else
+                    KeepChans = intersect(KeepChans, {ChannelMats{i}.Channel.Name}, 'stable');
+                end
+            end
+            [Unused, iMean, iChans] = intersect(KeepChans, {MeanChannelMat.Channel.Name}, 'stable'); % Stable keeps the order of CommonChans.
+            MeanChannelMat.Channel = MeanChannelMat.Channel(:, iChans);
+        case 'all'
+            % Find all channels from all files.
+            for i = 1:nFiles
+                if i == 1
+                    KeepChans = {ChannelMats{i}.Channel.Name};
+                else
+                    % Union can order sorted or 'stable' which is all 1
+                    % then new 2.  Ideally we'd want the new 2 to be in
+                    % their "normal" spot. (To do)
+                    %                     nChans = numel(KeepChans);
+                    [KeepChans, Unused, iNew] = union(KeepChans, {ChannelMats{i}.Channel.Name}, 'stable');
+                    %                     nNew = numel(iNew);
+                    %                     for n = 1:nNew
+                    %                         iBef =
+                    %                     end
+                    if ~isempty(iNew)
+                        
+                        iMeg = find(strcmp({ChannelMats{i}.Channel.Type}, 'MEG'));
+                        [Unused, iMegNew] = ismember(iNew, iMeg);
+                        % iiMeg is zero for non-matches. Get actual indices of new MEG channels.
+                        iMegNew(iMegNew == 0) = [];
+                        if ~isempty(iMegNew)
+                            % Add CTF compensation coefs for new channels if same number of references (actual same set confirmed later).
+                            if size(MeanChannelMat.MegRefCoef, 2) == size(ChannelMats{i}.MegRefCoef, 2)
+                                MeanChannelMat.MegRefCoef = [MeanChannelMat.MegRefCoef; ChannelMats{i}.MegRefCoef(iMegNew, :)];
+                                % else we'll just remove it later.
+                            end
+                            % Convert location and orientation of new MEG channels to 1st file coordinates.
+                            % They will be changed to an average location later. 
+                            TransfMeg = eye(4);
+                            if isfield(MeanChannelMat, 'TransfMeg')
+                                for t = 1:numel(MeanChannelMat.TransfMeg)
+                                    TransfMeg = MeanChannelMat.TransfMeg{t} * TransfMeg;
+                                end
+                            end
+                            if isfield(ChannelMats{i}, 'TransfMeg')
+                                for t = 1:numel(ChannelMats{i}.TransfMeg)
+                                    TransfMeg = TransfMeg / MeanChannelMat.TransfMeg{t};
+                                end
+                            end
+                            tempChannelMat = channel_apply_transf(ChannelMats{i}, TransfMeg, iMegNew, false);
+                            MeanChannelMat.Channel = [MeanChannelMat.Channel, tempChannelMat{1}.Channel(iMegNew)];
+                        end
+                        MeanChannelMat.Channel = [MeanChannelMat.Channel, ChannelMats{i}.Channel(setdiff(iNew, iMegNew))];
+                    end
+                end
+            end
+        case 'first'
+            KeepChans = {ChannelMats{1}.Channel.Name};
+        otherwise
+            error('Unrecognized method, should be ''all'', ''common'' or ''first''.');
+    end
+    
+    nChan = numel(MeanChannelMat.Channel);
+    if nChan == 0
+        Message = ['The channels files from the different studies do not have any channels in common.' 10 ...
+            'Cannot create a common channel file.'];
         MeanChannelMat = [];
         return;
     end
-    % Sum channel locations
-    for iChan = 1:length(MeanChannelMat.Channel)
-        % If the channel has no location in this file: skip
-        if isempty(ChannelMats{i}.Channel(iChan).Loc)
-            continue;
-        % If the current average is empty, use the new value directly
-        elseif isempty(MeanChannelMat.Channel(iChan).Loc)
-            MeanChannelMat.Channel(iChan).Loc    = ChannelMats{i}.Channel(iChan).Loc;
-            MeanChannelMat.Channel(iChan).Orient = ChannelMats{i}.Channel(iChan).Orient;
-        % Check the size of Loc matrix and the values of Weights matrix
-        elseif ~isequal(size(MeanChannelMat.Channel(iChan).Loc), size(ChannelMats{i}.Channel(iChan).Loc))
-            Message = ['The channels files from the different studies do not have the same structure.' 10 ...
-                       'Cannot create a common channel file.'];
-            MeanChannelMat = [];
-            return;
-        % Sum with existing average
-        else
-            MeanChannelMat.Channel(iChan).Loc    = MeanChannelMat.Channel(iChan).Loc    + ChannelMats{i}.Channel(iChan).Loc;
-            MeanChannelMat.Channel(iChan).Orient = MeanChannelMat.Channel(iChan).Orient + ChannelMats{i}.Channel(iChan).Orient;
-            nAvg(iChan) = nAvg(iChan) + 1;
+        
+    iMeg = find(strcmp({MeanChannelMat.Channel.Type}, 'MEG'));
+    iRef = find(strcmp({MeanChannelMat.Channel.Type}, 'MEG REF'));
+    iMegRef = sort([iMeg, iRef]);
+    
+    % Update channel number in comment
+    if nChan ~= numel(ChannelMats{1}.Channel) % The one we copied.
+        iComment = find(MeanChannelMat.Comment == '(', 1, 'last');
+        if ~isempty(iComment)
+            MeanChannelMat.Comment(iComment:end) = '';
+        end
+        MeanChannelMat.Comment = sprintf('%s (%d)', MeanChannelMat.Comment, numel(KeepChans));
+    end
+        
+    % Update MegRefCoef (only kept if reference channels are identical in all files)
+    if numel(iMeg) && numel(iRef)
+        if size(MeanChannelMat.MegRefCoef, 2) ~= numel(iRef)
+            % Can't merge coefficients if different reference sets.
+            MeanChannelMat.MegRefCoef = [];
+        elseif size(MeanChannelMat.MegRefCoef, 1) ~= numel(iMeg) % Only for 'common' method
+            iRemove = setdiff(iMeg, iChans);
+            if ~isempty(iRemove)
+                [Unused, iMegNew] = ismember(iRemove, iMeg);
+                MeanChannelMat.MegRefCoef(iMegNew, :) = [];
+            end
+        end
+    else
+        % Just get rid of it.
+        MeanChannelMat.MegRefCoef = [];
+    end
+        
+    % Either we don't know the source studies, or we know there are more than 1.
+    % Discard projectors.
+    MeanChannelMat.Projector(:) = []; % Keeps empty structure
+    % New history.
+    MeanChannelMat = bst_history('reset', MeanChannelMat);
+    MeanChannelMat = bst_history('add',  MeanChannelMat,  'average', ...
+        sprintf('Created by channel_average, from %d input files (incl. possible duplicates).', nFiles));
+    % List of distinct averaged files added to history below, if we have iStudies.
+    
+    % Find subjects
+    if ~isempty(iStudies)
+        iSubjects = zeros(nFiles, 1);
+        for i = 1:nFiles
+            [isFound, iFoundFile] = ismember(iSubjects(i), iSubjects(1:i-1));
+            if isFound
+                iSubjects(i) = iSubjects(iFoundFile);
+            else
+                sStudy = bst_get('Study', iStudies(i));
+                [Unused, iSubjects(i)] = bst_get('Subject', sStudy.BrainStormSubject);
+                MeanChannelMat = bst_history('add', MeanChannelMat, 'average', [' - ' sStudy.Channel.FileName]);
+            end
         end
     end
-end
-% Divide the locations of channels by the number of channel files
-for iChan = 1:length(MeanChannelMat.Channel)
-    if (nAvg(iChan) > 0)
-        MeanChannelMat.Channel(iChan).Loc    = MeanChannelMat.Channel(iChan).Loc    / nAvg(iChan);
-        MeanChannelMat.Channel(iChan).Orient = MeanChannelMat.Channel(iChan).Orient / nAvg(iChan);
+    if isempty(iStudies) || numel(unique(iSubjects)) > 1
+        % Discard head points.
+        MeanChannelMat.HeadPoints.Loc = [];
+        MeanChannelMat.HeadPoints.Label = {};
+        MeanChannelMat.HeadPoints.Type = {};
     end
+
+    % --------------------------------------------------------------------
+    % For MEG, best to "average" 'Dewar=>Native' transformation.  Applies
+    % directly to MEG and reference channels, all integration points.  Warn if
+    % missing or unusual transformations, but shouldn't happen.
+    if ~isempty(iMegRef)
+        BrainOrigin = zeros(nFiles, 3);
+        for i = 1:nFiles
+            if ~isempty(iStudies)
+                [isFound, iFoundFile] = ismember(iSubjects(i), iSubjects(1:i-1));
+                if isFound
+                    BrainOrigin(i, :) = BrainOrigin(iFoundFile, :);
+                else
+                    sSubject = bst_get('Subject', iSubjects(i));
+                    %             [sCortex, iSurface] = bst_get('SurfaceFileByType', iSubject, 'Cortex'); % Doesn't contain the surface data.
+                    if ~isempty(sSubject.iCortex) && ~isempty(sSubject.Surface(sSubject.iCortex).FileName)
+                        sCortex = in_tess_bst(sSubject.Surface(sSubject.iCortex).FileName, 0);
+                        BrainOrigin(i, :) = mean(sCortex.Vertices, 1);
+                    else
+                        BrainOrigin(i, :) = [1, 0, 6] ./ 100; % in m
+                    end
+                end
+            else
+                BrainOrigin(i, :) = [1, 0, 6] ./ 100; % in m
+            end
+        end
+        
+        TransfMeg = cell(0);
+        isWarnTransfOrder = false;
+        for i = 1:nFiles
+            iTransf = find(strcmpi(ChannelMats{i}.TransfMegLabels, 'Dewar=>Native'), 1, 'first');
+            if ~isempty(iTransf)
+                if iTransf ~= 1
+                    isWarnTransfOrder = true;
+                end
+                TransfMeg{end+1} = ChannelMats{i}.TransfMeg{iTransf};
+            end
+        end
+        if isWarnTransfOrder
+            if ~isempty(Message)
+                Message = [Message, '\n'];
+            end
+            Message = [Message, 'Unexpected MEG transformation order; MEG channel positions may be wrong.'];
+        end
+        nAvg = numel(TransfMeg);
+        if nAvg < nFiles && ~isempty(Message)
+            Message = [Message, '\n'];
+        end
+        if nAvg == 0
+            % Not sure if this is possible, but would be ok if the channels are
+            % still in dewar coordinates; no averaging required.
+            Message = [Message, 'No Dewar=>Native transformation found; MEG channel positions not averaged.'];
+            TransfMeg = eye(4);
+        else
+            if nAvg < nFiles
+                Message = [Message, 'Missing Dewar=>Native transformations; MEG channel positions not fully averaged.'];
+            end
+            % Optimal position and orientation average (without shrinkage),
+            % centered on brain origin.
+            TransfMeg = PositionAverage(TransfMeg, BrainOrigin);
+            iTransf = find(strcmpi(MeanChannelMat.TransfMegLabels, 'Dewar=>Native'), 1, 'first');
+            if isempty(iTransf)
+                OldTransf = eye(4);
+                % Insert at first position, though this is unusual especially
+                % if there are other transf.
+                MeanChannelMat.TransfMegLabels = [{'Dewar=>Native'}, MeanChannelMat.TransfMegLabels];
+                MeanChannelMat.TransfMeg = [{TransfMeg}, MeanChannelMat.TransfMeg];
+                iTransf = 1;
+            else
+                OldTransf = MeanChannelMat.TransfMeg{iTransf};
+                MeanChannelMat.TransfMeg{iTransf} = TransfMeg;
+            end
+            TransfMeg = TransfMeg / OldTransf;
+            % Combine with all subsequent transf for applying later.
+            for iTr = iTransf+1:numel(MeanChannelMat.TransfMeg)
+                % Remove first (right), reapply last (left).
+                TransfMeg = MeanChannelMat.TransfMeg{iTr} * TransfMeg / MeanChannelMat.TransfMeg{iTr};
+            end
+        end
+        
+        % Apply to channel locations and orientations.
+        MeanChannelMat = channel_apply_transf(MeanChannelMat, TransfMeg, iMegRef, false);
+        MeanChannelMat = MeanChannelMat{1};
+        % Remove last tranformation we just added, it's already in the new 'Dewar=>Native'.
+        MeanChannelMat.TransfMeg(end) = [];
+        MeanChannelMat.TransfMegLabels(end) = [];
+    end
+    
+    % --------------------------------------------------------------------
+    % For other channels, average positions and orientations, but correct
+    % distances to avoid "shrinkage" towards origin.  (Could use brain center
+    % again here.)
+    nAvg = zeros(1, nChan);
+    Dist = cell(nChan, 1);
+    % Keep channel location sizes, but initialize sums to zero.
+    for iChan = setdiff(1:nChan, iMegRef) 
+        % If the channel has no location, skip.
+        if ~isempty(MeanChannelMat.Channel(iChan).Loc)
+            MeanChannelMat.Channel(iChan).Loc(:) = 0; 
+            MeanChannelMat.Channel(iChan).Orient(:) = 0; 
+            Dist{iChan} = zeros(1, size(MeanChannelMat.Channel(iChan).Loc, 2));
+        end
+    end
+    
+    for i = 1:nFiles
+        %         % Check number of channels
+        %         if numel(ChannelMats{i}.Channel) ~= nChan
+        %             Message = ['The channels files from the different studies do not have the same number of channels.' 10 ...
+        %                 'Cannot create a common channel file.'];
+        %             MeanChannelMat = [];
+        %             return;
+        %         end
+        
+        % Match channels by name.
+        [Unused, iMean, iChans] = intersect(KeepChans, {ChannelMats{i}.Channel.Name}, 'stable'); % Stable keeps the order of CommonChans.
+        
+        % Sum EEG channel locations
+        [Unused, iiChan] = setdiff(iMean', iMegRef);
+        for c = iiChan'
+            % If the channel has no location in this file: skip
+            if isempty(ChannelMats{i}.Channel(iChans(c)).Loc)
+                continue;
+                % Check the size of Loc matrix and the values of Weights matrix
+            elseif isempty(MeanChannelMat.Channel(iChans(c)).Loc)
+                MeanChannelMat.Channel(iMean(c)).Loc = ChannelMats{i}.Channel(iChans(c)).Loc;
+                Dist{iMean(c)} = sqrt(sum(ChannelMats{i}.Channel(iChans(c)).Loc.^2, 1));
+                MeanChannelMat.Channel(iMean(c)).Orient = ChannelMats{i}.Channel(iChans(c)).Orient;
+                nAvg(iMean(c)) = nAvg(iMean(c)) + 1;
+            elseif ~isequal(size(MeanChannelMat.Channel(iMean(c)).Loc), size(ChannelMats{i}.Channel(iChans(c)).Loc))
+                Message = ['A channel does not have the same location structure between studies.' 10 ...
+                    'Cannot create a common channel file.'];
+                MeanChannelMat = [];
+                return;
+            else
+                % Sum with existing average
+                MeanChannelMat.Channel(iMean(c)).Loc = MeanChannelMat.Channel(iMean(c)).Loc + ChannelMats{i}.Channel(iChans(c)).Loc;
+                % Also sum distances from origin.
+                Dist{iMean(c)} = Dist{iMean(c)} + sqrt(sum(ChannelMats{i}.Channel(iChans(c)).Loc.^2, 1));
+                MeanChannelMat.Channel(iMean(c)).Orient = MeanChannelMat.Channel(iMean(c)).Orient + ChannelMats{i}.Channel(iChans(c)).Orient;
+                nAvg(iMean(c)) = nAvg(iMean(c)) + 1;
+            end
+        end
+    end
+    for iChan = 1:nChan
+        if nAvg(iChan) > 1
+            % Divide the locations of channels by the number of channel files averaged.
+            MeanChannelMat.Channel(iChan).Loc = MeanChannelMat.Channel(iChan).Loc / nAvg(iChan);
+            Dist{iChan} = Dist{iChan} / nAvg(iChan);
+            % Correct distance from origin.
+            MeanChannelMat.Channel(iChan).Loc = bsxfun(@times, MeanChannelMat.Channel(iChan).Loc, ...
+                Dist{iChan} ./ sqrt(sum(MeanChannelMat.Channel(iChan).Loc.^2, 1)));
+            % Orientations need to be normalized.
+            MeanChannelMat.Channel(iChan).Orient = MeanChannelMat.Channel(iChan).Orient / norm(MeanChannelMat.Channel(iChan).Orient);
+        end
+    end
+    
 end
 
-% CTF/4D files: Restore the full list of integration points
-if any(strcmpi(DeviceName, {'CTF', '4D', 'KRISS'}))
-    MeanChannelMat.Channel(iChanInteg) = ctf_add_coil_defs(MeanChannelMat.Channel(iChanInteg), DeviceName);
+
+function TransfAvg = PositionAverage(Transf, BrainOrigin)
+    % Average head position to minimize sum of square displacements over cortex.
+    
+    % Simply averaging positions (sensors or surface points) at different
+    % orientations shrinks the space.  We must average origins, and
+    % separately the spatial rotations.
+    
+    nT = numel(Transf);
+    TransfAvg = eye(4);
+    
+    % Rotations ------------------------------
+    % [Markley 2007 - Averaging Quaternions] gives a simple method for
+    % averaging orientations based on the quaternion representation.
+    Quat = zeros(4, nT);
+    for t = 1:nT
+        Quat(:, t) = RotToQuat(Transf{t}(1:3, 1:3));
+    end
+    % Eigenvector of max eigenvalue of Q'*Q is first singular vector of Q'.
+    [U, S] = svd(Quat, 'econ');
+    TransfAvg(1:3, 1:3) = QuatToRot(U(:, 1));
+    % Rotation verified.
+    
+    % Translations of origin ------------------------------
+    % To minimize brain displacement, we must choose the cortex center as
+    % the origin to average, and not the SCS origin.  We must know the
+    % cortex center in head coordinates.
+    Origins = zeros(4, nT);
+    BrainOriginAvg = zeros(3, 1);
+    for t = 1:nT
+        Origins(:, t) = Transf{t} \ [BrainOrigin(t, :)'; 1];
+        BrainOriginAvg = BrainOriginAvg + BrainOrigin(t, :)';
+    end
+    BrainOriginAvg = BrainOriginAvg / nT;
+    TransfAvg(1:3, 4) = BrainOriginAvg - TransfAvg(1:3, 1:3) * ...
+        process_adjust_coordinates('GeoMedian', Origins(1:3, :)')';
+    % Origin verified.
+    
 end
 
+
+% Verified conversions of matrix and quaternion representations.
+%     Transf = eye(3);
+%     t = pi/2;
+%     Transf(1:2, 1:2) = [cos(t), -sin(t); sin(t), cos(t)]
+%     NewTransf = QuatToRot(RotToQuat(Transf))
+function R = QuatToRot(q)
+    % q = [w, x, y, z]', w scalar
+    d = q(1)^2 - q(2)^2 - q(3)^2 - q(4)^2;
+    R = d * eye(3) + 2 * [q(2)^2, q(2)*q(3) - q(1)*q(4), q(2)*q(4) + q(1)*q(3); ...
+        q(2)*q(3) + q(1)*q(4), q(3)^2, q(3)*q(4) - q(1)*q(2); ...
+        q(2)*q(4) - q(1)*q(3), q(3)*q(4) + q(1)*q(2), q(4)^2];
+end
+
+function q = RotToQuat(R)
+    % q = [w, x, y, z]', w scalar
+    t = trace(R);
+    q = [1 + t; ...
+        1 - t + 2 * R(1, 1); ...
+        1 - t + 2 * R(2, 2); ...
+        1 - t + 2 * R(3, 3)];
+    if any(q < 0)
+        error('Quat problem');
+    end
+    q = 1/2 * sqrt(q);
+    q = q .* [1; ...
+        sign(R(3, 2) - R(2, 3));
+        sign(R(1, 3) - R(3, 1));
+        sign(R(2, 1) - R(1, 2))];
+    % For minimizing errors.
+    q = q ./ norm(q);
+end
 
 
 


### PR DESCRIPTION
Improvements:
1. Used to give an error if number of channels didn't match.  It now deals properly with varying channels (matches them by name), with the options of keeping either all channels (default), only common channels, or those from the first file (similarly to bst_avg_files).
2. Averaging locations caused "shrinkage" towards origin.  Now MEG channels are averaged based on the dewar=>native transformations, separately averaging the "brain origins" (based on the cortex surface if available) and the head orientations.  EEG channel locations are still simply averaged, but with a correction to avoid "shrinkage".
3. There was a bug in averaging orientations: they were not normalized.  Fixed.

Following this, process_average should also be modified to always match channels by name.  This is only an option (why?) and only for files that contain RowNames (tf and matrix types).  I think this can easily lead to errors in group averaging.  There should at the very least be a warning or error if channels don't match and the code can't deal with it.  Now it just averages by channel index.