### PR TITLE
minor fixes fiff_anonymizer

### DIFF
--- a/external/other/fiff_anonymizer.m
+++ b/external/other/fiff_anonymizer.m
@@ -710,8 +710,8 @@ end
 function test = isPositiveNumericInteger(i)
 try
   if ( isnumeric(i)   && ...
-       ~isinf(i)      && ...
-      (floor(i) == i) && ...
+       ~isinf(i)      && ...      %mod(i,1) == 0 would also work fine
+      (floor(i) == cei(i)) && ... %in these two cases.
       (i > 0) )
     test = true;
   else

--- a/external/other/fiff_anonymizer.m
+++ b/external/other/fiff_anonymizer.m
@@ -119,10 +119,10 @@ function fiff_anonymizer(inFile, varargin)
 %  Author: Juan Garcia-Prieto, juangpc@gmail.com
 %  License: MIT
 %
-%  Version 0.8 - April 2020
+%  Version 0.9 - May 2020
 %
-VERSION = 0.8;
-DATE = 'April 2020';
+VERSION = 0.9;
+DATE = 'May 2020';
 MAX_VALID_FIFF_VERSION = 1.3;
 
 opts = configure_options(inFile, varargin{:});
@@ -140,7 +140,7 @@ if opts.verbose
   disp(' ');
 end
 
-[inFid, ~] = fopen(opts.inputFile, 'r+', 'ieee-be');
+[inFid, ~] = fopen(opts.inputFile, 'r', 'ieee-be');
 if(opts.verbose && inFid>0)
   display(['Input file opened: ' opts.inputFile]);
 end
@@ -592,8 +592,8 @@ defaultOutFile = fullfile(inFilePath, [inFileName '_anonymized' inFileExt]);
 
 addParameter(inParams, 'verbose', false, @islogical);
 addParameter(inParams, 'output_file', defaultOutFile, @ischar);
-addParameter(inParams, 'set_measurement_date_offset', 0, @isPositiveIntegerValuedNumeric);
-addParameter(inParams, 'set_subject_birthday_offset', 0, @isPositiveIntegerValuedNumeric);
+addParameter(inParams, 'set_measurement_date_offset', 0, @isPositiveNumericInteger);
+addParameter(inParams, 'set_subject_birthday_offset', 0, @isPositiveNumericInteger);
 addParameter(inParams, 'delete_input_file_after', false, @islogical);
 addParameter(inParams, 'delete_confirmation', true, @islogical);
 addParameter(inParams, 'brute', false, @islogical);
@@ -707,3 +707,18 @@ function h = enumHandedness(i)
   h = handednessEnum{i+1};
 end
 
+function test = isPositiveNumericInteger(i)
+try
+  if ( isnumeric(i)   && ...
+       ~isinf(i)      && ...
+      (floor(i) == i) && ...
+      (i > 0) )
+    test = true;
+  else
+    test = false;
+  end
+catch
+  test = false;
+end
+
+end


### PR DESCRIPTION
Hi, 
Thanks for letting me include this function in bst some days ago. A user has reported a couple of issues and I here's the fix. Sorry for this. I'm pretty sure that if you had had a bit of time, you would've noticed these things and ask me to fix them.

- The function only reads data from the input fiff file. No writing. It is now explicitly expressed in the ```fopen``` call. This way even if the function was altered later it would not alter a valuable original fiff file. Also, it allows the user to use the function in a write-protected drive/folder.

- Originally, the function used a function as input  validator (positive integer) named ```isPositiveIntegerValuedNumeric```. This function is part of a toolbox which not everybody has to have. Therefore I've implemented a simpler local version of it.

Let me know if there is anything else I can do.