### PR TITLE
stop openmeeg LF computation if dipoles are outside of the innerskull

### DIFF
--- a/toolbox/forward/bst_openmeeg.m
+++ b/toolbox/forward/bst_openmeeg.m
@@ -284,11 +284,12 @@ for i = 1:length(OPTIONS.BemFiles)
     iDipInside = find(~inpolyhd(vDipoles, vInner, TessMat.Faces));
     if ~isempty(iDipInside)
         errMsg = sprintf(['Some dipoles are outside the BEM layers (%d dipoles).\n' ...
-                          'The leadfield for these dipoles is probably incorrect.\n\n'], length(iDipInside));
+                          'The leadfield for these dipoles could be incorrect.\n\n'], length(iDipInside));
         if strcmpi(OPTIONS.HeadModelType, 'surface')
             errMsg = [errMsg, 'To fix the cortex surface:', 10, 'Right-click on the surface file > Force inside skull.'];
         end
         disp([10 'WARNING: ' errMsg 10]);
+        return
     end
 end
 % Write geometry file

--- a/toolbox/process/functions/process_fem_mesh.m
+++ b/toolbox/process/functions/process_fem_mesh.m
@@ -296,7 +296,7 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
     end
         
     % ===== LOAD/CUT T1 =====
-    if ismember(lower(OPTIONS.Method), {'brain2mesh', 'simnibs'})
+    if ismember(lower(OPTIONS.Method), {'brain2mesh', 'simnibs', 'roast'})
         sMriT1 = in_mri_bst(T1File);
         % Cut neck (below MNI coordinate below Z=Zneck)
         if (OPTIONS.Zneck < 0)
@@ -313,7 +313,7 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
     end
 
     % ===== LOAD/CUT T2 =====
-    if ~isempty(T2File) && ismember(lower(OPTIONS.Method), {'brain2mesh', 'simnibs'})
+    if ~isempty(T2File) && ismember(lower(OPTIONS.Method), {'brain2mesh', 'simnibs', 'roast'})
         sMriT2 = in_mri_bst(T2File);
         % Cut neck (below MNI coordinate below Z=Zneck)
         if (OPTIONS.Zneck < 0)
@@ -449,6 +449,7 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
             % Orientation required for the FEM computation (at least with SimBio, maybe not for Duneuro)
             newelem = meshreorient(no, el(:,1:4));
             elem = [newelem elem(:,5)];
+            node = no; % need to updates the new list of nodes (it's wiered that it was working before)
             % Only tetra could be generated from this method
             OPTIONS.MeshType = 'tetrahedral';
 
@@ -655,8 +656,7 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
             end
             % Only tetra could be generated from this method
             OPTIONS.MeshType = 'tetrahedral';
-
-
+            
         case 'fieldtrip'
             % Segmentation process
             OPTIONS.layers     = {'white','gray','csf','skull','scalp'};
@@ -674,108 +674,88 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
                 return;
             end
 
-%         case 'roast'
-%             % Install ROAST if needed
-%             if ~exist('roast', 'file')
-%                 errMsg = InstallRoast(isInteractive);
-%                 if ~isempty(errMsg) || ~exist('roast', 'file')
-%                     return;
-%                 end
-%             end
-%             
-%             % === SAVE MRI AS NII ===
-%             bst_progress('setimage', 'logo_roast.gif');
-%             % Create temporary folder for fieldtrip segmentation files
-%             roastDir = bst_fullfile(bst_get('BrainstormTmpDir'), 'roast');
-%             mkdir(roastDir);
-%             % Save MRI in .nii format
-%             T1Nii = bst_fullfile(roastDir, 'roastT1.nii');
-%             out_mri_nii(T1File, T1Nii);
-%             if ~isempty(T2File)
-%                 T2Nii = bst_fullfile(roastDir, 'roastT2.nii');
-%                 out_mri_nii(T2File, T2Nii);
-%             end
-% 
-%             % === CALL ROAST PIPELINE ===
-%             % Segmentation
-%             bst_progress('text', 'MRI Segmentation...');
-%             segment_by_roast(T1Nii, T2Nii);
-%             % Convert the roast output to fieltrip in order to use prepare mesh
-%             data = load_untouch_nii(bst_fullfile(roastDir, 'roast_T1orT2_masks.nii'));
-%             allMask = data.img; 
-%             % Getting the MRI data
-%             ft_defaults
-%             mri = ft_read_mri(T1Nii);
-%             % Define layers
-%             switch (OPTIONS.NbLayers)
-%                 case 3
-%                     white_mask = zeros(size(allMask)); white_mask(allMask == 1) = true;
-%                     gray_mask  = zeros(size(allMask)); gray_mask(allMask == 2) = true;
-%                     csf_mask   = zeros(size(allMask)); csf_mask(allMask == 3) = true;
-%                     brain_mask = white_mask + gray_mask + csf_mask;
-%                     bone_mask  = zeros(size(allMask)); bone_mask(allMask == 4) = true;
-%                     skin_mask  = zeros(size(allMask)); skin_mask(allMask == 5) = true;
-%                     segmentedmri.dim = size(skin_mask);
-%                     segmentedmri.transform = [];
-%                     segmentedmri.coordsys = 'ctf';
-%                     segmentedmri.unit = 'mm';
-%                     segmentedmri.brain = brain_mask;
-%                     segmentedmri.skull = bone_mask;
-%                     segmentedmri.scalp = skin_mask;
-%                     segmentedmri.transform = mri.transform;
-%                 case 5   % {'white', 'gray', 'csf', 'bone', 'skin', 'air'}
-%                     white_mask = zeros(size(allMask)); white_mask(allMask == 1) = true;
-%                     gray_mask  = zeros(size(allMask)); gray_mask(allMask == 2) = true;
-%                     csf_mask   = zeros(size(allMask)); csf_mask(allMask == 3) = true;
-%                     bone_mask  = zeros(size(allMask)); bone_mask(allMask== 4) = true;
-%                     skin_mask  = zeros(size(allMask)); skin_mask(allMask == 5) = true;
-%                     segmentedmri.dim = size(skin_mask);
-%                     segmentedmri.transform = [];
-%                     segmentedmri.coordsys = 'ctf';
-%                     segmentedmri.unit = 'mm';
-%                     segmentedmri.gray = gray_mask;
-%                     segmentedmri.white = white_mask;
-%                     segmentedmri.csf = csf_mask;
-%                     segmentedmri.skull = bone_mask;
-%                     segmentedmri.scalp = skin_mask;
-%                     segmentedmri.transform = mri.transform;
-%             end
-% 
-%             % Output mesh type
-%             switch (OPTIONS.MeshType)
-%                 case 'hexahedral'
-%                     % Mesh using fieldtrip tools
-%                     cfg        = [];
-%                     cfg.shift  = OPTIONS.NodeShift ;
-%                     cfg.method = 'hexahedral';
-%                     mesh = ft_prepare_mesh(cfg,segmentedmri);
-%                     % Visualisation : not for brainstorm ...
-%                     %TODO : work on brainstom function to display the mesh better than the current version
-%                     % convert the mesh to tetra in order to use plotmesh
-%                     [el,pos,id] = hex2tet(mesh.hex,mesh.pos,mesh.tissue,2);
-%                     elem = [el id];        clear el id
-%                     figure;
-%                     plotmesh(pos,elem,'x<50')
-%                     title('Mesh hexa with vox2hexa')
-%                     clear pos elem
-%                     % save as hexa ...
-%                     node = mesh.pos;
-%                     elem = [mesh.hex mesh.tissue];
-%                     %             %% convert the hexa to tetra (add the function hex2tet to the toolbox)
-%                     %             [el, node, id]=hex2tet(mesh.hex,mesh.pos,mesh.tissue,2);
-%                     %             elem = [el id];
-%                     %             clear el id
-%                 case 'tetrahedral'
-%                     % Mesh by iso2mesh
-%                     bst_progress('text', 'Mesh Generation...'); %
-%                     %TODO ... Load the mask and apply Johannes process to generate the cubic Mesh
-%                     % TODO : Add the T2 images to the segmenttion process.
-%                     [node,elem] = mesh_by_iso2mesh(T1Nii, T2Nii);
-%                     figure;
-%                     plotmesh(node,elem,'x<90')
-%                     title('Mesh tetra  with iso2mesh ')
-%             end
-
+        case 'roast'                      
+            disp(['FEM> T1 MRI: ' T1File]);
+            disp(['FEM> T2 MRI: ' T2File]);
+            % Install ROAST if needed
+            if ~exist('roast', 'file')
+                errMsg = InstallRoast(isInteractive);
+                if ~isempty(errMsg) || ~exist('roast', 'file')
+                    return;
+                end
+            end            
+            % ===== VERIFY FIDUCIALS IN T1 MRI =====
+            % If the SCS transformation is not defined: compute MNI transformation to get a default one
+            if isempty(sMriT1) || ~isfield(sMriT1, 'SCS') || ~isfield(sMriT1.SCS, 'NAS') || ~isfield(sMriT1.SCS, 'LPA') || ~isfield(sMriT1.SCS, 'RPA') || (length(sMriT1.SCS.NAS)~=3) || (length(sMriT1.SCS.LPA)~=3) || (length(sMriT1.SCS.RPA)~=3) || ~isfield(sMriT1.SCS, 'R') || isempty(sMriT1.SCS.R) || ~isfield(sMriT1.SCS, 'T') || isempty(sMriT1.SCS.T)
+                % Issue warning
+                bst_report('Warning', 'process_fem_mesh', [], 'Missing NAS/LPA/RPA: Computing the MNI transformation to get default positions.');
+                % Compute MNI transformation
+                [sMriT1, errNorm] = bst_normalize_mni(sMriT1);
+                % Handle errors
+                if ~isempty(errNorm)
+                    errMsg = ['Error trying to compute the MNI transformation: ' 10 errNorm 10 'Set the NAS/LPA/RPA fiducials manually.'];
+                    return;
+                end
+            end            
+            % === SAVE T1 MRI AS NII ===
+            bst_progress('setimage', 'logo_roast.gif');
+            bst_progress('text', 'Exporting MRI...');
+            % Empty temporary folder, otherwise it may reuse previous files in the folder
+            gui_brainstorm('EmptyTempFolder');
+            % Create temporary folder for fieldtrip segmentation files
+            roastDir = bst_fullfile(bst_get('BrainstormTmpDir'), 'roast');
+            mkdir(roastDir);
+            % Save MRI in .nii format
+            subjid = strrep(sSubject.Name, '@', '');
+            T1Nii = bst_fullfile(roastDir, [subjid 'T1.nii']);
+            out_mri_nii(sMriT1, T1Nii);
+            % Save T2 MRI in .nii format
+            if ~isempty(T2File)
+                T2Nii = bst_fullfile(roastDir, [subjid 'T2.nii']);
+                out_mri_nii(sMriT2, T2Nii);
+            else
+                T2Nii = [];
+            end
+            % === CALL ROAST PIPELINE ===
+            % Segmentation
+            bst_progress('text', 'MRI Segmentation & Mesh Generation...');
+% two independant function            
+%             segment_by_roast(T1Nii, T2Nii);            
+%             % Mesh by iso2mesh
+%             bst_progress('text', 'Mesh Generation...'); %
+%             [node,elem]  = mesh_by_iso2mesh(T1Nii, T2Nii);
+            % or call this full function ... wait francois inputs for
+            % modifications 
+            [node,elem]  = roast_GenerateHeadModel(T1Nii, T2Nii);
+            if isempty(elem)
+                errMsg = 'Mesh generation with roast failed.';
+                return;
+            end
+            % Remove unwanted tissues (label <= 0)
+            iRemove = find(elem(:,end) <= 0);
+            if ~isempty(iRemove)
+                elem(iRemove,:) = [];
+            end
+            % Relabel the air as skin (maybe in the future we may distinguish the aire? to check)
+            iAir = find(elem(:,end) > 5);
+            elem(iAir,:) = 5; 
+            % Name tissue labels
+            TissueLabels = {'white','gray','csf','skull','scalp'};
+            OPTIONS.MeshType = 'tetrahedral';
+            % convert node from VOX to SCS
+            [node, Transf] = cs_convert(sMriT1, 'voxel', 'scs', node(:,1:3));     
+            % Mesh check and repair
+            [no,el] = removeisolatednode(node,elem(:,1:4));
+            % Orientation required for the FEM computation (at least with SimBio, maybe not for Duneuro)
+            newelem = meshreorient(no, el(:,1:4));
+            elem = [newelem elem(:,5)];
+            node = no; % need to updates the new list            
+            % Read masks to database as tissues
+            MaskNii = file_find(roastDir, '*_masks.nii', 2, 1);
+            if ~isempty(MaskNii)
+                MaskFile = import_mri(iSubject, MaskNii, [], 0, 1, 'tissues');
+            end            
+            
         otherwise
             errMsg = ['Invalid method "' OPTIONS.Method '".'];
             return;
@@ -877,12 +857,12 @@ function ComputeInteractive(iSubject, iMris, BemFiles) %#ok<DEFNU>
             '<B>SimNIBS</B>:<BR>Call SimNIBS to segment and mesh the <B>T1</B> (and <B>T2</B>) <B>MRI</B>.<BR>' ...
             'SimNIBS must be installed on the computer first.<BR>' ...
             'Website: https://simnibs.github.io/simnibs<BR><BR>' ...
-            ... '<B>ROAST</B>:<BR>Call ROAST to segment and mesh the <B>T1</B> (and <B>T2</B>) MRI.<BR>' ...
-            ... 'ROAST is downloaded and installed automatically when needed.<BR><BR>'...
+             '<B>ROAST</B>:<BR>Call ROAST to segment and mesh the <B>T1</B> (and <B>T2</B>) MRI.<BR>' ...
+            'ROAST is downloaded and installed automatically when needed.<BR><BR>'...
             '<B>FieldTrip</B>:<BR>Call FieldTrip to segment and mesh the <B>T1</B> MRI.<BR>' ...
             'FieldTrip must be installed on the computer first.<BR>' ...
             'Website: http://www.fieldtriptoolbox.org/download<BR><BR>' ...
-            ], 'FEM mesh generation method', [], {'Iso2mesh','Brain2Mesh','SimNIBS','FieldTrip'}, 'Iso2mesh');
+            ], 'FEM mesh generation method', [], {'Iso2mesh','Brain2Mesh','SimNIBS','ROAST','FieldTrip'}, 'Iso2mesh');
         if isempty(res)
             return
         end
@@ -953,16 +933,9 @@ function ComputeInteractive(iSubject, iMris, BemFiles) %#ok<DEFNU>
             end
             OPTIONS.NodeShift = str2double(res);
             
-%         case 'roast'
-%             % Ask user for the mesh element type :
-%             [res, isCancel]  = java_dialog('question', [...
-%                 '<HTML><B>Hexahedral Mesh</B>:<BR> Use the hexa element for the mesh , <BR>' ...
-%                 '<B>Tetrahedral Mesh</B>:<BR> Use the tetra element for the mesh <BR>(experimental : converts the hexa to tetra)<BR>' ], ...
-%                 'Mesh type', [], {'hexahedral','tetrahedral'}, 'tetrahedral');
-%             if isCancel
-%                 return
-%             end
-%             OPTIONS.MeshType = res;
+        case 'roast'
+            % No extra options for now
+            OPTIONS.MeshType =  'tetrahedral';
     end
 
     % Open progress bar
@@ -986,91 +959,91 @@ end
 
 
 
-% %% ===== INSTALL ROAST =====
-% function errMsg = InstallRoast(isInteractive)
-%     % Initialize variables
-%     errMsg = [];
-%     curdir = pwd;
-%     % Download URL
-%     url = 'https://www.parralab.org/roast/roast-3.0.zip';
-% 
-%     % Check if already available in path
-%     if exist('roast', 'file')
-%         disp([10, 'ROAST path: ', bst_fileparts(which('roast')), 10]);
-%         return;
-%     end
-%     % Local folder where to install ROAST
-%     roastDir = bst_fullfile(bst_get('BrainstormUserDir'), 'roast');
-%     exePath = bst_fullfile(roastDir, 'roast-3.0', 'roast.m');
-%     % If dir doesn't exist in user folder, try to look for it in the Brainstorm folder
-%     if ~isdir(roastDir)
-%         roastDirMaster = bst_fullfile(bst_get('BrainstormHomeDir'), 'roast');
-%         if isdir(roastDirMaster)
-%             roastDir = roastDirMaster;
-%         end
-%     end
-% 
-%     % URL file defines the current version
-%     urlFile = bst_fullfile(roastDir, 'url');
-%     % Read the previous download url information
-%     if isdir(roastDir) && file_exist(urlFile)
-%         fid = fopen(urlFile, 'r');
-%         prevUrl = fread(fid, [1 Inf], '*char');
-%         fclose(fid);
-%     else
-%         prevUrl = '';
-%     end
-%     % If file doesnt exist: download
-%     if ~isdir(roastDir) || ~file_exist(exePath) || ~strcmpi(prevUrl, url)
-%         % If folder exists: delete
-%         if isdir(roastDir)
-%             file_delete(roastDir, 1, 3);
-%         end
-%         % Create folder
-%         res = mkdir(roastDir);
-%         if ~res
-%             errMsg = ['Error: Cannot create folder' 10 roastDir];
-%             return
-%         end
-%         % Message
-%         if isInteractive
-%             isOk = java_dialog('confirm', ...
-%                 ['ROAST is not installed on your computer (or out-of-date).' 10 10 ...
-%                 'Download and the latest version of ROAST?'], 'ROAST');
-%             if ~isOk
-%                 errMsg = 'Download aborted by user';
-%                 return;
-%             end
-%         end
-%         % Download file
-%         zipFile = bst_fullfile(roastDir, 'roast.zip');
-%         errMsg = gui_brainstorm('DownloadFile', url, zipFile, 'Download ROAST');
-%         % If file was not downloaded correctly
-%         if ~isempty(errMsg)
-%             errMsg = ['Impossible to download ROAST:' 10 errMsg1];
-%             return;
-%         end
-%         % Display again progress bar
-%         bst_progress('text', 'Installing ROAST...');
-%         % Unzip file
-%         cd(roastDir);
-%         unzip(zipFile);
-%         file_delete(zipFile, 1, 3);
-%         cd(curdir);
-%         % Save download URL in folder
-%         fid = fopen(urlFile, 'w');
-%         fwrite(fid, url);
-%         fclose(fid);
-%     end
-%     % If installed but not in path: add roast to path
-%     if ~exist('roast', 'file')
-%         addpath(bst_fileparts(exePath));
-%         disp([10, 'ROAST path: ', bst_fileparts(roastDir), 10]);
-%         % If the executable is still not accessible
-%     else
-%         errMsg = ['ROAST could not be installed in: ' roastDir];
-%     end
-% end
+%% ===== INSTALL ROAST =====
+function errMsg = InstallRoast(isInteractive)
+    % Initialize variables
+    errMsg = [];
+    curdir = pwd;
+    % Download URL
+    url = 'https://www.parralab.org/roast/roast-3.0.zip';
+
+    % Check if already available in path
+    if exist('roast', 'file')
+        disp([10, 'ROAST path: ', bst_fileparts(which('roast')), 10]);
+        return;
+    end
+    % Local folder where to install ROAST
+    roastDir = bst_fullfile(bst_get('BrainstormUserDir'), 'roast');
+    exePath = bst_fullfile(roastDir, 'roast-3.0', 'roast.m');
+    % If dir doesn't exist in user folder, try to look for it in the Brainstorm folder
+    if ~isdir(roastDir)
+        roastDirMaster = bst_fullfile(bst_get('BrainstormHomeDir'), 'roast');
+        if isdir(roastDirMaster)
+            roastDir = roastDirMaster;
+        end
+    end
+
+    % URL file defines the current version
+    urlFile = bst_fullfile(roastDir, 'url');
+    % Read the previous download url information
+    if isdir(roastDir) && file_exist(urlFile)
+        fid = fopen(urlFile, 'r');
+        prevUrl = fread(fid, [1 Inf], '*char');
+        fclose(fid);
+    else
+        prevUrl = '';
+    end
+    % If file doesnt exist: download
+    if ~isdir(roastDir) || ~file_exist(exePath) || ~strcmpi(prevUrl, url)
+        % If folder exists: delete
+        if isdir(roastDir)
+            file_delete(roastDir, 1, 3);
+        end
+        % Create folder
+        res = mkdir(roastDir);
+        if ~res
+            errMsg = ['Error: Cannot create folder' 10 roastDir];
+            return
+        end
+        % Message
+        if isInteractive
+            isOk = java_dialog('confirm', ...
+                ['ROAST is not installed on your computer (or out-of-date).' 10 10 ...
+                'Download and the latest version of ROAST?'], 'ROAST');
+            if ~isOk
+                errMsg = 'Download aborted by user';
+                return;
+            end
+        end
+        % Download file
+        zipFile = bst_fullfile(roastDir, 'roast.zip');
+        errMsg = gui_brainstorm('DownloadFile', url, zipFile, 'Download ROAST');
+        % If file was not downloaded correctly
+        if ~isempty(errMsg)
+            errMsg = ['Impossible to download ROAST:' 10 errMsg1];
+            return;
+        end
+        % Display again progress bar
+        bst_progress('text', 'Installing ROAST...');
+        % Unzip file
+        cd(roastDir);
+        unzip(zipFile);
+        file_delete(zipFile, 1, 3);
+        cd(curdir);
+        % Save download URL in folder
+        fid = fopen(urlFile, 'w');
+        fwrite(fid, url);
+        fclose(fid);
+    end
+    % If installed but not in path: add roast to path
+    if ~exist('roast', 'file')
+        addpath(bst_fileparts(exePath));
+        disp([10, 'ROAST path: ', bst_fileparts(roastDir), 10]);
+        % If the executable is still not accessible
+    else
+        errMsg = ['ROAST could not be installed in: ' roastDir];
+    end
+end
 
 
 %% ===== INSTALL ISO2MESH =====


### PR DESCRIPTION
Hi, 

just a small correction for the bst_openmeeg.m function, 
the message "Error: Some dipoles are outside the BEM layers" is displayed at the end of the computation, 
and sometimes this computation can be long. 
so it's can be much better to display this message before the computation, then the users can correct the cortex by the ** Right-click on the surface file > Force inside the skull ... as proposed by the original version. 

A+
