### PR TITLE
delete folder prealocated for protocol unzipping

### DIFF
--- a/toolbox/inverse/bst_inverse_linear_2018.m
+++ b/toolbox/inverse/bst_inverse_linear_2018.m
@@ -827,21 +827,25 @@ fprintf('BST_INVERSE > Assumed SNR is %.1f (%.1f dB)\n',SNR,10*log10(SNR));
 switch lower(OPTIONS.InverseMethod) % {minnorm, lcmv, gls}
     case 'minnorm'
         
-        % We set a single lambda to achieve desired source variance. In min
-        % norm, all dipoles have the same lambda. We already added an
-        % optional amplifier weighting into the covariance prior above.
-        
-        % So the data covariance model in the MNE is now
-        % Cd = Lambda * L * L' + I
-        % = Lambda *UL * SL * UL' + I = UL * (LAMBDA*SL + I) * UL'
-        % so invert Cd and use for kernel
-        % xhat = Lambda * L' * inv(Cd)
-        % we reapply all of the covariances to put data back in original
-        % space in the last step.
-        
-        % as distinct from GLS, all dipoles have a common data covariance,
-        % but each has a unique noise covariance.
-        
+      % We set a single lambda to achieve desired source variance. In min
+      % norm, all dipoles have the same lambda. We already added an
+      % optional amplifier weighting into the covariance prior above.
+
+      % So the data covariance model in the MNE is now
+      % Cd = Lambda * L * L' + I
+      % = Lambda *UL * SL * UL' + I = UL * (LAMBDA*SL + I) * UL'
+      % so invert Cd and use for kernel
+      % xhat = Lambda * L' * inv(Cd)
+      % we reapply all of the covariances to put data back in original
+      % space in the last step.
+
+      % as distinct from GLS, all dipoles have a common data covariance,
+      % but each has a unique noise covariance.
+
+      % ==== April 2019 ==== Comment by JCM & JGP
+      % Next line's 'Kernel' is equal to T of eq.(11) in (PM, 2002).
+      % Reference: (PM, 2002) - Standardized low resolution brain electromagnetic
+      %             tomography (sLORETA): technical details, Pasqual-Marqui, 2002.
         Kernel = Lambda * L' * (UL * diag(1./(Lambda * SL2 + 1)) * UL');
 
         switch OPTIONS.InverseMeasure % {'amplitude',  'dspm2018', 'sloreta'}
@@ -923,17 +927,28 @@ switch lower(OPTIONS.InverseMethod) % {minnorm, lcmv, gls}
                     Ndx = StartNdx:EndNdx;
                     
                     if (NumDipoleComponents(kk) == 1)
+                        % 'sloretadiag' is the 'Resolution Kernel' for the
+                        % scalar case of eq.(17) of the sLORETA paper (PM, 2002)
                         sloretadiag = sqrt(sum(Kernel(Ndx,:) .* L(:,Ndx)', 2));
+                      
+                        % This results in the modified pseudo-statistic of
+                        % eq.(25) of (PM, 2002).
                         Kernel = bst_bsxfun(@rdivide, Kernel(Ndx,:), sloretadiag);
                     elseif (NumDipoleComponents(kk)==3 || NumDipoleComponents(kk)==2)
                         for spoint = StartNdx:NumDipoleComponents(kk):EndNdx
+                            % For each dipole location 'R' is the matrix
+                            % resolution kernel, following eq.(17) in (PM, 2002).
                             R = Kernel(spoint:spoint+NumDipoleComponents(kk)-1,:) * L(:,spoint:spoint+NumDipoleComponents(kk)-1);
                             % SIR = sqrtm(pinv(R)); % Aug 2016 can lead to errors if
                             % singular Use this more explicit form instead
                             [Ur,Sr,Vr] = svd(R); Sr = diag(Sr);
                             RNK = sum(Sr > (length(Sr) * eps(single(Sr(1))))); % single precision Rank
+                            % SIR is the square root matrix operator of 
+                            % eq.(25) in (PM, 2002).
                             SIR = Vr(:,1:RNK) * diag(1./sqrt(Sr(1:RNK))) * Ur(:,1:RNK)'; % square root of inverse
                             
+                            % Kernel is the matrix modified
+                            % pseudo-statistic of eq.(25) in (PM,2002).
                             Kernel(spoint:spoint+NumDipoleComponents(kk)-1,:) = SIR * Kernel(spoint:spoint+NumDipoleComponents(kk)-1,:);
                         end
                     end
@@ -941,7 +956,8 @@ switch lower(OPTIONS.InverseMethod) % {minnorm, lcmv, gls}
                     StartNdx = EndNdx; % next loop
 
                 end
-                
+                %We here add the overall whitener so Kernel can be applied
+                %to RAW data.
                 Kernel = Kernel * iW_noise; % overall whitener
                 
             otherwise

--- a/toolbox/inverse/bst_inverse_linear_2018.m
+++ b/toolbox/inverse/bst_inverse_linear_2018.m
@@ -933,7 +933,7 @@ switch lower(OPTIONS.InverseMethod) % {minnorm, lcmv, gls}
                       
                         % This results in the modified pseudo-statistic of
                         % eq.(25) of (PM, 2002).
-                        Kernel = bst_bsxfun(@rdivide, Kernel(Ndx,:), sloretadiag);
+                        Kernel(Ndx,:) = bst_bsxfun(@rdivide, Kernel(Ndx,:), sloretadiag);
                     elseif (NumDipoleComponents(kk)==3 || NumDipoleComponents(kk)==2)
                         for spoint = StartNdx:NumDipoleComponents(kk):EndNdx
                             % For each dipole location 'R' is the matrix

--- a/toolbox/io/import_protocol.m
+++ b/toolbox/io/import_protocol.m
@@ -75,6 +75,7 @@ end
 isOk = org.brainstorm.file.Unpack.unzip(ZipFile, ProtocolDir);
 if ~isOk
     bst_error('Could not unzip file.', 'Load protocol', 0);
+    rmdir(ProtocolDir,'s');
     return
 end
 

--- a/toolbox/io/import_protocol.m
+++ b/toolbox/io/import_protocol.m
@@ -88,7 +88,7 @@ if ~isOk
     file_delete(tmpProtocolDir, 1, 3); %in case of error during unzip.. rollback
     return
 end
-
+% Unzip went well. Go ahead and copy to db
 file_copy(tmpProtocolDir,ProtocolDir);
 file_delete(tmpProtocolDir,1,3); %clean up
 

--- a/toolbox/io/import_protocol.m
+++ b/toolbox/io/import_protocol.m
@@ -88,11 +88,16 @@ if ~isOk
     file_delete(tmpProtocolDir, 1, 3); %in case of error during unzip.. rollback
     return
 end
+bst_progress('stop');
+
 % Unzip went well. Go ahead and copy to db
+bst_progress('start', 'Load protocol', 'Copying files to database...');
 file_copy(tmpProtocolDir,ProtocolDir);
 file_delete(tmpProtocolDir,1,3); %clean up
+bst_progress('stop');
 
 %% ===== DETECT FOLDERS =====
+bst_progress('start','Load protocol','Parsing protocol info...');
 % Detect anatomy and datasets folders
 subjectFile = file_find(ProtocolDir, 'brainstormsubject*.mat', 3);
 studyFile   = file_find(ProtocolDir, 'brainstormstudy*.mat',   4);

--- a/toolbox/io/import_protocol.m
+++ b/toolbox/io/import_protocol.m
@@ -88,16 +88,14 @@ if ~isOk
     file_delete(tmpProtocolDir, 1, 3); %in case of error during unzip.. rollback
     return
 end
-bst_progress('stop');
 
 % Unzip went well. Go ahead and copy to db
-bst_progress('start', 'Load protocol', 'Copying files to database...');
+bst_progress('text', 'Copying files to database...');
 file_copy(tmpProtocolDir,ProtocolDir);
 file_delete(tmpProtocolDir,1,3); %clean up
-bst_progress('stop');
 
 %% ===== DETECT FOLDERS =====
-bst_progress('start','Load protocol','Parsing protocol info...');
+bst_progress('text', 'Parsing protocol info...');
 % Detect anatomy and datasets folders
 subjectFile = file_find(ProtocolDir, 'brainstormsubject*.mat', 3);
 studyFile   = file_find(ProtocolDir, 'brainstormstudy*.mat',   4);

--- a/toolbox/io/import_protocol.m
+++ b/toolbox/io/import_protocol.m
@@ -76,7 +76,6 @@ end
 % Progress bar
 bst_progress('start', 'Load protocol', 'Unzipping file...');
 % Create output folder
-
 if ~mkdir(tmpProtocolDir)
     bst_error(['Could not create folder: ' tmpProtocolDir], 'Load protocol', 0);
     return


### PR DESCRIPTION
Hi, 

Context: when loading a protocol from a zip file, the code creates a folder, starts unzipping, but if there is a problem the created folder (and crappy files in it) are left there. 
Patch: if there is aproblem delete the created folder.

Code follows this scheme:
1. Create folder for the protocol. toolbox/io/import_protocol.m [line:69].
2. Call Unpack class (java/brainstorm.jar/org/brainstorm/file/Unpack.java). Which starts unzipping, creating all necessary files, etc... on the fly.
   2a. if there is no problem while unzipping, folders are detected and finally, the protocol is then loaded.
   2b. If there is a problem while unzipping, the FileOutputStream (Unpack class line 70). The exception is caught, the process is interrupted and a false status flag is set (Unpack class line83).

![image](https://user-images.githubusercontent.com/8955424/56823710-3b02fa00-681a-11e9-8843-bb11237bcc1e.png)

Then Matlab checks the error (toolbox/io/import_protocol.m [line 76]). The message is processed and a return is reached.

Commit adds a 'delete folder' just before the return is reached.

A more "elegant' solution would be to unzip into a temp directory and only if there was no problem, create the folder in the db folder. But this also works.
 
