### PR TITLE
Openmeeg memory estimate fix for surface source models

### DIFF
--- a/toolbox/forward/panel_openmeeg.m
+++ b/toolbox/forward/panel_openmeeg.m
@@ -179,7 +179,16 @@ function [bstPanelNew, panelName] = CreatePanel(sProcess, sFiles)  %#ok<DEFNU>
         end
 
         % === COUNT MEMORY NEEDED ===
-        P = length(OPTIONS.GridLoc);
+        switch OPTIONS.HeadModelType
+            case 'volume'
+                P = length(OPTIONS.GridLoc);
+            case 'surface'
+                sTess = in_tess_bst(OPTIONS.CortexFile);
+                P = size(sTess.Vertices, 1);
+            case 'mixed'
+                sTess = in_tess_bst(OPTIONS.CortexFile);
+                P = length(OPTIONS.GridLoc) + size(sTess.Vertices, 1);
+        end
         estRam = 0;
         estHd = 0;
         % Number of dipoles * orientations

--- a/toolbox/gui/view_topography.m
+++ b/toolbox/gui/view_topography.m
@@ -238,7 +238,7 @@ switch(fileType)
         UseSmoothing = 0;
         UseMontage = 0;
     otherwise
-        error(['This files contains information about cortical sources or regions of interest.' 10 ...
+        error(['This file contains information about cortical sources or regions of interest.' 10 ...
                'Cannot display it as a sensor topography.']);
 end
 if isempty(iDS)


### PR DESCRIPTION
Fixes openmeeg memory estimate for surface source models.  
I wasn't sure how mixed models work, have a look if this makes sense please.

Note that this still doesn't match what openmeeg uses as per this issue: https://github.com/openmeeg/openmeeg/issues/364