### PR TITLE
remove the unused vertices, element and tensors from Cauchy files for MEG

### DIFF
--- a/toolbox/forward/bst_duneuro.m
+++ b/toolbox/forward/bst_duneuro.m
@@ -116,8 +116,23 @@ if strcmp(dnModality, 'meg')
     % Remove the elements corresponding to the unselected tissues
     iRemove = find(~ismember(FemMat.Tissue, find(cfg.FemSelect)));
     if ~isempty(iRemove)
-        FemMat.Elements(iRemove,:) = [];
-        FemMat.Tissue(iRemove,:) = [];
+        % Remove elements
+        FemMat.Elements(iRemove, :) = [];
+        FemMat.Tissue(iRemove) = [];
+        if isfield(FemMat, 'Tensors') && ~isempty(FemMat.Tensors)
+            FemMat.Tensors(iRemove, :) = [];
+        end        
+        % Find vertices to remove
+        nVert = size(FemMat.Vertices, 1);
+        iVertCut = setdiff(1:nVert, unique(FemMat.Elements(:)));
+        % Re-numbering matrix
+        iVertKept = setdiff(1:nVert, iVertCut);
+        iVertMap = zeros(1, nVert);
+        iVertMap(iVertKept) = 1:length(iVertKept);
+        % Remove vertices
+        FemMat.Vertices(iVertCut,:) = [];
+        % Renumber vertices in elements list
+        FemMat.Elements = iVertMap(FemMat.Elements);
     end
 elseif strcmp(dnModality,'meeg') && (sum(cfg.FemSelect) ~= length(unique(FemMat.Tissue)))
     errMsg = 'Reduced head model cannot be used when computing MEG+EEG simultaneously.';


### PR DESCRIPTION
Hi, 

This is related to the previous discussion with the introduction of the anisotropy computation, 

This PR contains part of code that removes the unused vertices, elements, and tensors from the femmat head model. 

This part of the code is exactly the same as the one that we have used to resect the neck, https://github.com/brainstorm-tools/brainstorm3/blob/3753b958571b6483e53f803e71d3049124cfbf45/toolbox/anatomy/fem_resect.m#L89

So, @ftadel it's up to you, we can merge this PR as it is or creates a sub-function that can be called by both functions.  

Best,  
