### PR TITLE
ignore empty line in coords file

### DIFF
--- a/toolbox/io/in_fopen_nirs_brs.m
+++ b/toolbox/io/in_fopen_nirs_brs.m
@@ -248,7 +248,7 @@ function [coords] = load_brainsight_coords(coords_file)
     ic = 1; % counter of entries
     while(~feof(fid))
        line = textscan(fid, '%s', 1, 'delimiter', '\n');
-       if ~strcmp(line{1}{1}(1), '#') % ignore comments
+       if ~isempty(line{1}{1}) && ~strcmp(line{1}{1}(1), '#') % ignore empty lines and comments
            toks = textscan(line{1}{1}, '%s\t%s\t%d\t%f\t%f\t%f%f', ...
                            'WhiteSpace', '\b\t');
            coords(ic).name = toks{1}{1};


### PR DESCRIPTION
Just a small fix to avoid error when there is an empty line at the end of the fiducial/optode file.