### PR TITLE
Added Rescale amplitude button to power spectrum figures

### DIFF
--- a/toolbox/gui/figure_spectrum.m
+++ b/toolbox/gui/figure_spectrum.m
@@ -628,6 +628,12 @@ function FigureKeyPressedCallback(hFig, ev)
             if isControl
                 view_topography(TfFile, [], '2DSensorCap', [], 0);
             end
+        % Y : Scale to fit Y axis
+        case 'y'
+            TsInfo = getappdata(hFig, 'TsInfo');
+            if strcmpi(TsInfo.DisplayMode, 'butterfly')
+                figure_timeseries('ScaleToFitY', hFig, ev);
+            end
         % RETURN: VIEW SELECTED CHANNELS
         case 'return'
             DisplaySelectedRows(hFig);

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -2532,7 +2532,8 @@ function DisplayConfigMenu(hFig, jParent)
         % Scale to fit Y
         if strcmpi(TsInfo.DisplayMode, 'butterfly')
             jMenu.addSeparator();
-            gui_component('MenuItem', jMenu, [], 'Scale selection to fit screen', IconLoader.ICON_Y, [], @(h,ev)ScaleToFitY(hFig, ev));
+            jItem = gui_component('MenuItem', jMenu, [], 'Scale selection to fit screen', IconLoader.ICON_Y, [], @(h,ev)ScaleToFitY(hFig, ev));
+            jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y, 0));
         end
         
     % === LINES ===

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3870,7 +3870,7 @@ function CreateScaleButtons(iDS, iFig)
     if isempty(TsInfo) || ~strcmpi(TsInfo.DisplayMode, 'column') || ~strcmpi(GlobalData.DataSet(iDS).Figure(iFig).Id.Type, 'DataTimeSeries')
         set([h7 h8 h9 h10], 'Visible', 'off');
     end
-    if ~strcmpi(GlobalData.DataSet(iDS).Figure(iFig).Id.Type, 'spectrum')
+    if (isempty(TsInfo) && ~strcmpi(TsInfo.DisplayMode, 'column')) || ~strcmpi(GlobalData.DataSet(iDS).Figure(iFig).Id.Type, 'spectrum')
         set(h11, 'Visible', 'off');
     end
 end
@@ -4165,6 +4165,12 @@ end
 
 %% ===== RESCALE SPECTRUM AMPLITUDE =====
 function RescaleSpectrumAmplitude(hFig, ev)
+    TsInfo = getappdata(hFig, 'TsInfo');
+    % Only for butterfly display mode
+    if isempty(TsInfo) || ~strcmpi(TsInfo.DisplayMode, 'butterfly')
+        return;
+    end
+
     global GlobalData
     % ===== GET DATA =====
     % Get figure description


### PR DESCRIPTION
Suggested by @Moo-Marc . When you zoom in a power spectrum (X axis), the Y axis amplitude limits do not change which can be annoying for visualization. I added a "Rescale amplitude" button to power spectrum figures in butterfly view so that you can rescale the figure on a single click when you zoom in.

![2020-06-09_14-04-23](https://user-images.githubusercontent.com/9253273/84183634-35866480-aa5a-11ea-86d8-22d110b7f1d7.gif)

I am not very familiar with the way figures handle the amplitude limits so I might not have done this in the best way, let me know.