### PR TITLE
choose between "mergsurf" or "mergemesh"

### DIFF
--- a/toolbox/process/functions/process_generate_fem.m
+++ b/toolbox/process/functions/process_generate_fem.m
@@ -309,8 +309,20 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
                 bemMerge = cat(2, bemMerge, BemMat.Vertices, BemMat.Faces);
             end
             % Merge all the surfaces
-            % [newnode, newelem] = mergesurf(bemMerge{:});
-            [newnode, newelem] = mergemesh(bemMerge{:});
+            % NOTE: mergesurf more robust for intersecting meshes than mergemesh
+            modality = {'Default(faster): Simply concatenates the meshes => "uses mergmesh: assumes that the surfaces are separated"  ',...
+                        'Advanced(longer): Concatenates the meshes and checks for intersections => "uses mergesurf: split intersecting elements"  ' };
+            [res, isCancel] = java_dialog('radio', ...
+                '<HTML><B> Surface Mesh Merging Options <B>', 'Merge Mesh', [], modality,1);
+            if isCancel;                return;            end
+            if res == 1
+                bst_progress('text', 'Merging surfaces (Iso2mesh/mergemesh)...');
+                tic; [newnode, newelem] = mergemesh(bemMerge{:}); tmergemesh = toc;
+            end
+            if res == 2
+                bst_progress('text', 'Merging surfaces (Iso2mesh/mergesurf)...');
+                tic; [newnode, newelem] = mergesurf(bemMerge{:}); tmergesurf = toc;
+            end
             
             % TODO: Replace mergemesh with mergesurf when iso2mesh fixes mwpath with no inputs in a new release.
             % See: https://github.com/fangq/iso2mesh/pull/42

--- a/toolbox/process/functions/process_generate_fem.m
+++ b/toolbox/process/functions/process_generate_fem.m
@@ -283,21 +283,29 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
                 end
             % If surfaces are given: get their labels
             else
+            allIndex = [];
                 for iBem = 1:length(OPTIONS.BemFiles)
                     [sSubject, iSubject, iSurface] = bst_get('SurfaceFile', OPTIONS.BemFiles{iBem});
-                    switch (sSubject.Surface(iSurface).SurfaceType)
-                        case 'Scalp',        TissueLabels{iBem} = 'scalp';
-                        case 'OuterSkull',   TissueLabels{iBem} = 'skull';
-                        case 'InnerSkull',   TissueLabels{iBem} = 'brain';
-                        case 'Cortex',       TissueLabels{iBem} = 'gray';
-                        otherwise,           TissueLabels{iBem} = sSubject.Surface(iSurface).Comment;
-                    end
+                    reference = {'white', 'gray', 'csf','skull','scalp'}; % not always true ...? 
+%                    switch (sSubject.Surface(iSurface).SurfaceType)
+%                        case 'Scalp',        TissueLabels{iBem} = 'scalp';
+%                        case 'OuterSkull',   TissueLabels{iBem} = 'skull';
+%                        case 'InnerSkull',   TissueLabels{iBem} = 'brain';
+%                        case 'Cortex',       TissueLabels{iBem} = 'gray';
+%                        otherwise,           TissueLabels{iBem} = sSubject.Surface(iSurface).Comment;
+%                    end
+                     index = find(contains(reference, sSubject.Surface(iSurface).Comment));
+                     TissueLabels{index} = sSubject.Surface(iSurface).Comment;
+                     allIndex = [allIndex, index];
                 end
+                TissueLabels(~cellfun(@isempty, TissueLabels));
+                [toto, realOrder] = sort(allIndex);              
             end
             % Load surfaces
             bemMerge = {};
             for iBem = 1:length(OPTIONS.BemFiles)
-                BemMat = in_tess_bst(OPTIONS.BemFiles{iBem});
+%                BemMat = in_tess_bst(OPTIONS.BemFiles{iBem});
+                BemMat = in_tess_bst(OPTIONS.BemFiles{realOrder(iBem)});
                 bemMerge = cat(2, bemMerge, BemMat.Vertices, BemMat.Faces);
             end
             % Merge all the surfaces


### PR DESCRIPTION
adding a checkbox option that asks the user if they want to
 call "mergsurf"  or  call "mergemesh"

In most case the mergemesh is sufficient. 
mergesurf takes longer since there is the self-intersection checking.
The execution time between mergsurf and mergemesh:
        tic; [newnode, newelem] = mergesurf(bemMerge{:}); tmergsurf = toc;
        tic; [newnode, newelem] = mergemesh(bemMerge{:}); tmergemesh = toc;
tmergsurf = 30.3988 s (here with three surfaces ... should be longer with more surfaces )
tmergemesh = 0.1330 s
