### PR TITLE
Update process_generate_fem.m

### DIFF
--- a/toolbox/process/functions/process_generate_fem.m
+++ b/toolbox/process/functions/process_generate_fem.m
@@ -252,7 +252,7 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
                 bemMerge = cat(2, bemMerge, BemMat.Vertices, BemMat.Faces);
             end
             % Merge all the surfaces
-            [newnode, newelem] = mergemesh(bemMerge{:});
+            [newnode, newelem] = mergesurf(bemMerge{:});
             
             % Find the seed point for each region
             center_inner = mean(bemMerge{end-1});


### PR DESCRIPTION
Use the function "mergesurf" unstead of "mergemesh".
mergemesh merge simply the surfaces and if there are intersection between the surfaces, the volume mesh generation will fail.
mergesurf can handles surface mesh intersection by splitting the intersecting elements and creates new nodes.
with this modification, the volume mesh generation will work.