### PR TITLE
modify default sMri Comment value

### DIFF
--- a/toolbox/io/import_mri.m
+++ b/toolbox/io/import_mri.m
@@ -47,7 +47,7 @@ if (nargin < 5) || isempty(isAutoAdjust)
     isAutoAdjust = 1;
 end
 if (nargin < 5) || isempty(Comment)
-    Comment = 1;
+    Comment = 'MRI';
 end
 % Initialize returned variables
 BstMriFile = [];
@@ -268,29 +268,35 @@ end
 
 %% ===== SAVE MRI IN BRAINSTORM FORMAT =====
 % Add a Comment field in MRI structure, if it does not exist yet
-if ~isempty(Comment)
-    sMri.Comment = Comment;
-    importedBaseName = file_standardize(Comment);
+if ~isfield(sMri,'Comment')
+    if ~isempty(Comment) && isstring(Comment)
+        sMri.Comment = Comment;
+        importedBaseName = file_standardize(Comment);
+    else
+      % Use filename as comment
+      if (iAnatomy > 1) || isInteractive || ~isAutoAdjust
+          [fPath, fBase, fExt] = bst_fileparts(MriFile);
+          fBase = strrep(fBase, '.nii', '');
+          sMri.Comment = file_unique([fBase, fileTag], {sSubject.Anatomy.Comment});
+      end
+      % Add MNI tag
+      if strcmpi(FileFormat, 'ALL-MNI')
+          sMri.Comment = [sMri.Comment ' (MNI)'];
+      end
+      % Get imported base name
+      [tmp__, importedBaseName] = bst_fileparts(MriFile);
+      importedBaseName = strrep(importedBaseName, 'subjectimage_', '');
+      importedBaseName = strrep(importedBaseName, '_subjectimage', '');
+      importedBaseName = strrep(importedBaseName, '.nii', '');
+    end
 else
-    if ~isfield(sMri, 'Comment')
-        sMri.Comment = 'MRI';
-    end
-    % Use filename as comment
-    if (iAnatomy > 1) || isInteractive || ~isAutoAdjust
-        [fPath, fBase, fExt] = bst_fileparts(MriFile);
-        fBase = strrep(fBase, '.nii', '');
-        sMri.Comment = file_unique([fBase, fileTag], {sSubject.Anatomy.Comment});
-    end
-    % Add MNI tag
-    if strcmpi(FileFormat, 'ALL-MNI')
-        sMri.Comment = [sMri.Comment ' (MNI)'];
-    end
-    % Get imported base name
-    [tmp__, importedBaseName] = bst_fileparts(MriFile);
-    importedBaseName = strrep(importedBaseName, 'subjectimage_', '');
-    importedBaseName = strrep(importedBaseName, '_subjectimage', '');
-    importedBaseName = strrep(importedBaseName, '.nii', '');
+  % Check for non valid 
+  if ~isstring(sMri.Comment)
+      sMri.Comment = 'MRI';
+  end
+  importedBaseName = file_standardize(Comment);
 end
+
 % Get subject subdirectory
 subjectSubDir = bst_fileparts(sSubject.FileName);
 % Produce a default anatomy filename


### PR DESCRIPTION
Hi, 
I've come across this little bug while importing a freesurfer folder. The mri importer was unable to set the name of the mri properly and thus, the sMri.Comment field remained with the default value at the beginning of import_mri.m.

The effect of keeping the default value in Comment is that when setting up the gui, this sMri.Comment field will be used to set the name of the MRI in the tree and the java method setText will not accept the default value of (double)1 (actually it accepts it, but since 1 is non-printable... it prints a square!). 
A more important problem rises when you try to righ-click on the scalp node. It crashes.

**Context:** If you want to replicate, send me an email and I can send you a link to download the fs folder that triggered this error. Otherwise with an mri making bst's mri importer to be unable to set the Comment field properly.

**Changes I propose:** 
- defulat Comment value. Why would you want the default value for a string to ever be a double?
- The logic for error checking of ```sMri.Comment``` value. 
 In line 270 (io/import_mri.m) there is this comment ```% Add a Comment field in MRI structure, if it does not exist yet``` which was not the logic implemented at all. I made it so that it checks if the field exists, and if it desn't, it creates it with the value of a valid Comment variable.
If it exists, it checks if it is valid in order to avoid the problems of having non-string values, which will be later used as input to java methods (gui).

@tmedani thanks for your help.
 