### PR TITLE
Fix import fiff missing ssp names

### DIFF
--- a/external/mne/matlab/fiff_read_proj.m
+++ b/external/mne/matlab/fiff_read_proj.m
@@ -87,7 +87,6 @@ for i = 1:length(items)
             error(me,'Projection item description missing');
         end
     end
-    
     tag = find_tag(item,FIFF.FIFF_PROJ_ITEM_CH_NAME_LIST);
     if ~isempty(tag)
         namelist = tag.data;

--- a/external/mne/matlab/fiff_read_proj.m
+++ b/external/mne/matlab/fiff_read_proj.m
@@ -74,7 +74,11 @@ for i = 1:length(items)
     end
     tag = find_tag(item,FIFF.FIFF_DESCRIPTION);
     if ~isempty(tag)
-        desc = tag.data;
+        if(isstring(desc))
+          desc = tag.data;
+        else
+          desc=['proj_item_' num2str(i)];
+        end 
     else
         tag = find_tag(item,FIFF.FIFF_NAME);
         if ~isempty(tag)
@@ -83,6 +87,7 @@ for i = 1:length(items)
             error(me,'Projection item description missing');
         end
     end
+    
     tag = find_tag(item,FIFF.FIFF_PROJ_ITEM_CH_NAME_LIST);
     if ~isempty(tag)
         namelist = tag.data;

--- a/external/mne/matlab/fiff_read_proj.m
+++ b/external/mne/matlab/fiff_read_proj.m
@@ -74,7 +74,7 @@ for i = 1:length(items)
     end
     tag = find_tag(item,FIFF.FIFF_DESCRIPTION);
     if ~isempty(tag)
-        if(isstring(desc))
+        if isstring(desc)
           desc = tag.data;
         else
           desc=['proj_item_' num2str(i)];

--- a/external/mne/matlab/fiff_read_proj.m
+++ b/external/mne/matlab/fiff_read_proj.m
@@ -74,7 +74,7 @@ for i = 1:length(items)
     end
     tag = find_tag(item,FIFF.FIFF_DESCRIPTION);
     if ~isempty(tag)
-        if isstring(desc)
+        if ischar(desc)
           desc = tag.data;
         else
           desc=['proj_item_' num2str(i)];


### PR DESCRIPTION
Hi, 

I've encountered a file wich had ssp vector information in it, but the labels for each projector vector had been removed. This is all related to the way in which those labels are stored in a fif file. I think Matti knows about this (see image below) but either way, this small modification will ensure that the file can be used even when the actual labels of the projectors are missing. Maybe it can come in handy in the future.

![image](https://user-images.githubusercontent.com/8955424/79396162-e849b300-7f40-11ea-8f97-65cea58f8e0d.png)

