### PR TITLE
add option to display lead field as rows

### DIFF
--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1226,7 +1226,8 @@ switch (lower(action))
                     % gui_component('MenuItem', jPopup, [], 'Compute sources [2009]', IconLoader.ICON_RESULTS, [], @(h,ev)selectHeadmodelAndComputeSources(bstNodes, '2009'));
                     % gui_component('MenuItem', jPopup, [], 'Compute sources [2016]', IconLoader.ICON_RESULTS, [], @(h,ev)selectHeadmodelAndComputeSources(bstNodes, '2016'));
                     gui_component('MenuItem', jPopup, [], 'Compute sources [2018]', IconLoader.ICON_RESULTS, [], @(h,ev)selectHeadmodelAndComputeSources(bstNodes, '2018'));
-                end
+		    gui_component('MenuItem', jPopup, [], 'Display Lead Field [testing]', IconLoader.ICON_RESULTS, [], @(h,ev)DisplayLeadFIeld(bstNodes));
+		end
                 % === SET AS DEFAULT HEADMODEL ===
                 if ~bst_get('ReadOnly') && (~ismember(iHeadModel, sStudy.iHeadModel) || ~bstNodes(1).isMarked())
                     AddSeparator(jPopup);


### PR DESCRIPTION
Add an option on the right-click menu for the computed head model
that allows the display of the lead field.

The dependant function 'DisplayLeadFIeld.m' is on the bst-duneuro folder (for now).

This option is working for EEG (and probably for sEEG/ECOG)
but needs adaptation & discussion for MEG {@jcmosher}.


![image](https://user-images.githubusercontent.com/37831900/76377521-55e23e00-6308-11ea-9fab-c91e48bb3795.png)

![image](https://user-images.githubusercontent.com/37831900/76377455-2e8b7100-6308-11ea-91bf-ab084c8e9d89.png)


