### PR TITLE
Adding constrained optimization for Matlab FOOOF and visualization tools in Brainstorm for frequency-wise error

### DIFF
--- a/toolbox/gui/figure_spectrum.m
+++ b/toolbox/gui/figure_spectrum.m
@@ -1073,7 +1073,7 @@ function UpdateFigurePlot(hFig, isForced)
                  case 'peaks'
                      TF(chan,1,i_model) = GlobalData.DataSet(iDS).Timefreq.Options.FOOOF.data(chan).FOOOF.peak_fit;
                  case 'error'
-                     TF(chan,1,i_model) = GlobalData.DataSet(iDS).Timefreq.Options.FOOOF.stats(chan).frequency_wise_error;
+                     TF(chan,1,i_model) = 10.^(GlobalData.DataSet(iDS).Timefreq.Options.FOOOF.stats(chan).frequency_wise_error);
              end
              % Apply requested function to measure
              switch TfInfo.Function

--- a/toolbox/gui/figure_spectrum.m
+++ b/toolbox/gui/figure_spectrum.m
@@ -1072,6 +1072,8 @@ function UpdateFigurePlot(hFig, isForced)
                      TF(chan,1,i_model) = GlobalData.DataSet(iDS).Timefreq.Options.FOOOF.data(chan).FOOOF.ap_fit;
                  case 'peaks'
                      TF(chan,1,i_model) = GlobalData.DataSet(iDS).Timefreq.Options.FOOOF.data(chan).FOOOF.peak_fit;
+                 case 'error'
+                     TF(chan,1,i_model) = GlobalData.DataSet(iDS).Timefreq.Options.FOOOF.stats(chan).frequency_wise_error;
              end
              % Apply requested function to measure
              switch TfInfo.Function

--- a/toolbox/gui/panel_display.m
+++ b/toolbox/gui/panel_display.m
@@ -77,6 +77,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         jRadioFModel   = gui_component('Radio', jPanelFOOOF, 'br', 'FOOOF Model',  jButtonGroup, '', @DisplayOptions_Callback);
         jRadioFAperiodic   = gui_component('Radio', jPanelFOOOF, 'br', 'Aperiodic only', jButtonGroup, '', @DisplayOptions_Callback);
         jRadioFPeaks   = gui_component('Radio', jPanelFOOOF, 'br', 'Peaks only', jButtonGroup, '', @DisplayOptions_Callback);
+        jRadioFError = gui_component('Radio', jPanelFOOOF, 'br', 'Frequency-wise error', jButtonGroup, '', @DisplayOptions_Callback);
     jPanelNew.add(jPanelFOOOF);
     
     % ===== PAC: PAC/FLOW/FHIGH =====
@@ -184,6 +185,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
     jRadioFModel.setEnabled(0);
     jRadioFAperiodic.setEnabled(0);
     jRadioFPeaks.setEnabled(0);
+    jRadioFError.setEnabled(0);
     
     % Create the BstPanel object that is returned by the function
     % => constructor BstPanel(jHandle, panelName, sControls)
@@ -203,10 +205,11 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
                                   'jRadioFunMag',           jRadioFunMag, ...
                                   'jRadioFunLog',           jRadioFunLog, ...
                                   'jRadioFunPhase',         jRadioFunPhase, ...
-                                  'jRadioFSpectrum',      jRadioFSpectrum, ...
-                                  'jRadioFModel',         jRadioFModel, ...
-                                  'jRadioFAperiodic',     jRadioFAperiodic, ...
-                                  'jRadioFPeaks',         jRadioFPeaks, ...
+                                  'jRadioFSpectrum',        jRadioFSpectrum, ...
+                                  'jRadioFModel',           jRadioFModel, ...
+                                  'jRadioFAperiodic',       jRadioFAperiodic, ...
+                                  'jRadioFPeaks',           jRadioFPeaks, ...
+                                  'jRadioFError',           jRadioFError, ...
                                   'jRadioPacMax',           jRadioPacMax, ...
                                   'jRadioPacFlow',          jRadioPacFlow, ...
                                   'jRadioPacFhigh',         jRadioPacFhigh, ...
@@ -333,6 +336,7 @@ function UpdatePanel(hFig)
         ctrl.jRadioFModel.setEnabled(0);
         ctrl.jRadioFAperiodic.setEnabled(0);
         ctrl.jRadioFPeaks.setEnabled(0);
+        ctrl.jRadioFError.setEnabled(0);
         ctrl.jCheckHideEdge.setEnabled(0);
         ctrl.jCheckHighRes.setEnabled(0);
         ctrl.jPanelSelect.setVisible(0);
@@ -373,6 +377,7 @@ function UpdatePanel(hFig)
         ctrl.jRadioFModel.setEnabled(0);
         ctrl.jRadioFAperiodic.setEnabled(0);
         ctrl.jRadioFPeaks.setEnabled(0);
+        ctrl.jRadioFError.setEnabled(0);
         ctrl.jCheckHideEdge.setEnabled(0);
         ctrl.jCheckHighRes.setEnabled(0);
         ctrl.jPanelFunction.setVisible(0);
@@ -435,11 +440,17 @@ function UpdatePanel(hFig)
                 ctrl.jRadioFModel.setEnabled(1);
                 ctrl.jRadioFAperiodic.setEnabled(1);
                 ctrl.jRadioFPeaks.setEnabled(1);
+                ctrl.jRadioFError.setEnabled(1);
                 switch TfInfo.FOOOFDisp
                     case 'spectrum', ctrl.jRadioFSpectrum.setSelected(1);
                     case 'model', ctrl.jRadioFModel.setSelected(1);
                     case 'aperiodic', ctrl.jRadioFAperiodic.setSelected(1);
                     case 'peaks', ctrl.jRadioFPeaks.setSelected(1);
+                    case 'error' 
+                        ctrl.jRadioFError.setSelected(1);
+                        ctrl.jRadioFunPower.setEnabled(1);
+                        ctrl.jRadioFunMag.setEnabled(0);
+                        ctrl.jRadioFunLog.setEnabled(0);
                 end
             else
                 ctrl.jRadioFSpectrum.setSelected(1);
@@ -447,6 +458,7 @@ function UpdatePanel(hFig)
                 ctrl.jRadioFModel.setEnabled(0);
                 ctrl.jRadioFAperiodic.setEnabled(0);
                 ctrl.jRadioFPeaks.setEnabled(0);
+                ctrl.jRadioFError.setEnabled(0);
             end                
         end
 
@@ -632,12 +644,26 @@ function sOptions = GetDisplayOptions()
     % Get FOOOF display specifics 
     if ctrl.jRadioFSpectrum.isSelected()
         sOptions.FOOOFDisp = 'spectrum';
+        ctrl.jRadioFunMag.setEnabled(1);
+        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFModel.isSelected()
         sOptions.FOOOFDisp = 'model';
+        ctrl.jRadioFunMag.setEnabled(1);
+        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFAperiodic.isSelected()
         sOptions.FOOOFDisp = 'aperiodic';
+        ctrl.jRadioFunMag.setEnabled(1);
+        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFPeaks.isSelected()
         sOptions.FOOOFDisp = 'peaks';
+        ctrl.jRadioFunMag.setEnabled(1);
+        ctrl.jRadioFunLog.setEnabled(1);
+    elseif ctrl.jRadioFError.isSelected()
+        sOptions.FOOOFDisp = 'error';
+        ctrl.jRadioFunPower.setSelected(1);
+        ctrl.jRadioFunMag.setEnabled(0);
+        ctrl.jRadioFunLog.setEnabled(0);
+        sOptions.Function = 'power';
     end
     
     % Hide edge effects / Resolution

--- a/toolbox/gui/panel_display.m
+++ b/toolbox/gui/panel_display.m
@@ -448,9 +448,9 @@ function UpdatePanel(hFig)
                     case 'peaks', ctrl.jRadioFPeaks.setSelected(1);
                     case 'error' 
                         ctrl.jRadioFError.setSelected(1);
-                        ctrl.jRadioFunPower.setEnabled(1);
+                        ctrl.jRadioFunPower.setEnabled(0);
                         ctrl.jRadioFunMag.setEnabled(0);
-                        ctrl.jRadioFunLog.setEnabled(0);
+                        ctrl.jRadioFunLog.setEnabled(1);
                 end
             else
                 ctrl.jRadioFSpectrum.setSelected(1);
@@ -644,26 +644,26 @@ function sOptions = GetDisplayOptions()
     % Get FOOOF display specifics 
     if ctrl.jRadioFSpectrum.isSelected()
         sOptions.FOOOFDisp = 'spectrum';
+        ctrl.jRadioFunPower.setEnabled(1);
         ctrl.jRadioFunMag.setEnabled(1);
-        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFModel.isSelected()
         sOptions.FOOOFDisp = 'model';
+        ctrl.jRadioFunPower.setEnabled(1);
         ctrl.jRadioFunMag.setEnabled(1);
-        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFAperiodic.isSelected()
         sOptions.FOOOFDisp = 'aperiodic';
+        ctrl.jRadioFunPower.setEnabled(1);
         ctrl.jRadioFunMag.setEnabled(1);
-        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFPeaks.isSelected()
         sOptions.FOOOFDisp = 'peaks';
+        ctrl.jRadioFunPower.setEnabled(1);
         ctrl.jRadioFunMag.setEnabled(1);
-        ctrl.jRadioFunLog.setEnabled(1);
     elseif ctrl.jRadioFError.isSelected()
         sOptions.FOOOFDisp = 'error';
-        ctrl.jRadioFunPower.setSelected(1);
+        ctrl.jRadioFunLog.setSelected(1);
+        ctrl.jRadioFunPower.setEnabled(0);
         ctrl.jRadioFunMag.setEnabled(0);
-        ctrl.jRadioFunLog.setEnabled(0);
-        sOptions.Function = 'power';
+        sOptions.Function = 'log';
     end
     
     % Hide edge effects / Resolution

--- a/toolbox/process/functions/process_fooof.m
+++ b/toolbox/process/functions/process_fooof.m
@@ -233,7 +233,7 @@ function [fs, fg] = FOOOF_matlab(TF, Freqs, opt)
         % Fit peaks
         [peak_pars, pti] = fit_peaks(fs, flat_spec, opt.max_peaks, opt.peak_threshold, opt.min_peak_height, ...
             opt.peak_width_limits/2, opt.proximity_threshold, opt.peak_type, opt.guess_weight,hasOptimToolbox);
-        if opt.thresh_after && ~hasOptimToolbox  % Check thresholding requirements are met again
+        if opt.thresh_after && ~hasOptimToolbox  % Check thresholding requirements are met for unbounded optimization
             peak_pars(peak_pars(:,2) < opt.min_peak_height,:)     = []; % remove peaks shorter than limit
             peak_pars(peak_pars(:,3) < opt.peak_width_limits(1)/2,:)  = []; % remove peaks narrower than limit
             peak_pars(peak_pars(:,3) > opt.peak_width_limits(2)/2,:)  = []; % remove peaks broader than limit

--- a/toolbox/process/functions/process_fooof.m
+++ b/toolbox/process/functions/process_fooof.m
@@ -147,9 +147,9 @@ function OutputFile = Run(sProcess, sInputs) %#ok<DEFNU>
         return
     end
     
-    hasOptimToolbox = 0;
-    if exist('fir2','file') == 2 && strcmp(implementation,'matlab')
-        hasOptimToolbox = 1;
+    hasOptimTools = 0;
+    if exist('fmincon') == 2 && strcmp(implementation,'matlab')
+        hasOptimTools = 1;
         disp("Using constrained optimization, Guess Weight ignored.")
     end
     
@@ -168,7 +168,7 @@ function OutputFile = Run(sProcess, sInputs) %#ok<DEFNU>
         % Switch between implementations
         switch (implementation)
             case 'matlab'   % Matlab standalone FOOOF
-                [FOOOF_freqs, FOOOF_data] = FOOOF_matlab(PsdMat.TF, PsdMat.Freqs, opt, hasOptimToolbox);  
+                [FOOOF_freqs, FOOOF_data] = FOOOF_matlab(PsdMat.TF, PsdMat.Freqs, opt, hasOptimTools);  
             case 'python'
                 opt.peak_type = 'gaussian';
                 [FOOOF_freqs, FOOOF_data] = process_fooof_py('FOOOF_python', PsdMat.TF, PsdMat.Freqs, opt);


### PR DESCRIPTION
Once these changes are approved, I will also add new sections to the tutorial to reflect them.

For visualizing frequency-wise error, it makes the most sense (based on how the values are stored) to view frequency-wise error in log10 space; it also makes no sense in other scales, so all other scaling options are disabled for figures currently displaying frequency-wise error.

Happy to answer any questions related to the purpose of each line change/addition!