### PR TITLE
Nirs : fix sensor display and MRI registration

### DIFF
--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -4207,7 +4207,7 @@ function hPairs = PlotNirsCap(hFig, isDetails)
         locPairDet = cat(1, locPairDet{:});
         
         % Make the position of the links more superficial, so they can be outside of the head and selected with the mouse
-        if any(~locPairDet(:,3)== locPairDet(1,3) ) || any(~locPairSrc(:,3)==locPairSrc(1,3)) 
+        if length(unique(locPairDet(:,3))) > 1 || length(unique(locPairSrc(:,3))) > 1
             normSrc = sqrt(sum(locPairSrc .^ 2, 2));
             normDet = sqrt(sum(locPairDet .^ 2, 2));
             locPairSrc = bst_bsxfun(@times, locPairSrc, (normSrc + 0.0035) ./ normSrc);
@@ -4228,30 +4228,31 @@ function hPairs = PlotNirsCap(hFig, isDetails)
             %set(hPairs(i), 'UserData', iChannels(iChanPairs(i)));
             set(hPairs(i), 'UserData', uniquePairs(i,:));
         end
-
-        % ===== DISPLAY TEXT =====
-        % Text display properties
-        textOpt = {...
-            'Parent',              hAxes, ...
-            'HorizontalAlignment', 'center', ...
-            'FontSize',            bst_get('FigFont') + 2, ...
-            'FontUnits',           'points', ...
-            'FontWeight',          'normal', ...
-            'Tag',                 'NirsCapText', ...
-            'Interpreter',         'none'};
-        % Display text for sources
-        for i = 1:size(locSrc,1)
-            txtLoc = locSrc(i,:) .* 1.08;
-            text(txtLoc(1), txtLoc(2), txtLoc(3), Snames{i}, 'Color', [1,.8,0], textOpt{:});
-        end
-        % Display text for detectors
-        for i = 1:size(locDet,1)
-            txtLoc = locDet(i,:) .* 1.08;
-            text(txtLoc(1), txtLoc(2), txtLoc(3), Dnames{i}, 'Color', [.8,1,0], textOpt{:});
-        end
     else
         hPairs = [];
     end
+    
+    
+    % ===== DISPLAY TEXT =====
+    % Text display properties
+    textOpt = {...
+        'Parent',              hAxes, ...
+        'HorizontalAlignment', 'center', ...
+        'FontSize',            bst_get('FigFont') + 2, ...
+        'FontUnits',           'points', ...
+        'FontWeight',          'normal', ...
+        'Tag',                 'NirsCapText', ...
+        'Interpreter',         'none'};
+    % Display text for sources
+    for i = 1:size(locSrc,1)
+        txtLoc = locSrc(i,:) .* 1.08;
+        text(txtLoc(1), txtLoc(2), txtLoc(3), Snames{i}, 'Color', [1,.8,0], textOpt{:});
+    end
+    % Display text for detectors
+    for i = 1:size(locDet,1)
+        txtLoc = locDet(i,:) .* 1.08;
+        text(txtLoc(1), txtLoc(2), txtLoc(3), Dnames{i}, 'Color', [.8,1,0], textOpt{:});
+    end    
 end
 
 

--- a/toolbox/gui/view_channels.m
+++ b/toolbox/gui/view_channels.m
@@ -201,7 +201,7 @@ if is3DElectrodes
     end
 elseif ismember(lower(Modality), {'ctf', 'vectorview306', '4d', 'kit', 'kriss', 'babymeg', 'ricoh'})
     figure_3d('PlotCoils', hFig, Modality, isMarkers);
-elseif strcmpi(Modality, 'NIRS-BRS')
+elseif ismember(lower(Modality), {'nirs','nirs-brs'})
     figure_3d('PlotNirsCap', hFig, isMarkers);
 else
     isMesh = ~isequal(Modality, 'SEEG');

--- a/toolbox/gui/view_topography.m
+++ b/toolbox/gui/view_topography.m
@@ -299,8 +299,10 @@ if UseMontage
         % For NIRS (: Force the selection of a montage
         if strcmpi(Modality, 'NIRS') && isempty(MontageName)
             % 3DOptodes and 3DSensorCap: Only one value can be displayed at a time
-            if ismember(TopoType, {'3DSensorCap', '3DOptodes'}) 
+            if ismember(TopoType, {'3DSensorCap', '3DOptodes'}) && length(sFigMontages) > 1
                 MontageName = sFigMontages(2).Name;
+            elseif ismember(TopoType, {'3DSensorCap', '3DOptodes'}) 
+                MontageName = sFigMontages(1).Name;
             elseif strcmpi(TopoType, '2DLayout')
                 MontageName = sFigMontages(1).Name;
             end

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -152,7 +152,7 @@ if isMeg
 % EEG Electrodes / NIRS optodes
 elseif isNirs || isEeg
     % View sensors
-    view_channels(ChannelFile, Modality, 0, 1, hFig);
+    view_channels(ChannelFile, Modality, isEeg, 1, hFig);
     % Hide sensors labels
     hSensorsLabels = findobj(hFig, 'Tag', 'SensorsLabels');
     set(hSensorsLabels, 'Visible', 'off');

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -152,7 +152,7 @@ if isMeg
 % EEG Electrodes / NIRS optodes
 elseif isNirs || isEeg
     % View sensors
-    view_channels(ChannelFile, Modality, 1, 1, hFig);
+    view_channels(ChannelFile, Modality, 0, 1, hFig);
     % Hide sensors labels
     hSensorsLabels = findobj(hFig, 'Tag', 'SensorsLabels');
     set(hSensorsLabels, 'Visible', 'off');
@@ -162,6 +162,11 @@ end
 % Get sensors patch
 hSensorsPatch = findobj(hFig, 'Tag', 'SensorsPatch');
 hSensorsMarkers = findobj(hFig, 'Tag', 'SensorsMarkers');
+
+if isNirs && isempty(hSensorsPatch)
+    hSensorsPatch = findobj(hFig, 'Tag', 'NirsCapPatch');
+    hSensorsMarkers = findobj(hFig, 'Tag', 'NirsCapText');
+end    
 if (isempty(hSensorsPatch) || (~isempty(hSensorsPatch) && ~ishandle(hSensorsPatch(1)))) && ...
    (isempty(hSensorsMarkers) || (~isempty(hSensorsMarkers) && ~ishandle(hSensorsMarkers(1))))
     bst_error('Cannot display sensors patch', 'Align electrode contacts', 0);

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -295,9 +295,15 @@ end
 Channel = GlobalData.DataSet(gChanAlign.iDS).Channel;
 iChan = good_channel(Channel, [], Modality);
 gChanAlign.iGlobal2Local = zeros(1, length(Channel));
-gChanAlign.iGlobal2Local(iChan) = 1:size(gChanAlign.SensorsVertices,1);
+if isNirs
+    gChanAlign.iGlobal2Local(iChan) = 1:size(iChan,2);
+    gChanAlign.SensorsLabels(iChan) = {GlobalData.DataSet(gChanAlign.iDS).Channel(iChan).Name};
+    
+else    
+    gChanAlign.iGlobal2Local(iChan) = 1:size(gChanAlign.SensorsVertices,1);
+end    
 % EEG/NIRS: Get the labels of the electrodes
-if isEeg || isNirs
+if isEeg
     iTextChan = length(gChanAlign.hSensorsLabels) - (1:length(iChan)) + 1;
     gChanAlign.SensorsLabels(iTextChan) = {GlobalData.DataSet(gChanAlign.iDS).Channel(iChan).Name};
 end


### PR DESCRIPTION
Hi, 

This PR fixes an old bug that occurs when importing nirs. When importing nirs data, at the end of the registration, instead of showing the montage, Brainstorm was showing this figure : 

![Capture d’écran 2020-05-31 à 20 29 15](https://user-images.githubusercontent.com/24530402/83361854-c4292080-a38c-11ea-86ab-b5dd6566c6b7.png)
Each white dot is the middle of a channel, so not very informative to see if the registration was ok. 
This was due to the fact that sometimes, the modality is defined as 'NIRS' and sometimes as 'NIRS-BRS'.   One thing that could be great, I don't know if you can help me with that, would be to allow like with EEG to project probe on the scalp. 

This commit also fixes the display when we use 'Display Sensors > NIRS (scalp)' by adding the name of the probe in the figures. 


Sensors display (scalp & pairs) : 
![Capture d’écran 2020-05-31 à 22 24 24](https://user-images.githubusercontent.com/24530402/83361946-9db7b500-a38d-11ea-8941-fab7b1b6c90c.png)

MRI registration > check 
![Capture d’écran 2020-05-31 à 22 24 43](https://user-images.githubusercontent.com/24530402/83361950-a7d9b380-a38d-11ea-8249-3b48c2fee723.png)

MRI registration > edit 
This only fixes the display, but I am almost certain we need to make changes to handle the difference between EEG and nirs as we want to make change on the probe and not channels ( pair of two probes).  

![Capture d’écran 2020-05-31 à 22 25 01](https://user-images.githubusercontent.com/24530402/83361953-ae682b00-a38d-11ea-9070-cee18fca4bf3.png)

Best regards, 
Edouard 





