### PR TITLE
use gray colormap for mri as default

### DIFF
--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -119,7 +119,7 @@ function sColormap = GetDefaults(ColormapType)
             sColormap.MaxMode          = 'global';
         % Anatomy colormap
         case 'anatomy'
-            sColormap.Name             = 'bone';
+            sColormap.Name             = 'gray';
             sColormap.CMap             = bone(DEFAULT_CMAP_SIZE);
             sColormap.isAbsoluteValues = 1;
             sColormap.MaxMode          = 'local';


### PR DESCRIPTION
Hi, 
This PR proposes to change the default colormap for mri viewer from 'bone' to 'gray'. 
It is clear that this might just be my opinion, so feel free to reject no worries. I'm opening the pr just to propose the change. A couple of weeks ago, while working with MDs, it was mentioned that the colors of brainstorm's mri viewer seemed "blueish". When comparing with other software, typically the colors are more black-and-white. 

This is an edited capture of an image we came up with where the difference is clear. A is a capture from bst, B is done with another sw. 

I think MDs like more the black-and-white map. Maybe not.

In any case thanks for reviewing the pr. Take care,

![image](https://user-images.githubusercontent.com/8955424/81093547-e2078080-8ec7-11ea-941f-d9a91c68f6ae.png)


