### PR TITLE
PSD: Consider bad segments on raw scout sources

### DIFF
--- a/toolbox/timefreq/bst_timefreq.m
+++ b/toolbox/timefreq/bst_timefreq.m
@@ -444,6 +444,23 @@ for iData = 1:length(Data)
             else
                 nComponents = OPTIONS.nComponents(iData);
             end
+            
+            % PSD: we don't want the bad segments
+            if ~isempty(iStudy) && strcmpi(OPTIONS.Method, 'psd')
+                % Load associated data file
+                sMat = in_bst_data(sStudy.Result(iFile).DataFile);
+                % Raw file
+                if isstruct(sMat.F)
+                    sFile = sMat.F;
+                else
+                    sFile = sMat;
+                end
+                % Get list of bad segments in file
+                isChannelEvtBad = 0;
+                BadSegments = panel_record('GetBadSegments', sFile, isChannelEvtBad);
+                % Convert them to the beginning of the time section that is processed
+                BadSegments = BadSegments - sFile.prop.sfreq * sMat.Time(1) + 1;
+            end
         end
         nAvg = 1;
     end


### PR DESCRIPTION
The PSD process currently considers bad segments on raw recordings, raw sources, but not when using scouts of raw sources. 
If this was intended or not implemented in the best way please let me know!

To reproduce issue:
1. Add a bad segment to a raw data file
2. Compute sources
3. Run PSD on the sources. If you check "Use scouts", no bad segment are skipped. If you do not, bad segments are skipped (for quick debugging, the user is notified in the command window when bad segments are skipped).