### PR TITLE
Add documentation to specify event fields.

### DIFF
--- a/toolbox/db/db_template.m
+++ b/toolbox/db/db_template.m
@@ -437,17 +437,18 @@ switch lower(structureName)
         
     % ==== EVENT ====
     case 'event'
+        % See: https://neuroimage.usc.edu/brainstorm/Tutorials/EventMarkers#On_the_hard_drive
         template = struct(...
-            'label',      '', ...
-            'color',      [], ...
-            'epochs',     [], ...      % [list of epochs indices]
-            'times',      [], ...      % [list of time values]
-            'reactTimes', [], ...      % [list of reaction times, when applicable]
-            'select',     1, ...
-            'channels',   [], ...
-            'notes',      []);
-        template.channels = {};
-        template.notes = {};
+            'label',      '', ...      % str, label of the event group. Can be empty.
+            'color',      [], ...      % array of double (R,G,B): color triplet, size: (1, 3). Values btwn 0 and 1. Cannot be empty.
+            'epochs',     [], ...      % array of int (epochs indices), size: (1, nb of event items). Cannot be empty.
+            'times',      [], ...      % array of double (time values), size: (1 or 2, nb of event items). Cannot be empty.
+            'reactTimes', [], ...      % array of double (reaction times), size: (1, nb of event items). Can be empty.
+            'select',     1, ...       % int: display flag (0 or 1).
+            'channels',   [], ...      % see below
+            'notes',      []);         % see below
+        template.channels = {};        % cell array of cell arrays of str, size: (1, nb of event items:(1, nb of associated channels)). Cannot be empty.
+        template.notes = {};           % cell array of str, size: (1, nb of event items). Cannot be empty.
         
     % ==== EPOCH ====
     case 'epoch'

--- a/toolbox/db/db_template.m
+++ b/toolbox/db/db_template.m
@@ -439,7 +439,7 @@ switch lower(structureName)
     case 'event'
         % See: https://neuroimage.usc.edu/brainstorm/Tutorials/EventMarkers#On_the_hard_drive
         template = struct(...
-            'label',      '', ...      % str, label of the event group.
+            'label',      '', ...      % str, label of the event group. Should not be empty.
             'color',      [], ...      % array of double (R,G,B): color triplet, size: (1, 3). Values btwn 0 and 1. Cannot be empty.
             'epochs',     [], ...      % array of int (epochs indices), size: (1, nb of event items). Cannot be empty.
             'times',      [], ...      % array of double (time values), size: (1 or 2, nb of event items). Cannot be empty.

--- a/toolbox/db/db_template.m
+++ b/toolbox/db/db_template.m
@@ -439,7 +439,7 @@ switch lower(structureName)
     case 'event'
         % See: https://neuroimage.usc.edu/brainstorm/Tutorials/EventMarkers#On_the_hard_drive
         template = struct(...
-            'label',      '', ...      % str, label of the event group. Can be empty.
+            'label',      '', ...      % str, label of the event group.
             'color',      [], ...      % array of double (R,G,B): color triplet, size: (1, 3). Values btwn 0 and 1. Cannot be empty.
             'epochs',     [], ...      % array of int (epochs indices), size: (1, nb of event items). Cannot be empty.
             'times',      [], ...      % array of double (time values), size: (1 or 2, nb of event items). Cannot be empty.


### PR DESCRIPTION
Picking up on #199, here are some additional comments to try and clarify the fields of the event structure.

Especially, whether lists can be empty or not. I found that all lists should never be empty except `reactTimes`. Right?

I would be happy to have you confirmation on these.