### PR TITLE
add option that remove the tensors matrix from FemMat structure by right click

### DIFF
--- a/toolbox/process/functions/process_fem_tensors.m
+++ b/toolbox/process/functions/process_fem_tensors.m
@@ -365,7 +365,20 @@ function ComputeInteractive(iSubject, FemFile) %#ok<DEFNU>
     bst_progress('stop');
 end
 
-
+function ClearTensors(FemFile)
+    bst_progress('start', 'FEM tensors', 'Clear conductivity tensors...');
+    bst_progress('text', 'Loading FEM head model...');
+    FemMat = load(FemFile);
+    bst_progress('text', 'Clear tensors...');
+    FemMat.Tensors = [];
+    bst_progress('text', 'Saving FEM head model ...');
+    % Add history entry
+    FemMat = bst_history('add', FemMat, 'process_fem_tensors', 'clear fem tensors');
+    % Save tensors to the FemFile
+    bst_save(FemFile, FemMat, 'v7');
+   % Close progress bar
+    bst_progress('stop');
+end
 
 %% =================================================================================
 %  === HELPER FUNCTIONS ============================================================

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1217,7 +1217,6 @@ switch (lower(action))
                         AddSeparator(jMenuFemDisp);
                         gui_component('MenuItem', jMenuFemDisp, [], 'Display as ellipses (FEM mesh)', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@view_fem_tensors, filenameFull, 'ellipse', [], filenameFull));
                         gui_component('MenuItem', jMenuFemDisp, [], 'Display as arrows (FEM mesh)', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@view_fem_tensors, filenameFull, 'arrow', [], filenameFull));
-                        AddSeparator(jMenuFemDisp);
                         gui_component('MenuItem', jPopup, [], 'Clear FEM tensors', IconLoader.ICON_DELETE, [], @(h,ev)bst_call(@process_fem_tensors, 'ClearTensors', filenameFull));
                     end
                 end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1217,6 +1217,8 @@ switch (lower(action))
                         AddSeparator(jMenuFemDisp);
                         gui_component('MenuItem', jMenuFemDisp, [], 'Display as ellipses (FEM mesh)', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@view_fem_tensors, filenameFull, 'ellipse', [], filenameFull));
                         gui_component('MenuItem', jMenuFemDisp, [], 'Display as arrows (FEM mesh)', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@view_fem_tensors, filenameFull, 'arrow', [], filenameFull));
+                        AddSeparator(jMenuFemDisp);
+                        gui_component('MenuItem', jPopup, [], 'Clear FEM tensors', IconLoader.ICON_DELETE, [], @(h,ev)bst_call(@process_fem_tensors, 'ClearTensors', filenameFull));
                     end
                 end
                 


### PR DESCRIPTION
Hi, 

Small and it can be a useful function that removes the FEM tensors from the head model.
It can speed the tests and also useful in the case to compare different models with 
differents conductivity (scalar, tensors).

![image](https://user-images.githubusercontent.com/37831900/90067217-9ec96480-dca3-11ea-8d05-0d53955cd21f.png)

Best, 
