### PR TITLE
Updated TDT importer

### DIFF
--- a/toolbox/io/in_fopen_tdt.m
+++ b/toolbox/io/in_fopen_tdt.m
@@ -1,17 +1,14 @@
 function [sFile, ChannelMat] = in_fopen_tdt(DataFile)
-
-%% IN_FOPEN_TDT: Open recordings saved in the Tucker Davis Technologies format
-
-% The importer needs the folder that the files are in. I selected one type
+% IN_FOPEN_TDT Open recordings saved in the Tucker Davis Technologies format.
+%
+% The importer needs the folder that the files are in. K Nasiotis selected one type
 % of files to work as the "raw file" - (.Tbk)
-
-
- %% 
- % @=============================================================================
+ 
+% @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
 % 
-% Copyright (c)2000-2019 University of Southern California & McGill University
+% Copyright (c)2000-2020 University of Southern California & McGill University
 % This software is distributed under the terms of the GNU General Public License
 % as published by the Free Software Foundation. Further details on the GPLv3
 % license can be found at http://www.gnu.org/copyleft/gpl.html.
@@ -25,7 +22,7 @@ function [sFile, ChannelMat] = in_fopen_tdt(DataFile)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Author: Konstantinos Nasiotis 2019, 2020
+% Author: Konstantinos Nasiotis 2019-2020
 
 
 % Not available in the compiled version

--- a/toolbox/io/in_fopen_tdt.m
+++ b/toolbox/io/in_fopen_tdt.m
@@ -11,7 +11,7 @@ function [sFile, ChannelMat] = in_fopen_tdt(DataFile)
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
 % 
-% Copyright (c)2000-2020 University of Southern California & McGill University
+% Copyright (c)2000-2019 University of Southern California & McGill University
 % This software is distributed under the terms of the GNU General Public License
 % as published by the Free Software Foundation. Further details on the GPLv3
 % license can be found at http://www.gnu.org/copyleft/gpl.html.
@@ -25,7 +25,7 @@ function [sFile, ChannelMat] = in_fopen_tdt(DataFile)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Author: Konstantinos Nasiotis 2019
+% Author: Konstantinos Nasiotis 2019, 2020
 
 
 % Not available in the compiled version
@@ -69,6 +69,9 @@ end
 
 %% ===== READ DATA HEADERS =====
 
+bst_progress('start', 'TDT', 'Reading headers...');
+
+
 % Load one second segment to see what type of signals exist in this dataset
 % Use as general sampling rate the rate of the HIGHEST sampled signal
 % The signals that have a lower sampling rate will be interpolated to match
@@ -79,30 +82,66 @@ headers = TDTbin2mat(DataFolder, 'HEADERS', 1);
 data = TDTbin2mat(DataFolder, 'T1', 0, 'T2', 1); % 1 second segment
 all_streams = fieldnames(data.streams);
 
-several_sampling_rates = [];
-total_channels         = [];
+
+%% Get rid of streams that are pNe and SynC
+
+all_streams = all_streams(~ismember(all_streams,{'pNe1','pNe2','pNe3','pNe4','SynC'}));
 
 % The sampling rates present are the weirdest numbers I have ever seen:
 % e.g. Fs = 3051.7578125 Hz !!!
 % Those numbers create problems when loading segments of data.
 % The segment loading is in TimeBounds, not SampleBounds that makes it even
 % worse with those sampling rates
+stream_info = struct;   
+
+LFP_label_exists = 0;
+
+
+ii = 1;
 for iStream = 1:length(all_streams)
-    several_sampling_rates = [several_sampling_rates data.streams.(all_streams{iStream}).fs];
-    total_channels         = [total_channels, size(data.streams.(all_streams{iStream}).data,1)];
+    stream_info(iStream).label          = all_streams{iStream};
+    stream_info(iStream).fs             = data.streams.(all_streams{iStream}).fs;
+    stream_info(iStream).total_channels = size(data.streams.(all_streams{iStream}).data,1);
+    stream_info(iStream).channelIndices = ii:ii+size(data.streams.(all_streams{iStream}).data,1)-1;
+    
+    ii = ii + size(data.streams.(all_streams{iStream}).data,1);
+
+    
+    % Brainstorm needs a single sampling rate. I assign the one on the LFPs
+    
+    theLFPlabel = 'LFP';
+    if strfind(all_streams{iStream},theLFPlabel)
+        data_new = TDTbin2mat(DataFolder, 'STORE', all_streams{iStream},'T1', 0, 'T2', 1); % 1 second segment       
+        
+        general_sampling_rate = data_new.streams.(all_streams{iStream}).fs;
+        LFP_label_exists = 1;
+    end
 end
 
-[general_sampling_rate iHighestSampledChannel] = max(several_sampling_rates);
-
-nChannels = sum(total_channels);
+if ~LFP_label_exists    
+    [indx,tf] = listdlg('PromptString',{'Select the label of the electrophysiological signal that is present in this dataset',...
+    'If more streams are present, they will be resampled to match the Fs of this stream.',''},...
+    'SelectionMode','single','ListString',all_streams);
+    
+    data_new = TDTbin2mat(DataFolder, 'STORE', all_streams{indx},'T1', 0, 'T2', 1); % 1 second segment       
+        
+    general_sampling_rate = data_new.streams.(all_streams{indx}).fs;
+    LFP_label_exists = 1;
+    
+    
+    if isempty(indx)
+        bst_error('No stream was selected')
+           stop
+    end
+end
+    
+nChannels = sum([stream_info.total_channels]);
 
  %% ===== CREATE BRAINSTORM SFILE STRUCTURE =====
 % Initialize returned file structure
 sFile = db_template('sfile');
 
-
-
- % Add information read from header
+% Add information read from header
 sFile.prop.sfreq   =  general_sampling_rate;
 sFile.byteorder    = 'l';
 sFile.filename     = DataFolder;
@@ -115,20 +154,18 @@ sFile.prop.nAvg    = 1;
 % No info on bad channels
 sFile.channelflag  = ones(nChannels, 1);
 
-sFile.header.several_sampling_rates = several_sampling_rates;
-sFile.header.total_channels         = total_channels;
-sFile.header.all_streams            = all_streams;
+sFile.header.stream_info = stream_info;
 
- %% ===== CREATE EMPTY CHANNEL FILE =====
+%% ===== CREATE EMPTY CHANNEL FILE =====
 ChannelMat = db_template('channelmat');
 ChannelMat.Comment = 'TDT channels';
 ChannelMat.Channel = repmat(db_template('channeldesc'), [1, nChannels]);
 
 ii = 0;
 for iStream = 1:length(all_streams)
-     for iChannel = 1:total_channels(iStream)
+     for iChannel = 1:stream_info(iStream).total_channels
          ii = ii+1;
-         if ~(total_channels(iStream)==1)
+         if ~(stream_info(iStream).total_channels==1)
             ChannelMat.Channel(ii).Name = [all_streams{iStream} '_' num2str(iChannel)];
          else
              ChannelMat.Channel(ii).Name= [all_streams{iStream}];
@@ -137,10 +174,10 @@ for iStream = 1:length(all_streams)
 
          ChannelMat.Channel(ii).Group   = all_streams{iStream};
          
-         if ~(total_channels(iStream) == 1)
+         if strfind(stream_info(iStream).label, theLFPlabel)
             ChannelMat.Channel(ii).Type = 'EEG'; % Not all are EEGs - NOT SURE WHAT TO PUT HERE - AS A STARTING POINT, I PUT WHATEVER IS ONLY ONE CHANNEL SET IT AS Misc
          else
-            ChannelMat.Channel(ii).Type = 'Misc';
+            ChannelMat.Channel(ii).Type = all_streams{iStream};
          end
          ChannelMat.Channel(ii).Orient  = [];
          ChannelMat.Channel(ii).Weight  = 1;
@@ -151,7 +188,10 @@ end
 
 %% Check for acquisition events
 
-NO_data = TDTbin2mat(DataFolder, 'NODATA',1); % Memory Management???
+bst_progress('start', 'TDT', 'Collecting acquisition events...');
+
+disp('Getting Acquisition System events')
+NO_data = TDTbin2mat(DataFolder, 'TYPE', 2); % Just load epocs / events
 
 are_there_events = ~isempty(NO_data.epocs);
 
@@ -169,7 +209,7 @@ if are_there_events
             events(iindex).label      = NO_data.epocs.(all_event_Labels{iEvent}).name;
             events(iindex).color      = rand(1,3);
             events(iindex).epochs     = ones(1,length(NO_data.epocs.(all_event_Labels{iEvent}).onset))  ;
-            events(iindex).times      = round(NO_data.epocs.(all_event_Labels{iEvent}).onset' .* general_sampling_rate) ./ general_sampling_rate;
+            events(iindex).times      = NO_data.epocs.(all_event_Labels{iEvent}).onset';
             events(iindex).reactTimes = [];
             events(iindex).select     = 1;
             events(iindex).channels   = cell(1, size(events(iindex).times, 2));
@@ -186,7 +226,7 @@ if are_there_events
                 events(iindex).label      = [NO_data.epocs.(all_event_Labels{iEvent}).name num2str(conditions_in_event(iCondition))];
                 events(iindex).color      = rand(1,3);
                 events(iindex).epochs     = ones(1,length(selected_Events_for_condition))  ;
-                events(iindex).times      = round(NO_data.epocs.(all_event_Labels{iEvent}).onset(selected_Events_for_condition)' .* general_sampling_rate) ./ general_sampling_rate;
+                events(iindex).times      = NO_data.epocs.(all_event_Labels{iEvent}).onset(selected_Events_for_condition)';
                 events(iindex).reactTimes = [];
                 events(iindex).select     = 1;
                 events(iindex).channels   = cell(1, size(events(iindex).times, 2));
@@ -199,23 +239,57 @@ end
     
 %% Check for spike events
 
-are_there_spikes = ~isempty(NO_data.snips);
 
-if  ~exist ('events','var')
-    events = struct;
-    last_event_index = 0;
+check_for_spikes = 1;
+
+
+
+
+
+
+
+if check_for_spikes
+    bst_progress('start', 'TDT', 'Collecting spiking events...');
+    disp('Getting spiking events')
+    NO_data = TDTbin2mat(DataFolder, 'TYPE', 3); % Just load spikes
+    are_there_spikes = ~isempty(NO_data.snips);
 else
-    last_event_index = length(events);
+    are_there_spikes = 0;
 end
 
 
+
+
+%%%%%%%%
+disp('***************************************************')
+disp('CHECK THE SPIKES. THEY ARE ONLY ASSIGNED ON RIG TWO')
+disp('***************************************************')
+%%%%%%%%
+
+
+
+
 if are_there_spikes
+    
+    if  ~exist ('events','var')
+        events = struct;
+        last_event_index = 0;
+    else
+        last_event_index = length(events);
+    end
+    
     all_spike_event_Labels = fieldnames(NO_data.snips);
-    channels_are_EEG = find(strcmp({ChannelMat.Channel.Type}, 'EEG'));
 
     for iSpikeDetectedField = 1:length(all_spike_event_Labels)
+%         channels_are_EEG = find(strcmp({ChannelMat.Channel.Type}, 'EEG'));
         
-        for iChannel = 1:length(channels_are_EEG)
+        try
+            channels_are_EEG_on_selected_RIG = find(strcmp({ChannelMat.Channel.Type}, 'EEG') & strcmp({ChannelMat.Channel.Group}, ['LFP' num2str(iSpikeDetectedField)]));
+        catch
+            error('There is an assumption here that LFP1 corresponds to eNe1, LFP2 to eNe2 and so on. If that''s not the case on your system please contact the forum') 
+        end
+
+        for iChannel = 1:length(channels_are_EEG_on_selected_RIG)
             
             NeuronIDs = unique(NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).sortcode(find(NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).chan == iChannel)));
             
@@ -234,15 +308,15 @@ if are_there_spikes
 
                     if length(NeuronIDs) == 1
                         SpikesOfThatNeuronOnChannel_Indices = find(NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).chan == iChannel & NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).sortcode == 0); % Unsorted
-                        events(last_event_index).label = ['Spikes Channel ' ChannelMat.Channel(channels_are_EEG(iChannel)).Name];
+                        events(last_event_index).label = ['Spikes Channel ' ChannelMat.Channel(channels_are_EEG_on_selected_RIG(iChannel)).Name];
                     else
-                        SpikesOfThatNeuronOnChannel_Indices = find(NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).chan == iChannel & NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).sortcode == iNeuron); % Sorted
-                        events(last_event_index).label = ['Spikes Channel ' ChannelMat.Channel(channels_are_EEG(iChannel)).Name ' |' num2str(iNeuron) '|'];                    
+                        SpikesOfThatNeuronOnChannel_Indices = find(NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).chan == iChannel & NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).sortcode == NeuronIDs(iNeuron)); % Sorted
+                        events(last_event_index).label = ['Spikes Channel ' ChannelMat.Channel(channels_are_EEG_on_selected_RIG(iChannel)).Name ' |' num2str(NeuronIDs(iNeuron)) '|'];                    
                     end
 
                     events(last_event_index).color      = rand(1,3);
                     events(last_event_index).epochs     = ones(1,length(SpikesOfThatNeuronOnChannel_Indices));
-                    events(last_event_index).times      = round(events(NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).ts(SpikesOfThatNeuronOnChannel_Indices)' .* general_sampling_rate)) ./ general_sampling_rate;
+                    events(last_event_index).times      = NO_data.snips.(all_spike_event_Labels{iSpikeDetectedField}).ts(SpikesOfThatNeuronOnChannel_Indices)';
                     events(last_event_index).reactTimes = [];
                     events(last_event_index).select     = 1;
                     events(last_event_index).channels   = cell(1, size(events(last_event_index).times, 2));
@@ -260,15 +334,12 @@ end
 
 
 
-
-
-
-
- function downloadAndInstallTDT()
+function downloadAndInstallTDT()
 
     TDTDir = bst_fullfile(bst_get('BrainstormUserDir'), 'TDT');
     TDTTmpDir = bst_fullfile(bst_get('BrainstormUserDir'), 'TDT_tmp');
-    url = 'https://www.tdt.com/support/examples/TDTMatlabSDK.zip';
+    url = 'https://www.tdt.com/files/examples/TDTMatlabSDK.zip';
+           
     % If folders exists: delete
     if isdir(TDTDir)
         file_delete(TDTDir, 1, 3);
@@ -315,6 +386,8 @@ end
     file_delete(TDTTmpDir, 1, 3);
     % Add TDT to Matlab path
     addpath(genpath(TDTDir));
+    
+    bst_progress('start', 'TDT', 'TDT SDK successfully installed');
 
  end
 

--- a/toolbox/io/in_fread_tdt.m
+++ b/toolbox/io/in_fread_tdt.m
@@ -1,12 +1,7 @@
 function F = in_fread_tdt(sFile, SamplesBounds, selectedChannels)
+% IN_FREAD_TDT Read recordings saved in the Tucker Davis Technologies format
 
-
-
-%% IN_FOPEN_TDT: Open recordings saved in the Tucker Davis Technologies format
-
-
- %% 
- % @=============================================================================
+% @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
 % 
@@ -24,34 +19,9 @@ function F = in_fread_tdt(sFile, SamplesBounds, selectedChannels)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Author: Konstantinos Nasiotis 2019, 2020
+% Author: Konstantinos Nasiotis 2019-2020
 
-
-% IN_FREAD_TDT Read a block of recordings from TDT files
-%
-% USAGE:  F = in_fread_TDT(sFile, SamplesBounds=[], iChannels=[])
-
- % @=============================================================================
-% This function is part of the Brainstorm software:
-% https://neuroimage.usc.edu/brainstorm
-% 
-% Copyright (c)2000-2019 University of Southern California & McGill University
-% This software is distributed under the terms of the GNU General Public License
-% as published by the Free Software Foundation. Further details on the GPLv3
-% license can be found at http://www.gnu.org/copyleft/gpl.html.
-% 
-% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
-% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
-% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
-% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
-% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
-%
-% For more information type "brainstorm license" at command prompt.
-% =============================================================================@
-%
-% Author: Konstantinos Nasiotis 2019, 2020
-
- % Parse inputs
+% Parse inputs
 if (nargin < 3) || isempty(selectedChannels)
     selectedChannels = 1:length(sFile.channelflag);
 end

--- a/toolbox/io/in_fread_tdt.m
+++ b/toolbox/io/in_fread_tdt.m
@@ -1,13 +1,16 @@
 function F = in_fread_tdt(sFile, SamplesBounds, selectedChannels)
-% IN_FREAD_TDT Read a block of recordings from Tucker Davis Technologies files
-%
-% USAGE:  F = in_fread_TDT(sFile, SamplesBounds=[], iChannels=[])
 
-% @=============================================================================
+
+
+%% IN_FOPEN_TDT: Open recordings saved in the Tucker Davis Technologies format
+
+
+ %% 
+ % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
 % 
-% Copyright (c)2000-2020 University of Southern California & McGill University
+% Copyright (c)2000-2019 University of Southern California & McGill University
 % This software is distributed under the terms of the GNU General Public License
 % as published by the Free Software Foundation. Further details on the GPLv3
 % license can be found at http://www.gnu.org/copyleft/gpl.html.
@@ -21,8 +24,32 @@ function F = in_fread_tdt(sFile, SamplesBounds, selectedChannels)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Author: Konstantinos Nasiotis 2019
+% Author: Konstantinos Nasiotis 2019, 2020
 
+
+% IN_FREAD_TDT Read a block of recordings from TDT files
+%
+% USAGE:  F = in_fread_TDT(sFile, SamplesBounds=[], iChannels=[])
+
+ % @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2019 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Author: Konstantinos Nasiotis 2019, 2020
 
  % Parse inputs
 if (nargin < 3) || isempty(selectedChannels)
@@ -32,14 +59,12 @@ if (nargin < 2) || isempty(SamplesBounds)
     SamplesBounds = round(sFile.prop.times .* sFile.prop.sfreq);
 end
 
-nChannels = length(selectedChannels);
 nSamples = SamplesBounds(2) - SamplesBounds(1) + 1;
 
-Fs = floor(max(sFile.header.several_sampling_rates));
+%% Just get the LFP sampling rate and work on that 
+% This is assigned at the importer
 
-
-
-
+Fs = sFile.prop.sfreq;
 
 %% The importer for TDT, imports based on timeBounds, not samplebounds
 % This is a nightmare when trying to load segments of the same length
@@ -48,38 +73,110 @@ Fs = floor(max(sFile.header.several_sampling_rates));
 % rate of the highest sampled signal (typically LFP or Raw)
 % This might create a problem at certain datasets.
 
+stream_info = sFile.header.stream_info;
 
-data = TDTbin2mat(sFile.filename, 'T1', SamplesBounds(1)/Fs, 'T2', SamplesBounds(2)/Fs);
 
 
-F = zeros(length(selectedChannels), nSamples);
-ii = 1;
-for iStream = 1:length(sFile.header.total_channels)
+%% Get the different types of streams that are needed based on the indices of the selected channels
 
-    % DO THE EXTRAPOLATION HERE FOR THE LOW SAMPLED SIGNALS (EYE TRACES, ARM MOVEMENTS ETC.)
-    if sFile.header.several_sampling_rates(iStream) ~= max(sFile.header.several_sampling_rates)
-        if mod(max(sFile.header.several_sampling_rates),sFile.header.several_sampling_rates(iStream))~=0
-            warning ('The sampling rate of the extra channels is not divided by the sampling rate of the EEG signals - POTENTIAL ERROR')
+all_stream_labels = {stream_info.label};
+streams_needed = [];
+selected_channels_from_stream = {};
+
+iSelectedStreams = [];
+% if all channels are selected (I assume here that the same channel can't be selected multiple times)
+if length(selectedChannels) == length(length(sFile.channelflag)) 
+    streams_to_load = all_stream_labels;
+    iSelectedStreams = 1:length(all_stream_labels);
+else
+    ii = 0;
+    for iStream = 1:length(stream_info)
+        
+        if any(ismember(stream_info(iStream).channelIndices, [selectedChannels]))
+            ii = ii+1;
+            iSelectedStreams = [iSelectedStreams iStream];
+            disp(['Will load Stream: ' stream_info(iStream).label])
+            selected_channels_from_stream{ii}= find(ismember(stream_info(iStream).channelIndices, [selectedChannels]));
+
+            streams_needed = [streams_needed iStream];
         end
-        temp = interp(double(data.streams.(sFile.header.all_streams{iStream}).data),round(max(sFile.header.several_sampling_rates)/sFile.header.several_sampling_rates(iStream)));
-    else
-        temp = double(data.streams.(sFile.header.all_streams{iStream}).data);
+    end
+
+    streams_to_load = all_stream_labels(streams_needed);
+end
+
+
+ii = 1;
+F = zeros(length(selectedChannels), nSamples);
+for iStream = 1:length(streams_to_load)
+    
+    data = TDTbin2mat(sFile.filename, 'TYPE', 4, 'STORE', streams_to_load{iStream}, 'T1', SamplesBounds(1)/Fs, 'T2', SamplesBounds(2)/Fs);
+    data = data.streams.(streams_to_load{iStream});
+    
+
+    % DO THE EXTRAPOLATION HERE FOR THE LOW SAMPLED SIGNALS (EYE TRACES ETC.)
+    if stream_info(iStream).fs < Fs
+        
+        low_sampled_signal = double(data.data(selected_channels_from_stream{iStream},:));
+        
+        temp = zeros(size(low_sampled_signal,1),nSamples);
+        for iChannel = 1:size(low_sampled_signal,1)
+            
+            %1. UPSAMPLE AND DROP RANDOM ENTRIES
+            % Upsampling the lower sampled behavioral signals
+            upsampled_position = repelem(low_sampled_signal(iChannel,:),ceil(nSamples/size(low_sampled_signal,2)));
+            logical_keep = true(1,length(upsampled_position));
+            random_points_to_remove = randperm(length(upsampled_position),length(upsampled_position)-nSamples);
+            logical_keep(random_points_to_remove) = false;
+            temp(iChannel,:) = upsampled_position(logical_keep);
+            
+%             %2. INTERPOLATION
+%             temp(iChannel,:) = interp(double(data.streams.(stream_info(iStream).label).data),round(Fs/stream_info(iStream).fs));
+
+        end
+        
+        
+    % DROP SAMPLES HERE FOR THE HIGH SAMPLED SIGNALS (LED, EMG ETC.)
+    elseif stream_info(iStream).fs > Fs
+        
+        
+       high_sampled_signal = double(data.data(selected_channels_from_stream{iStream},:));
+       
+       % Make sure the signal has all the samples we expect
+       nExpectedSamples = floor(nSamples / Fs * stream_info(iStream).fs);
+       nGottenSamples = size(high_sampled_signal,2);
+       high_sampled_signal2 = zeros(size(high_sampled_signal,1), nExpectedSamples);
+       high_sampled_signal2(:,1:min(nGottenSamples,nExpectedSamples)) = high_sampled_signal;
+       high_sampled_signal = high_sampled_signal2;
+        
+        
+%         high_sampled_signal = double(data.data(selected_channels_from_stream{iStream},:));        
+        
+        nSamplesToDrop =  size(high_sampled_signal,2) - nSamples;
+        
+        keep_these_samples = true(1,size(high_sampled_signal,2));
+        remove_these_samples = round(linspace(1, size(high_sampled_signal,2), nSamplesToDrop));
+        
+        keep_these_samples(remove_these_samples) = false;
+        
+        
+        temp = high_sampled_signal(:,keep_these_samples);
+        
+    elseif stream_info(iStream).fs == Fs
+        temp = double(data.data(selected_channels_from_stream{iStream},:));
     end
 
     % At the end of the signals' length, since the loading based on time is awful,
     % leave the extra samples as zeros (shouldn't create a problem)
     if nSamples > size(temp,2)
-        F(ii : ii + sFile.header.total_channels(iStream) - 1,1:size(temp,2)) = temp; clear temp
+%         F(stream_info(iSelectedStreams(iStream)).channelIndices(selected_channels_from_stream{iStream}),1:size(temp,2)) = temp; clear temp
+        F(ii : ii + length(selected_channels_from_stream{iStream}) - 1,1:size(temp,2)) = temp; clear temp
     else  
-        F(ii : ii + sFile.header.total_channels(iStream) - 1,:) = temp(:,1:nSamples); clear temp
+%         F(stream_info(iSelectedStreams(iStream)).channelIndices(selected_channels_from_stream{iStream}),:) = temp(:,1:nSamples); clear temp
+        F(ii : ii + length(selected_channels_from_stream{iStream}) - 1,:) = temp(:,1:nSamples); clear temp
     end
-    ii = ii + sFile.header.total_channels(iStream);
+     ii = ii + length(selected_channels_from_stream{iStream});
 end
-
-
-% Lazy selection, Improve
-F = F(selectedChannels,:);
-      
 
 end
 


### PR DESCRIPTION
Neurons are correctly assigned to channels in case multiple Rigs are simultaneously connected to the same acquisition system.

Importer was modified to accommodate behavioral signals. They will be upsampled/downsampled to match the electrophysiological signals since they have different sampling rates.

Unfortunately this will break backwards compatibility with datasets already imported in the database. Users will have to import again.