### PR TITLE
Convert event type (single vs extended) when merging events

### DIFF
--- a/toolbox/io/import_events.m
+++ b/toolbox/io/import_events.m
@@ -183,6 +183,24 @@ for iNew = 1:length(newEvents)
         end
     % Event exists: merge occurrences
     else
+        % Convert new event type if required
+        sizeTimeWindow = size(sFile.events(iEvt).times, 1);
+        sizeNewTimeWindow = size(newEvents(iNew).times, 1);
+        if sizeTimeWindow ~= sizeNewTimeWindow
+            if sizeTimeWindow == 1
+                % Convert to single event
+                disp(['BST> Warning: Event type of "', ...
+                     sFile.events(iEvt).label, ...
+                     '" inconsistent, converting to single event using start time.']);
+                newEvents(iNew).times = newEvents(iNew).times(1,:);
+            else
+                % Convert to extended event
+                disp(['BST> Warning: Event type of "', ...
+                     sFile.events(iEvt).label, ...
+                     '" inconsistent, converting to extended event.']);
+                newEvents(iNew).times = [newEvents(iNew).times; newEvents(iNew).times + 0.001];
+            end
+        end
         % Merge events occurrences
         sFile.events(iEvt).times      = [sFile.events(iEvt).times, newEvents(iNew).times];
         sFile.events(iEvt).epochs     = [sFile.events(iEvt).epochs, newEvents(iNew).epochs];


### PR DESCRIPTION
This is an issue when you're averaging trials together that have an event of the same name but different type (single vs extended). Brainstorm would crash when trying to merge the events. My solution is to consider the first occurence of the event as the "correct" type, and convert others to this type using the following approach:
 - Single to extended: Event time = [singleTime, singleTime + 0.001s]
 - Extended to single: Event time = start of time window

The user is warned that this conversion happened. I don't have a strong opinion on the chosen approach, so long as we automatically convert the events so that Brainstorm doesn't crash.