### PR TITLE
Add keyboard shortcut to toggle crosshair visibility in mri viewer

### DIFF
--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -673,11 +673,6 @@ function checkCrosshair_Callback(hFig, varargin)
                    Handles.crosshairSagittalH, Handles.crosshairSagittalV, ...
                    Handles.crosshairAxialH, Handles.crosshairAxialV];
     % Update crosshairs visibility
-%     if Handles.jCheckViewCrosshair.isSelected()
-%         set(hCrosshairs, 'Visible', 'on');
-%     else
-%         set(hCrosshairs, 'Visible', 'off');
-%     end
     if all(arrayfun(@(c) strcmp(c,'off'),get(hCrosshairs,'Visible')))
         set(hCrosshairs, 'Visible', 'on');
     else

--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -604,7 +604,7 @@ function FigureKeyPress_Callback(hFig, keyEvent)
                 case 'm'
                     JumpMaximum(hFig);
                 
-                % C : Toggle crosshair visibility 
+                % C : Toggle crosshairs visibility 
                 case 'c'
                    checkCrosshair_Callback(hFig);
                     
@@ -675,8 +675,10 @@ function checkCrosshair_Callback(hFig, varargin)
     % Update crosshairs visibility
     if all(arrayfun(@(c) strcmp(c,'off'),get(hCrosshairs,'Visible')))
         set(hCrosshairs, 'Visible', 'on');
+        Handles.jCheckViewCrosshair.setSelected(1);
     else
         set(hCrosshairs, 'Visible', 'off');
+        Handles.jCheckViewCrosshair.setSelected(0);
     end
 end
 

--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -604,7 +604,7 @@ function FigureKeyPress_Callback(hFig, keyEvent)
                 case 'm'
                     JumpMaximum(hFig);
                 
-                % C : Toggle crosshairs visibility 
+                % C : Toggle crosshair visibility 
                 case 'c'
                    checkCrosshair_Callback(hFig);
                     

--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -603,6 +603,10 @@ function FigureKeyPress_Callback(hFig, keyEvent)
                 % M : Jump to maximum
                 case 'm'
                     JumpMaximum(hFig);
+                
+                % C : Toggle crosshairs visibility 
+                case 'c'
+                   checkCrosshair_Callback(hFig);
                     
                 % === SCROLL MRI CUTS ===
                 case {'x','y','z','1','2','3','4','5','6'}
@@ -665,9 +669,16 @@ function checkCrosshair_Callback(hFig, varargin)
     % Get figure Handles
     Handles = bst_figures('GetFigureHandles', hFig);
     % Get all the crosshairs in the figure
-    hCrosshairs = [Handles.crosshairCoronalH, Handles.crosshairCoronalV, Handles.crosshairSagittalH, Handles.crosshairSagittalV, Handles.crosshairAxialH, Handles.crosshairAxialV];
+    hCrosshairs = [Handles.crosshairCoronalH, Handles.crosshairCoronalV, ...
+                   Handles.crosshairSagittalH, Handles.crosshairSagittalV, ...
+                   Handles.crosshairAxialH, Handles.crosshairAxialV];
     % Update crosshairs visibility
-    if Handles.jCheckViewCrosshair.isSelected()
+%     if Handles.jCheckViewCrosshair.isSelected()
+%         set(hCrosshairs, 'Visible', 'on');
+%     else
+%         set(hCrosshairs, 'Visible', 'off');
+%     end
+    if all(arrayfun(@(c) strcmp(c,'off'),get(hCrosshairs,'Visible')))
         set(hCrosshairs, 'Visible', 'on');
     else
         set(hCrosshairs, 'Visible', 'off');


### PR DESCRIPTION
Hi all,
I know everyone is busy with other stuff. This is zero urgent.
Please, @ftadel don't kill me. :sweat_smile:

As a frequent user of MRI importer, viewer, I find myself usually in the situation where, during the location of the anterior/posterior commissures, the crosshair is on the way. I find this shortcut quite useful.
I've added the same shortcut key, 'c', [used in Fieldtrip](https://github.com/fieldtrip/fieldtrip/blob/9fe225d58b9460a4e1d23d554da7ddaf4cb9d62e/ft_volumerealign.m#L495), which also has this shortcut implemented.

In the crosshair checkbox callback, the condition was changed because in order for the shortcut to work it is the actual state what needs to be checked, not if the checkbox was selected. Otherwise, another callback would need to be added (I think).

This function returns true if all crosshairs are not visible.

```
all(arrayfun(@(c) strcmp(c,'off'),get(hCrosshairs,'Visible')))
```

I've checked and everything seems to work no problem with the added shortcut.

Thanks,