### PR TITLE
generate FEM tensors from DWI

### DIFF
--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1028,6 +1028,7 @@ switch (lower(action))
                     end
                     if ~isAtlas && (length(bstNodes) <= 2)
                         gui_component('MenuItem', jPopup, [], 'Generate FEM mesh', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@process_generate_fem, 'ComputeInteractive', iSubject, iAnatomy));
+                        gui_component('MenuItem', jPopup, [], 'Generate FEM tensor', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@bst_generate_conductivity_tensor, iSubject, iAnatomy));
                     end
                     if ~isAtlas && (length(bstNodes) == 1)
                         AddSeparator(jPopup);


### PR DESCRIPTION
Add the item to the right-click menu 
that calls the process to generate the FEM tensors.

@ftadel following your [recommendation](https://github.com/brainstorm-tools/brainstorm3/issues/267#issuecomment-617096797), 

The function "bst_generate_conductivity_tensor" is located on the bst-duneuro repo (need to pull the new release).
There are also the functions that call the Brainsuite process, conversion of the tensor from voxel to scs and the function to display tensors as an ellipse on the mesh.

All these functions are working as they are but still under development/improvement/cleaning.  

In order to call this function from brainstorm, right-click on the MRI and then "Generate FEM tensor"

The installation of the Brainsuite software http://forums.brainsuite.org/download/ is required.

You need to have the DWI data (nifty, bval and bvec). 
As it's implemented now, you need to have all these files in the same folder and have the same name (s01.nii, s01.bvec and s01.bval). 
You need just to select the nii file during the uiopen is called. 

There is no output to brainstorm database, you need to add a breakpoint on the function to see what is going on. 

The main output data needed from this process is either (or both) the :
- DTItensor on each element
- Conductivity tensor en each element 






