### PR TITLE
print Modified Apr 2019 version

### DIFF
--- a/toolbox/inverse/bst_inverse_linear_2018.m
+++ b/toolbox/inverse/bst_inverse_linear_2018.m
@@ -163,7 +163,7 @@ if (nargin == 0)
     return
 end
 
-fprintf('\nBST_INVERSE (2016) > Modified Apr 2019\n\n');
+fprintf('\nBST_INVERSE (2018) > Modified Apr 2019\n\n');
 
 % How many head models have been passed, if greater than 1, then we are
 % doing a "DBA" or "Deep Brain Analysis"

--- a/toolbox/inverse/bst_inverse_linear_2018.m
+++ b/toolbox/inverse/bst_inverse_linear_2018.m
@@ -163,7 +163,7 @@ if (nargin == 0)
     return
 end
 
-fprintf('\nBST_INVERSE (2016) > Modified Feb 2018\n\n');
+fprintf('\nBST_INVERSE (2016) > Modified Apr 2019\n\n');
 
 % How many head models have been passed, if greater than 1, then we are
 % doing a "DBA" or "Deep Brain Analysis"


### PR DESCRIPTION
A user had (reasonable) doubts on which version he was running. 
Changed a fprintf to specify Apr 2019 version.

See: https://neuroimage.usc.edu/forums/t/sloreta-with-deep-brain-atlas-dba-error/7922?u=juangpc