### PR TITLE
BST vs "clear all"

### DIFF
--- a/toolbox/core/bst_exit.m
+++ b/toolbox/core/bst_exit.m
@@ -77,20 +77,25 @@ try
         end
     end
 catch
-  status = 0;
+  status = -1;
   return;
 end
 
 %% ===== CLOSE WINDOW =====
 % Only in the GUI was created
-if (GlobalData.Program.GuiLevel >= 0)
-    % Hide all the registered panels
-    listPanels = GlobalData.Program.GUI.panels;
-    for iPanel = 1:length(listPanels)
-        gui_hide(listPanels(iPanel)); 
-    end
-    % Close Brainstorm main window
-    ctrl.jBstFrame.dispose();
+try
+  if (GlobalData.Program.GuiLevel >= 0)
+      % Hide all the registered panels
+      listPanels = GlobalData.Program.GUI.panels;
+      for iPanel = 1:length(listPanels)
+          gui_hide(listPanels(iPanel)); 
+      end
+      % Close Brainstorm main window
+      ctrl.jBstFrame.dispose();
+  end
+catch
+  status = -1;
+  return;
 end
 % Release Brainstorm global mutex
 bst_mutex('release', 'Brainstorm');

--- a/toolbox/core/bst_exit.m
+++ b/toolbox/core/bst_exit.m
@@ -50,32 +50,36 @@ end
 % Stop execution
 rmappdata(0, 'BrainstormRunning');
 % Only in the GUI was created
-if (GlobalData.Program.GuiLevel >= 0)
-    % Protocols list
-    if isfield(ctrl, 'jComboBoxProtocols') && ~isempty(ctrl.jComboBoxProtocols)
-        java_setcb(ctrl.jToolButtonSubject,     'ItemStateChangedCallback', []);
-        java_setcb(ctrl.jToolButtonStudiesSubj, 'ItemStateChangedCallback', []);
-        java_setcb(ctrl.jToolButtonStudiesCond, 'ItemStateChangedCallback', []);
-        comboBoxModel = ctrl.jComboBoxProtocols.getModel();
-        java_setcb(comboBoxModel, 'ContentsChangedCallback', []);
+try
+    if (GlobalData.Program.GuiLevel >= 0)
+        % Protocols list
+        if isfield(ctrl, 'jComboBoxProtocols') && ~isempty(ctrl.jComboBoxProtocols)
+            java_setcb(ctrl.jToolButtonSubject,     'ItemStateChangedCallback', []);
+            java_setcb(ctrl.jToolButtonStudiesSubj, 'ItemStateChangedCallback', []);
+            java_setcb(ctrl.jToolButtonStudiesCond, 'ItemStateChangedCallback', []);
+            comboBoxModel = ctrl.jComboBoxProtocols.getModel();
+            java_setcb(comboBoxModel, 'ContentsChangedCallback', []);
+        end
+        % Panel SCOUTS
+        scoutsManagerControls = bst_get('PanelControls', 'Scout');
+        if ~isempty(scoutsManagerControls)
+            java_setcb(scoutsManagerControls.jListScouts, 'ValueChangedCallback', []);
+        end
+        % Panel CLUSTERS
+        clustersManagerControls = bst_get('PanelControls', 'Cluster');
+        if ~isempty(clustersManagerControls)
+            java_setcb(clustersManagerControls.jListClusters, 'ValueChangedCallback', []);
+        end
+        % PanelContainer TOOLS
+        jTabpaneTools = bst_get('PanelContainer', 'Tools');
+        if ~isempty(jTabpaneTools)
+            java_setcb(jTabpaneTools, 'StateChangedCallback', []);
+        end
     end
-    % Panel SCOUTS
-    scoutsManagerControls = bst_get('PanelControls', 'Scout');
-    if ~isempty(scoutsManagerControls)
-        java_setcb(scoutsManagerControls.jListScouts, 'ValueChangedCallback', []);
-    end
-    % Panel CLUSTERS
-    clustersManagerControls = bst_get('PanelControls', 'Cluster');
-    if ~isempty(clustersManagerControls)
-        java_setcb(clustersManagerControls.jListClusters, 'ValueChangedCallback', []);
-    end
-    % PanelContainer TOOLS
-    jTabpaneTools = bst_get('PanelContainer', 'Tools');
-    if ~isempty(jTabpaneTools)
-        java_setcb(jTabpaneTools, 'StateChangedCallback', []);
-    end
+catch
+  status = 0;
+  return;
 end
-
 
 %% ===== CLOSE WINDOW =====
 % Only in the GUI was created

--- a/toolbox/gui/gui_brainstorm.m
+++ b/toolbox/gui/gui_brainstorm.m
@@ -493,7 +493,7 @@ function GUI = CreateWindow() %#ok<DEFNU>
 %  =================================================================================
 %% ===== CLOSE WINDOW =====
     function closeWindow_Callback(varargin)
-      
+      try
         % If GUI was displayed: save current position
         if (GlobalData.Program.GuiLevel >= 1)
             % Update main window size and position
@@ -505,7 +505,9 @@ function GUI = CreateWindow() %#ok<DEFNU>
             % bst_set('Layout', 'MainWindowPos', MainWindowPos);
             GlobalData.Preferences.Layout.MainWindowPos = MainWindowPos;
         end
-        
+      catch
+        disp('BST> Warning: Unable to save current window position.');
+      end
         
         % Try to exit via bst_exit function
         if (~bst_exit())

--- a/toolbox/gui/gui_brainstorm.m
+++ b/toolbox/gui/gui_brainstorm.m
@@ -509,13 +509,18 @@ function GUI = CreateWindow() %#ok<DEFNU>
         disp('BST> Warning: Unable to save current window position.');
       end
         
-        % Try to exit via bst_exit function
-        exit_status=bst_exit();
-        if (exit_status == -1)
-            % If window is not registered as a current Brainstorm process : just kill it
-            disp('BST> Warning: Force quiting.');
-            jBstFrame.dispose();
-        end
+      % Try to exit via bst_exit function
+      try
+          exit_status=bst_exit();
+          if (exit_status == -1)
+              % If window is not registered as a current Brainstorm process : just kill it
+              disp('BST> Warning: Force quiting.');
+              jBstFrame.dispose();
+          end
+      catch
+          disp('BST> Warning: Force quiting.');
+          jBstFrame.dispose();
+      end
     end
 
 

--- a/toolbox/gui/gui_brainstorm.m
+++ b/toolbox/gui/gui_brainstorm.m
@@ -512,6 +512,7 @@ function GUI = CreateWindow() %#ok<DEFNU>
         % Try to exit via bst_exit function
         if (~bst_exit())
             % If window is not registered as a current Brainstorm process : just kill it
+            disp('BST> Warning: Force quiting.');
             jBstFrame.dispose();
         end
     end

--- a/toolbox/gui/gui_brainstorm.m
+++ b/toolbox/gui/gui_brainstorm.m
@@ -493,6 +493,7 @@ function GUI = CreateWindow() %#ok<DEFNU>
 %  =================================================================================
 %% ===== CLOSE WINDOW =====
     function closeWindow_Callback(varargin)
+      
         % If GUI was displayed: save current position
         if (GlobalData.Program.GuiLevel >= 1)
             % Update main window size and position
@@ -504,6 +505,8 @@ function GUI = CreateWindow() %#ok<DEFNU>
             % bst_set('Layout', 'MainWindowPos', MainWindowPos);
             GlobalData.Preferences.Layout.MainWindowPos = MainWindowPos;
         end
+        
+        
         % Try to exit via bst_exit function
         if (~bst_exit())
             % If window is not registered as a current Brainstorm process : just kill it

--- a/toolbox/gui/gui_brainstorm.m
+++ b/toolbox/gui/gui_brainstorm.m
@@ -510,7 +510,8 @@ function GUI = CreateWindow() %#ok<DEFNU>
       end
         
         % Try to exit via bst_exit function
-        if (~bst_exit())
+        exit_status=bst_exit();
+        if (exit_status == -1)
             % If window is not registered as a current Brainstorm process : just kill it
             disp('BST> Warning: Force quiting.');
             jBstFrame.dispose();


### PR DESCRIPTION
~~ NOT URGENT ~~

Hi all,
I've found a problem which might be of interest to others. The problem is related to the behavior of bst when the GlobalData variable has been deleted. 

Context:
 - Start bst normally. While running bst.
 - execute ```clear all```.
 - try to close bst. 

There is a problem with GlobalData, precisely with the way Matlab treats the dot operator of undeclared variables. My doubts are not precisely focused on the fact that ```clear all``` corrupts brainstorm's instance. My doubts are related to the fact that if a user is not comfortable with bst's underpinnings, he/she might need to restart Matlab altogether, in order to close bst's main window. I think this is undesirable. ```clear all``` is too common in many scripts, in my opinion, to force the user to restart Matlab. The fact that GlobalData is 'hidden' does not help, because the user will not know ```clear all``` is actually erasing anything since the Workspace window will appear empty. But that is my opinion.

One quick fix is to call ``` jBstFrame.dispose(); ``` directly breaking execution inside closeWindow_Callback, but I think a regular user would not know how to do that. 

If other people feel that this is not a problem that needs to be fixed: sorry for the interruption. I'm just trying to help. It would be great if somebody could shed a bit of light on why we should not consider this a problem and/or why is this a preferred behavior for the toolbox. If anybody has a better solution or can find a problem with the code I propose, please let me know.

As in the previous PR, this is not urgent, at all. 

Proposed solutions:
 - One first issue is that the 'X' button callback (aka closeWindow_Callback) tries to save the position of the window for future runs. Which I think is legit but comes costly. A try/catch solves that.
 - Once the previous problem is solved, the final issue is that bst_exit is also interrupted mid-through (due to the same problem with GlobalData and the dot operator). The second time the button is pressed, however, it will exit with a 0 code, and thus ```jBstFrame.dispose();``` will be executed OK. A second try/catch structure in bst_exit function solves the problem.

Thanks all,

