### PR TITLE
save channel names with projectors and check when importing

### DIFF
--- a/toolbox/io/export_ssp.m
+++ b/toolbox/io/export_ssp.m
@@ -46,6 +46,7 @@ switch (fExt)
         out_projector_fif(OutputFile, ChannelNames, Projectors);
     case '.mat'
         NewMat.Projector = Projectors;
+        NewMat.RowNames = ChannelNames;
         bst_save(OutputFile, NewMat, 'v7');
     otherwise
         error(['Unknown file extension "' fExt '"']);

--- a/toolbox/io/import_ssp.m
+++ b/toolbox/io/import_ssp.m
@@ -121,7 +121,13 @@ if isempty(Projector)
             switch (FileFormat)
                 case 'BST'
                     % Load file
-                    ProjMat = in_bst_channel(SspFiles{iFile}, 'Projector');
+                    ProjMat = in_bst_channel(SspFiles{iFile}, 'Projector', 'RowNames');
+                    if ~isempty(ChannelMat) && ~isempty(ProjMat.Projector) && ~isempty(ProjMat.RowNames) % && isfield(ProjMat, 'RowNames'), always because we ask for it explicitly
+                        [ProjMat, errMsg] = VerifyProjectorChannels(ChannelMat, ProjMat);
+                        if ~isempty(errMsg)
+                            return;
+                        end
+                    end
                     % Get projectors
                     newProj = ProjMat.Projector;
                 case 'ASCII'
@@ -247,6 +253,37 @@ if ~isProgress
     bst_progress('stop');
 end
 
+end
 
+function [ProjMat, errMsg] = VerifyProjectorChannels(ChannelMat, ProjMat)
+    errMsg = [];
+    % Check consistency
+    if numel(ProjMat.RowNames) ~= size(ProjMat.Projector(1).Components, 1)
+        errMsg = 'Inconsistent number of projector channel names.';
+        ProjMat = [];
+        return;
+    end
+    % Find channels involved. If any are missing in ChannelMat, the
+    % projector is not valid.
+    iProjNeeded = find(any(ProjMat.Projector(1).Components ~= 0, 2));
+    [isChanInProj, iProjPresent] = ismember({ChannelMat.Channel.Name}, ProjMat.RowNames);
+    % Remove zeros for those not found.
+    iProjPresent(iProjPresent == 0) = [];
+    Missing = ~ismember(iProjNeeded, iProjPresent);
+    if any(Missing)
+        Example = ProjMat.RowNames{iProjNeeded(find(Missing, 1))};
+        errMsg = sprintf('Projector contains channels not present in channel file (e.g. %s).', Example);
+        ProjMat = [];
+        return;
+    end
+    if numel(ChannelMat.Channel) > size(ProjMat.Projector(1).Components, 1)
+        for p = 1:numel(ProjMat.Projector)
+            % Add rows or zeros for additional channels.
+            tempProj = zeros(numel(ChannelMat.Channel), size(ProjMat.Projector(p).Components, 2));
+            tempProj(isChanInProj, :) = ProjMat.Projector(p).Components(iProjPresent, :);
+            ProjMat.Projector(p).Components = tempProj;
+        end
+    end
+end
 
 


### PR DESCRIPTION
The main goal is to be able to compute projectors on empty room recordings and apply these to data that may have additional channels not involved in the projector (e.g. triggers, ECG, ADC).