### PR TITLE
Revert recent change in mri_histogram that failed with some defaced MRIs

### DIFF
--- a/toolbox/anatomy/mri_histogram.m
+++ b/toolbox/anatomy/mri_histogram.m
@@ -228,8 +228,8 @@ switch(volumeType)
         %               - bg removed if : (nzero > 1) and (nnonzero > nzero)
         nzero = find(Histogram.fncY(2:length(Histogram.fncY)) ~= 0);
         nnonzero = find(Histogram.fncY((nzero(1)+1):length(Histogram.fncY)) == 0);
-        if (((nzero(1)>2) && ~isempty(nnonzero) && (nnonzero(1) > nzero(1))) ...
-            || ((Histogram.fncX(1) == 0) && (Histogram.fncY(1) / sum(Histogram.fncY) > 0.5)))
+        if (nzero(1)>2) && ~isempty(nnonzero) && (nnonzero(1) > nzero(1))
+            % || ((Histogram.fncX(1) == 0) && (Histogram.fncY(1) / sum(Histogram.fncY) > 0.5)))
             Histogram.bgLevel = nzero(1);
         % Else, background has not been removed yet
         % If there is less than two maxima : use the default background threshold

--- a/toolbox/anatomy/tess_isohead.m
+++ b/toolbox/anatomy/tess_isohead.m
@@ -67,7 +67,7 @@ end
 %% ===== ASK PARAMETERS =====
 % Ask user to set the parameters if they are not set
 if (nargin < 4) || isempty(erodeFactor) || isempty(nVertices)
-    res = java_dialog('input', {'Number of vertices [integer]:', 'Erode factor [0,1,2,3]:', 'Fill holes factor [0,1,2,3]:', 'Background intensity threshold:'}, 'Generate head surface', [], {'10000', '0', '2', num2str(sMri.Histogram.bgLevel)});
+    res = java_dialog('input', {'Number of vertices [integer]:', 'Erode factor [0,1,2,3]:', 'Fill holes factor [0,1,2,3]:', 'Background threshold (determined from MRI histogram):'}, 'Generate head surface', [], {'10000', '0', '2', num2str(sMri.Histogram.bgLevel)});
     % If user cancelled: return
     if isempty(res)
         return
@@ -77,6 +77,9 @@ if (nargin < 4) || isempty(erodeFactor) || isempty(nVertices)
     erodeFactor = str2num(res{2});
     fillFactor  = str2num(res{3});
     bgLevel     = str2num(res{4});
+    if isempty(bgLevel)
+        bgLevel = sMri.Histogram.bgLevel;
+    end
 else
     bgLevel = sMri.Histogram.bgLevel;
 end

--- a/toolbox/gui/view_mri_histogram.m
+++ b/toolbox/gui/view_mri_histogram.m
@@ -1,4 +1,4 @@
-function hFig = view_mri_histogram( MriFile )
+function hFig = view_mri_histogram( MriFile, Recompute )
 % VIEW_MRI_HISTOGRAM: Compute and view the histogram of a brainstorm MRI.
 %
 % USAGE:  hFig = view_mri_histogram( MriFile );
@@ -25,8 +25,11 @@ function hFig = view_mri_histogram( MriFile )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2006-2010
+% Authors: Francois Tadel, 2006-2010, Marc Lalancette 2020
 
+if nargin < 2 || isempty(Recompute)
+    Recompute = false;
+end
 %% ===== COMPUTE HISTOGRAM =====
 % Display progress bar
 bst_progress('start', 'View MRI historgram', 'Computing histogram...');
@@ -35,7 +38,7 @@ warning off
 MRI = load(MriFile, 'Histogram');
 warning on
 % Histogram not computed yet
-if ~isfield(MRI, 'Histogram') || isempty(MRI.Histogram)
+if Recompute || ~isfield(MRI, 'Histogram') || isempty(MRI.Histogram)
     % Load full MRI
     MRI = load(MriFile);
     % Compute histogram
@@ -43,6 +46,10 @@ if ~isfield(MRI, 'Histogram') || isempty(MRI.Histogram)
     % Save histogram
     s.Histogram = Histogram;
     bst_save(MriFile, s, 'v7', 1);
+    if Recompute
+        % Force reload next time.
+        bst_memory('UnloadMri', MriFile);
+    end
 else
     Histogram = MRI.Histogram;
 end
@@ -93,8 +100,8 @@ ylim(yLimits);
 % Display background and white matter thresholds
 line([Histogram.bgLevel, Histogram.bgLevel], yLimits, 'Color','b');
 line([Histogram.whiteLevel, Histogram.whiteLevel], yLimits, 'Color','y');
-h = legend('MRI hist.','Smoothed hist.','Cumulated hist.','Maxima','Minima',...
-    'Grey m thresh.','White m thresh.');
+h = legend('MRI hist.','Smoothed hist.','Cumulative hist.','Maxima','Minima',...
+    'Scalp or grey m thresh.','White m thresh.');
 set(h, 'FontSize',  bst_get('FigFont'), ...
        'FontUnits', 'points');
 


### PR DESCRIPTION
As described [here](https://neuroimage.usc.edu/forums/t/brainstorm-generate-head-surface-fails/20166/13), removed 50% limit for detecting "already removed background" as this failed in tutorials with defaced MRIs.

I also changed the label for the new option as it wasn't clear that the displayed value was the default automatically calculated one.  Fixed to avoid error when this new field is left empty, though it can still give an error on a value to large.

Added "Recompute" option in view histogram function, so that one can easily fix this issue without having to re-import files:
view_mri_histogram(MriFile, true)

![image](https://user-images.githubusercontent.com/31040756/88979935-a266ef80-d290-11ea-86f6-d57e3fb5c136.png)
(Image for updating [the tutorial](https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer) once merged.)