### PR TITLE
add interactive option to view the tensors

### DIFF
--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1009,52 +1009,19 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                     if isempty(TimeSliderMutex) || ~TimeSliderMutex
                         panel_time('TimeKeyCallback', keyEvent);
                     end
-           % === 'UPARROW', 'DOWNARROW','SPACE' : change fem tensor view ===
-            case {'uparrow', 'downarrow','space'}
-                if ismember('shift', keyEvent.Modifier)
-                    % Get figure handles
-                    Handles = bst_figures('GetFigureHandles', hFig);
-                    s = Handles.TensorDisplay;
-                    if isempty(s)
-                        hTensorCut = [];
-                        return;
-                    end                    
-                    hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
-                    for ind = 1 : 2
-                        if ind == 1
-                            data = findobj(hAxes, '-depth', 1, 'Tag', 'TensorEllipses');
-                            if ~isempty(data)
-                                break;
-                            end
-                        end
-                        if ind == 2
-                            data = findobj(hAxes, '-depth', 1, 'Tag', 'TensorArrows');
-                        end
-                    end                         
-                    % get the data 
-                    sliceLocation = data.UserData(1);
-                    dim = data.UserData(2);
-                    isRelative = data.UserData(3);
-                    factor =  data.UserData(4);
-                    switchTensorMode =  data.UserData(5);
-                    % Delete previous slices
-                    delete(findobj(hAxes, '-depth', 1, 'Tag', 'TensorArrows'));
-                    % Delete previous slices
-                    delete(findobj(hAxes, '-depth', 1, 'Tag', 'TensorEllipses'));
-                    if strcmp(keyEvent.Key,'uparrow')
-                        factor = factor*1.2;
-                    end
-                    if strcmp(keyEvent.Key,'downarrow')
-                        factor = factor/1.2;
-                    end
-                    if strcmp(keyEvent.Key,'space')
-                        switchTensorMode = ~switchTensorMode;
-                    end
-                    hTensorCut = PlotTensorCut(hFig, sliceLocation, dim, isRelative,factor,switchTensorMode);
-                end                 
-                % === UP DOWN : Processed by Freq panel ===
+               % === UP, DOWN, SPACE: Frequency or Tensor mode ===
                 case {'uparrow', 'downarrow'}
-                    panel_freq('FreqKeyCallback', keyEvent);
+                    % If there are tensors displayed: update display
+                    Handles = bst_figures('GetFigureHandles', hFig);
+                    if ~isempty(Handles.TensorDisplay)
+                        PlotTensorCut(hFig, [], [], [], keyEvent.Key, []);
+                    % Up/Down: Process by Freq panel
+                    else
+                        panel_freq('FreqKeyCallback', keyEvent);
+                    end
+                % === SPACE: Toggle tensor display mode ===
+                case 'space'
+                    PlotTensorCut(hFig, [], [], [], [], 'toggle');
                 % === DATABASE NAVIGATOR ===
                 case {'f1', 'f2', 'f3', 'f4', 'f6'}
                     if ~isAlignFig 
@@ -1803,6 +1770,26 @@ function DisplayFigurePopup(hFig)
         jItem0.setSelected(MriOptions.UpsampleImage == 0);
         jItem1.setSelected(MriOptions.UpsampleImage == 4);
         jItem2.setSelected(MriOptions.UpsampleImage == 8);
+    end
+    
+    % ==== MENU: TENSORS DISPLAY ====
+    Handles = bst_figures('GetFigureHandles', hFig);
+    if ~isempty(Handles.TensorDisplay)
+        jMenuTensors = gui_component('Menu', jPopup, [], 'FEM tensors', IconLoader.ICON_FEM);
+        % Display mode
+        jItemEllipse = gui_component('radiomenuitem', jMenuTensors, [], 'Ellipses', [], [], @(h,ev)PlotTensorCut(hFig, [], [], [], [], 'ellipse'));
+        jItemEllipse.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0));
+        jItemArrows = gui_component('radiomenuitem', jMenuTensors, [], 'Arrows', [], [], @(h,ev)PlotTensorCut(hFig, [], [], [], [], 'arrow'));
+        jItemArrows.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0));
+        switch lower(Handles.TensorDisplay.DisplayMode)
+            case 'ellipse',  jItemEllipse.setSelected(1);
+            case 'arrow',    jItemArrows.setSelected(1);
+        end
+        jMenuTensors.addSeparator();  
+        jItemPlus = gui_component('radiomenuitem', jMenuTensors, [], 'Increase size', IconLoader.ICON_PLUS, [], @(h,ev)PlotTensorCut(hFig, [], [], [], 'uparrow', []));
+        jItemPlus.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0));
+        jItemMinus = gui_component('radiomenuitem', jMenuTensors, [], 'Decrease size', IconLoader.ICON_MINUS, [], @(h,ev)PlotTensorCut(hFig, [], [], [], 'downarrow', []));
+        jItemMinus.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0));
     end
     
     % ==== MENU: NAVIGATOR ====
@@ -4524,7 +4511,6 @@ function hFigFib = SelectFiberScouts(hFigConn, iScouts, Color, ColorOnly)
     
     % If fibers not yet assigned to atlas, do so now
     if isempty(FibMat.Scouts(1).ConnectFile) || ~ismember(TfInfo.FileName, {FibMat.Scouts.ConnectFile})
-        ScoutNames     = bst_figures('GetFigureHandleField', hFigConn, 'RowNames');
         ScoutCentroids = bst_figures('GetFigureHandleField', hFigConn, 'RowLocs');
         FibMat = fibers_helper('AssignToScouts', FibMat, TfInfo.FileName, ScoutCentroids);
         % Save in memory to avoid recomputing
@@ -4565,54 +4551,68 @@ end
 
 
 %% ===== PLOT TENSORS =====
-function hTensorCut = PlotTensorCut(hFig, sliceLocation, dim, isRelative,factor,switchTensorMode)
-    if nargin < 6
-        switchTensorMode = 0;
-    end
-    if nargin < 5
-        factor = 4 / 100;
-        switchTensorMode = 0;
-    end
+function hTensorCut = PlotTensorCut(hFig, CutPosition, CutDim, isRelative, Factor, DisplayMode)
+    hTensorCut = [];
     % Get figure handles
     Handles = bst_figures('GetFigureHandles', hFig);
-    s = Handles.TensorDisplay;
-    if isempty(s)
-        hTensorCut = [];
+    opt = Handles.TensorDisplay;
+    if isempty(opt)
         return;
     end
-    % Get axes
+    % Replace previous options with input parameters
+    if (nargin >= 6) && ~isempty(DisplayMode)
+        if isequal(DisplayMode, 'toggle')
+            if strcmp(opt.DisplayMode,'ellipse')
+                opt.DisplayMode = 'arrow';
+            else
+                opt.DisplayMode = 'ellipse';
+            end
+        else
+            opt.DisplayMode = DisplayMode;
+        end
+    end
+    if (nargin >= 5) && ~isempty(Factor)
+        if isequal(Factor, 'uparrow')
+            opt.Factor = opt.Factor * 1.2;
+        elseif isequal(Factor, 'downarrow')
+            opt.Factor = opt.Factor / 1.2;
+        else
+            opt.Factor = Factor;
+        end
+    end
+    if (nargin >= 4) && ~isempty(isRelative)
+        opt.isRelative = isRelative;
+    end
+    if (nargin >= 3) && ~isempty(CutDim)
+        opt.CutDim = CutDim;
+    end
+    if (nargin >= 2) && ~isempty(CutPosition)
+        opt.CutPosition = CutPosition;
+    else
+        CutPosition = [];
+    end
+    
+    % Delete previous slices
     hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
-    if isempty(hAxes)
-        return;
-    end
+    delete(findobj(hAxes, '-depth', 1, 'Tag', 'TensorEllipses'));
+    delete(findobj(hAxes, '-depth', 1, 'Tag', 'TensorArrows'));
+    
     % Convert relative slice to absolute
-    if isRelative && nargin  < 5
+    if opt.isRelative && ~isempty(CutPosition)
         TessInfo = getappdata(hFig, 'Surface');
         Vertices = get(TessInfo(1).hPatch, 'Vertices');
         % Compute mean and max of the coordinates
-        meanVertx = mean(Vertices(:,dim), 1);
-        maxVertx  = max(abs(Vertices(:,dim)), [], 1);
+        meanVertx = mean(Vertices(:, opt.CutDim), 1);
+        maxVertx  = max(abs(Vertices(:, opt.CutDim)), [], 1);
         % Limit values
-        sliceLocation = sliceLocation .* maxVertx + meanVertx;
+        opt.CutPosition = opt.CutPosition .* maxVertx + meanVertx;
     end
     % Find elements in the current cut
-    iElemCut = find(abs(s.ElemCenterAnat(:,dim) - sliceLocation) < s.tol);
-    % Scaling tensor object size
-    %factor = 4 / 1000; % 4=optimal value for the SCS coordinates, 1000=display S/m values at a millimeter scale
+    iElemCut = find(abs(opt.ElemCenterAnat(:,opt.CutDim) - opt.CutPosition) < opt.tol);
 
     % Different display modes
-    if switchTensorMode
-        if strcmp(s.DisplayMode,'ellipse')
-            s.DisplayMode = 'arrow';
-        else
-            s.DisplayMode = 'ellipse';
-        end
-    end
-
-    switch lower(s.DisplayMode)
+    switch lower(opt.DisplayMode)
         case 'ellipse'
-            % Delete previous slices
-            delete(findobj(hAxes, '-depth', 1, 'Tag', 'TensorEllipses'));
             % Define ellipse geometry
             nVert = 32;
             [sphereVertex, sphereFaces] = tess_sphere(nVert);
@@ -4620,17 +4620,17 @@ function hTensorCut = PlotTensorCut(hFig, sliceLocation, dim, isRelative,factor,
             tensorFaces = repmat(sphereFaces, length(iElemCut), 1) + ...
                 repmat(reshape(repmat((0:length(iElemCut)-1)*nVert, size(sphereFaces,1), 1), [], 1), 1, 3);
             % Assemble colors: abs([v(2,1) v(1,1) v(3,1)])
-            tensorColor = reshape(repmat(abs(s.Tensors(iElemCut,[2,1,3]))', size(sphereFaces,1), 1), 3, [])';
+            tensorColor = reshape(repmat(abs(opt.Tensors(iElemCut,[2,1,3]))', size(sphereFaces,1), 1), 3, [])';
             % Assemble all tensors ellipsoids
             tensorVertices = repmat(sphereVertex, length(iElemCut), 1);
             for i = 1:length(iElemCut)
                 iVertSph = ((i-1) * nVert + 1) : i*nVert;
                 % Scaling
-                tensorVertices(iVertSph,:) = bst_bsxfun(@times, tensorVertices(iVertSph,:), s.Tensors(iElemCut(i), 10:12) .* factor);
+                tensorVertices(iVertSph,:) = bst_bsxfun(@times, tensorVertices(iVertSph,:), opt.Tensors(iElemCut(i), 10:12) .* opt.Factor);
                 % Rotation
-                tensorVertices(iVertSph,:) = (reshape(s.Tensors(iElemCut(i), 1:9),3,3) * tensorVertices(iVertSph,:)')';
+                tensorVertices(iVertSph,:) = (reshape(opt.Tensors(iElemCut(i), 1:9),3,3) * tensorVertices(iVertSph,:)')';
                 % Translation
-                tensorVertices(iVertSph,:) = bst_bsxfun(@plus, tensorVertices(iVertSph,:), s.ElemCenter(iElemCut(i),:));
+                tensorVertices(iVertSph,:) = bst_bsxfun(@plus, tensorVertices(iVertSph,:), opt.ElemCenter(iElemCut(i),:));
             end
             % Plot tensors
             hTensorCut = patch(...
@@ -4645,30 +4645,30 @@ function hTensorCut = PlotTensorCut(hFig, sliceLocation, dim, isRelative,factor,
                 'SpecularStrength', 0, ...
                 'FaceLighting',     'gouraud', ...
                 'Tag',              'TensorEllipses', ...
-                'UserData', [sliceLocation, dim, isRelative, factor, switchTensorMode],...
                 'Parent',           hAxes);
 
         case 'arrow'
-            % Delete previous slices
-            delete(findobj(hAxes, '-depth', 1, 'Tag', 'TensorArrows'));
             % Assemble colors: abs([v(2,1) v(1,1) v(3,1)])
-            tensorColor = reshape(repmat(abs(s.Tensors(iElemCut,[2,1,3]))', 2, 1), 3, [])';
+            tensorColor = reshape(repmat(abs(opt.Tensors(iElemCut,[2,1,3]))', 2, 1), 3, [])';
             % Vertices: Segments from element centers in the direction of the tensor
-            vertArrows = [s.ElemCenter(iElemCut,:)'; ...
-                s.ElemCenter(iElemCut,:)' + factor .* s.Tensors(iElemCut, 10:12)' .* s.Tensors(iElemCut, 1:3)'];
+            vertArrows = [opt.ElemCenter(iElemCut,:)'; ...
+                opt.ElemCenter(iElemCut,:)' + opt.Factor .* opt.Tensors(iElemCut, 10:12)' .* opt.Tensors(iElemCut, 1:3)'];
             % Display arrows
             hTensorCut = patch(...
-                'Vertices', reshape(vertArrows, 3, [])', ...
-                'Faces', [(1:2:2*length(iElemCut))', (2:2:2*length(iElemCut))'], ...
+                'Vertices',         reshape(vertArrows, 3, [])', ...
+                'Faces',            [(1:2:2*length(iElemCut))', (2:2:2*length(iElemCut))'], ...
                 'LineWidth',        1, ...
                 'FaceVertexCData',  tensorColor, ...
                 'FaceColor',       'none', ...
                 'EdgeColor',       'flat', ...
                 'MarkerFaceColor', 'none', ...
                 'Tag',              'TensorArrows', ...
-                'UserData', [sliceLocation, dim, isRelative, factor, switchTensorMode],...
                 'Parent',           hAxes);
         otherwise
             error('Invalid display mode.');
-end
+    end
+    
+    % Update figure handles
+    Handles.TensorDisplay = opt;
+    bst_figures('SetFigureHandles', hFig, Handles);
 end

--- a/toolbox/gui/view_fem_tensors.m
+++ b/toolbox/gui/view_fem_tensors.m
@@ -135,6 +135,17 @@ end
 % Set application data
 setappdata(hFig, 'SubjectFile',  SubjectFile);
 
+%% ===== DISPLAY ANATOMY =====
+if isNewFig
+    switch (AnatType)
+        case 'subjectimage'
+            view_mri_3d(AnatFile, [], 0.7, hFig);           
+        case 'fem'
+            alphaLayer = zeros(length(FemMat.TissueLabels));
+            alphaLayer(iTissues) = 0.5;
+            view_surface_fem(AnatFile, alphaLayer, [], [], hFig);
+    end
+end
 
 %% ===== LOAD FEM TENSORS =====
 % Display progress bar
@@ -160,7 +171,7 @@ nElem = length(iElemTissue);
 nMesh = size(FemMat.Elements, 2);
 TensorDisplay.ElemCenter = zeros(nElem, 3);
 for i = 1:3
-    TensorDisplay.ElemCenter(:,i) = sum(reshape(FemMat.Vertices(FemMat.Elements(iElemTissue,:),i), nElem, nMesh)')' / nMesh;
+    TensorDisplay.ElemCenter(:,i) = sum(reshape(FemMat.Vertices(FemMat.Elements(iElemTissue,:),i), nElem, nMesh), 2) / nMesh;
 end
 % Compute average distance between element center and vertices
 TensorDisplay.tol = 0.5 .* sqrt(mean(sum(bst_bsxfun(@minus, FemMat.Vertices(FemMat.Elements(iElemTissue(1:10:end),1),:), TensorDisplay.ElemCenter(1:10:end,:)) .^ 2, 2)));
@@ -172,23 +183,16 @@ end
 TensorDisplay.ElemCenterAnat = cs_convert(sMri, 'scs', CoordSystem, TensorDisplay.ElemCenter);
 % Save display mode
 TensorDisplay.DisplayMode = DisplayMode;
+% Scaling factor for tensor object size
+TensorDisplay.Factor = 4 / 100;
+% Initialize other properties
+TensorDisplay.CutPosition = [];
+TensorDisplay.CutDim = [];
+TensorDisplay.isRelative = [];
 % Save display info in figure handles
 Handles = bst_figures('GetFigureHandles', hFig);
 Handles.TensorDisplay = TensorDisplay;
 bst_figures('SetFigureHandles', hFig, Handles);
-
-
-%% ===== DISPLAY ANATOMY =====
-if isNewFig
-    switch (AnatType)
-        case 'subjectimage'
-            view_mri_3d(AnatFile, [], 0.7, hFig);           
-        case 'fem'
-            alphaLayer = zeros(length(FemMat.TissueLabels));
-            alphaLayer(iTissues) = 0.5;
-            view_surface_fem(AnatFile, alphaLayer, [], [], hFig);
-    end
-end
 
 
 %% ===== UPDATE INTERFACE =====
@@ -220,6 +224,3 @@ if isProgress
     drawnow
     bst_progress('stop');
 end
-
-
-


### PR DESCRIPTION
New option to view the tensors,
when the tensors are displayed either on the MRI or the Mesh,
-> Shift + uparrow ==> increase the size of the ellipsoid or the line
-> Shift + downarrow==> decrease the size of the ellipsoid or the line
-> Shift + space ==> switch from ellipsoids view to lines and inversely
