### PR TITLE
remove the isolated surface from mesh

### DIFF
--- a/toolbox/io/import_femlayers.m
+++ b/toolbox/io/import_femlayers.m
@@ -120,7 +120,14 @@ for iFile = 1:length(FemFiles)
         if ~isempty(iRemoveVert)
             [Vertices, Faces] = tess_remove_vert(Vertices, Faces, iRemoveVert);
         end
-
+        
+        % call meshfixe via iso2mesh to remove the inner islandes
+        if exist('iso2meshver', 'file') & isdir(bst_fullfile(bst_fileparts(which('iso2meshver')), 'doc'))
+             [Vertices,Faces] = meshcheckrepair(Vertices, Faces,'meshfix');
+        else
+            warning('iso2mesh is not found in your machine ... the extracted surface may have some isolated faces')
+        end
+        
         % ===== NEW STRUCTURE =====
         NewTess = db_template('surfacemat');
         NewTess.Comment  = FemMat.TissueLabels{iTissue};


### PR DESCRIPTION
This slight modification will remove the isolated surface (https://github.com/brainstorm-tools/brainstorm3/issues/185#issuecomment-577729534)
Adding these lines will fixe the mesh by calling the meshfixe routine (from iso2mesh toolbox)

![image](https://user-images.githubusercontent.com/37831900/73120767-ee725980-3f26-11ea-89bd-57f0ce02149f.png)
(right figure, before the meshfixe, left figure after the correction)