### PR TITLE
Added permutation test for 95% confidence intervals on Tuning Curves and Spike Triggered Average

### DIFF
--- a/toolbox/process/functions/process_tuning_curves.m
+++ b/toolbox/process/functions/process_tuning_curves.m
@@ -146,12 +146,23 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             %%%%%%%%%%%%%%%%%% 1. meanData (that will be the center vector)
             %%%%%%%%%%%%%%%%%% 2. CI(1,:) (Bottom confidence interval)
             %%%%%%%%%%%%%%%%%% 3. CI(2,:) (Top confidence interval)
-            plot_ci(x,[meanData; CI(1,:); CI(2,:)], 'PatchColor', 'r', 'PatchAlpha', 0.2, ...
-                      'MainLineWidth', 2, 'MainLineStyle', '-', 'MainLineColor', 'y', ...
-                      'LineWidth', 1.5, 'LineStyle','--', 'LineColor', 'k');
+%             plot_ci(x,[meanData; CI(1,:); CI(2,:)], 'PatchColor', 'r', 'PatchAlpha', 0.2, ...
+%                       'MainLineWidth', 2, 'MainLineStyle', '-', 'MainLineColor', 'y', ...
+%                       'LineWidth', 1.5, 'LineStyle','--', 'LineColor', 'k');
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-                  
-                  
+        
+            
+            % Create the plot with the confidence intervals
+            plot(x, CI(1,:), 'k--', 'LineWidth', 1.5);
+            hold on;
+            plot(x, CI(2,:), 'k--', 'LineWidth', 1.5);
+            
+            x2 = [x, fliplr(x)];
+            inBetween = [CI(1,:), fliplr(CI(2,:))];
+            fill(x2, inBetween, 'g','FaceAlpha',.4);
+            plot(x, meanData,'LineWidth', 2)
+
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
                   
             set(gca, 'Xtick', 1:length(sProcess.options.eventsel.Value), 'Xticklabel', sProcess.options.eventsel.Value);
             xlabel('Condition');

--- a/toolbox/process/functions/process_tuning_curves.m
+++ b/toolbox/process/functions/process_tuning_curves.m
@@ -57,10 +57,6 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.timewindow.Comment    = 'Time window:';
     sProcess.options.timewindow.Type       = 'range';
     sProcess.options.timewindow.Value      = {[0, 0.150],'ms',[]};
-    % === NORMALIZE OUTPUT ===
-    sProcess.options.normalize.Comment = 'Normalize Tuning Curve';
-    sProcess.options.normalize.Type    = 'checkbox';
-    sProcess.options.normalize.Value   = 0;
 end
 
 
@@ -98,10 +94,8 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         allEventLabels = {events.label}';
 
         % Initialize the output file. Its size will be nNeurons x nEvents selected
-        final_matrix = zeros(length(sProcess.options.spikesel.Value),length(sProcess.options.eventsel.Value));
-        
-        nStimulusEventsOccurences = zeros(length(sProcess.options.spikesel.Value),1); % This will be used for normalizing the tuning curves - if selected
-        
+        final_matrix = cell(length(sProcess.options.spikesel.Value),length(sProcess.options.eventsel.Value));
+                
         % Compute the spikes in the bin around the Events selected
         for iNeuron = 1:length(sProcess.options.spikesel.Value)
             index_NeuronEvents = find(ismember(allEventLabels, sProcess.options.spikesel.Value{iNeuron})); % Find the index of the spike-events that correspond to that electrode (Exact string match)
@@ -110,50 +104,64 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             for iEvent = 1:length(sProcess.options.eventsel.Value)
                 index_StimulusEvents = find(ismember(allEventLabels, sProcess.options.eventsel.Value{iEvent})); % Find the index of the spike-events that correspond to that electrode (Exact string match)
                 times_StimulusEvents = events(index_StimulusEvents).times;
-                
-                nStimulusEventsOccurences(iNeuron) = length(times_StimulusEvents);
-                
+                                
                 for iSampleEvent = 1:length(times_StimulusEvents)
                     condition_success = sum((times_NeuronEvents>times_StimulusEvents(iSampleEvent) - sProcess.options.timewindow.Value{1}(1)) & (times_NeuronEvents < times_StimulusEvents(iSampleEvent) + sProcess.options.timewindow.Value{1}(2)));
                     if condition_success
-                        final_matrix(iNeuron, iEvent) = condition_success;
+                        final_matrix{iNeuron, iEvent} = [final_matrix{iNeuron, iEvent} condition_success];
                     end
                 end
             end
             
-            % Create the plot, and overlap a Shape-Preserving Interpolant fit on it
+           
+            % Initialize the 3 vectors that will be plotted (mean, and 95% confidence intervals)   
+            meanData = zeros(1,length(sProcess.options.eventsel.Value));
+            CI = zeros(2,length(sProcess.options.eventsel.Value));
+            
+            
+            % Assign the confidence intervals values
+            for iCondition = 1:length(sProcess.options.eventsel.Value)
+                y = final_matrix{iNeuron,iCondition}./(sProcess.options.timewindow.Value{1}(2) - sProcess.options.timewindow.Value{1}(1)); % Convert to firing rate
+                meanData(iCondition) = mean(y);
+                
+                % Compute the 95% confidence intervals
+                RESAMPLING = 1000; % Number of permutations
+                CI(:,iCondition) = bootci(RESAMPLING, {@mean, y}, 'type','cper','alpha',0.05);
+            end
+
+            
+                
+            %% Create the plot
             %TODO: brainstorm figure?
             figure((iFile-1)*100 + iNeuron); % Each Link to Raw file figure set will be separated by an index of 100.
-
-            x = 1:length(sProcess.options.eventsel.Value);
-            % Y will be the y points that will be plotted
-            if sProcess.options.normalize.Value
-                y = final_matrix(iNeuron,:)./nStimulusEventsOccurences(iNeuron,:);
-                set(gcf, 'Name', ['Normalized : ' sProcess.options.spikesel.Value{iNeuron}]);
-            else
-                y = final_matrix(iNeuron,:);
-                set(gcf, 'Name', sProcess.options.spikesel.Value{iNeuron});
-            end
-
-            % Plot a fit on the tuning curves if fitting toolbox is present
-            try
-                % Fit the Shape-Preserving Interpolant
-                f = fit(x.',y.','pchip');
-                plot(f,x,y);
-                legend('Spikes', 'Fitted Curve');
-            catch
-                % If no fitting toolbox is present, just connect the points
-                plot(x,y);
-            end
+            set(gcf, 'Name', sProcess.options.spikesel.Value{iNeuron});
             
+            x = 1:length(sProcess.options.eventsel.Value);
+            
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+            %%%%%%%%%%%%%%%%%% MARTIN - THIS NEEDS TO BE SUBSTITUTED WITH
+            %%%%%%%%%%%%%%%%%% THE BRAINSTORM FUNCTIONS THAT DISPLAY THE
+            %%%%%%%%%%%%%%%%%% HALO.
+            %%%%%%%%%%%%%%%%%% Vectors to be plotted:
+            %%%%%%%%%%%%%%%%%% 1. meanData (that will be the center vector)
+            %%%%%%%%%%%%%%%%%% 2. CI(1,:) (Bottom confidence interval)
+            %%%%%%%%%%%%%%%%%% 3. CI(2,:) (Top confidence interval)
+            plot_ci(x,[meanData; CI(1,:); CI(2,:)], 'PatchColor', 'r', 'PatchAlpha', 0.2, ...
+                      'MainLineWidth', 2, 'MainLineStyle', '-', 'MainLineColor', 'y', ...
+                      'LineWidth', 1.5, 'LineStyle','--', 'LineColor', 'k');
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                  
+                  
+                  
             set(gca, 'Xtick', 1:length(sProcess.options.eventsel.Value), 'Xticklabel', sProcess.options.eventsel.Value);
             xlabel('Condition');
-            ylabel('Number of Spikes');
+            ylabel('Firing Rate (Spikes/second)');
+            grid on
                 
-            if max(y) == 0
+            if max(CI(2,:)) == 0
                 axis([0 length(sProcess.options.eventsel.Value)+1 0 Inf]);
             else
-                axis([0 length(sProcess.options.eventsel.Value)+1 0 max(y) + std(y)]);
+                axis([0 length(sProcess.options.eventsel.Value)+1 0 max(CI(2,:)) + std(CI(2,:))]);
             end
         end
         


### PR DESCRIPTION
Removed normalization parameter (maybe add it again)
Added 1000 permutations by default

![image](https://user-images.githubusercontent.com/23224563/59136808-d1b2f280-8952-11e9-86b5-3feca7ee64d4.png)



This functions uses personal code for the visualization of the halo.
The halo creation should be modified once Martin finalizes the STD intervals changes, and ultimately get integrated with the Brainstorm window configuration (right now it just creates a new Matlab window for plotting).