### PR TITLE
convert mesh on database

### DIFF
--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1176,7 +1176,9 @@ switch (lower(action))
                 gui_component('MenuItem', jPopup, [], 'Display', IconLoader.ICON_DISPLAY, [], @(h,ev)view_surface_fem(filenameRelative, [], [], [], 'NewFigure'));
                 % Extract surfaces
                 gui_component('MenuItem', jPopup, [], 'Extract surfaces', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@import_femlayers, iSubject, filenameFull, 'BSTFEM', 1));
-                
+                % Convert mesh type		
+                gui_component('MenuItem', jPopup, [], 'Convert Tetra2Hexa', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@fem_tetra2hexa, iSubject, filenameFull, 'BSTFEM', 1));
+                gui_component('MenuItem', jPopup, [], 'Convert Hexa2Tetra', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@fem_hexa2tetra, iSubject, filenameFull, 'BSTFEM', 1));
                 
 %% ===== POPUP: NOISECOV =====
             case {'noisecov', 'ndatacov'}


### PR DESCRIPTION
add on the FEM menu the functions that convert the mesh (tetra to hexa / hexa to tetra).
The associated functions "fem_tetra2hexa.m" and "fem_hexa2tetra.m" 
are saved on bst-duneuro/matlab

Thes options are useful for testing and integrating the Hexa mesh (displays and comparisons of the FEM computation (tetra vs Hexa) on the same model).