### PR TITLE
Add the seeg/ecog support with DUNEuro FEM 

### DIFF
--- a/toolbox/forward/bst_duneuro.m
+++ b/toolbox/forward/bst_duneuro.m
@@ -64,7 +64,7 @@ end
 if isEeg
     EegLoc = cat(2, cfg.Channel(cfg.iEeg).Loc);
 else
-EegLoc = [];
+    EegLoc = [];
 end
 % Get MEG positions/orientations
 if isMeg
@@ -553,7 +553,7 @@ Gain = NaN * zeros(length(cfg.Channel), 3 * length(cfg.GridLoc));
 if isMeg
     Gain(cfg.iMeg,:) = GainMeg; 
 end 
-if isEeg 
+if isEeg
     Gain(cfg.iEeg,:) = GainEeg; 
 end
 if isEcog 

--- a/toolbox/forward/bst_duneuro.m
+++ b/toolbox/forward/bst_duneuro.m
@@ -79,9 +79,9 @@ if isMeg
         end
     end
 end
-% TODO : use the real position of the sensors unstead of the integration
+% TODO : MEG use the real position of the sensors unstead of the integration
 % points ==> Too much memory for low accuracies advantages ==> discuss with
-% ftadel and create git discussion + PR
+% ftadel and create git discussion + PR ==> will do it in different PR
 
 %% ===== HEAD MODEL =====
 % Load FEM mesh
@@ -382,9 +382,9 @@ fprintf(fid, 'geometry_adapted = %s\n', bool2str(cfg.GeometryAdapted));
 fprintf(fid, 'tolerance = %d\n', cfg.Tolerance);
 % [electrodes]
 if isEcog || isSeeg 
-  cfg.ElecType = 'closest_subentity_center';
   % Unstead to select the electrode on the outer surface,
   % it uses the nearest FEM node as an electrode location.
+  cfg.ElecType = 'closest_subentity_center';
 end
 if strcmp(dnModality, 'eeg') || strcmp(dnModality, 'meeg')
     fprintf(fid, '[electrodes]\n');
@@ -487,9 +487,8 @@ bst_progress('text', 'DUNEuro: Reading leadfield...');
 if (isEeg || isEcog || isSeeg) 
     GainEeg = in_duneuro_bin(fullfile(TmpDir, cfg.BstEegLfFile))';
 end
-% MEG
-% TODO : add an option to use the real sensors location without the
-% integrations points.
+
+%MEG
 if isMeg
     GainMeg = in_duneuro_bin(fullfile(TmpDir, cfg.BstMegLfFile))';
     
@@ -540,8 +539,6 @@ end
 if (isEeg || isEcog || isSeeg) 
     Gain(cfg.iEeg,:) = GainEeg; 
 end
-
-% TODO : check if this is possible wiht combined sEEG/EEG and EcoG
 
 %% ===== SAVE TRANSFER MATRIX ======
 disp('DUNEURO> TODO: Save transferOut.dat to database.')

--- a/toolbox/forward/bst_headmodeler.m
+++ b/toolbox/forward/bst_headmodeler.m
@@ -22,8 +22,8 @@ function [OPTIONS, errMessage] = bst_headmodeler(OPTIONS)
 %     .EEGMethod:  Method used to compute the forward model for EEG sensors.
 %         - 'eeg_3sphereberg' : EEG forward modeling with a set of 3 concentric spheres (Scalp, Skull, Brain/CSF) 
 %         - 'openmeeg'        : OpenMEEG forward model
-%     .SEEGMethod:    'openmeeg' only 
-%     .ECOGMethod:    'openmeeg' only
+%     .SEEGMethod:    'openmeeg' and 'duneuro'  
+%     .ECOGMethod:    'openmeeg' and 'duneuro' 
 %
 %     ======= METHODS OPTIONS =============================================
 %     OpenMEEG: see bst_openmeeg

--- a/toolbox/forward/bst_headmodeler.m
+++ b/toolbox/forward/bst_headmodeler.m
@@ -502,6 +502,16 @@ if ismember('duneuro', {OPTIONS.MEGMethod, OPTIONS.EEGMethod, OPTIONS.ECOGMethod
     bst_progress('setimage', 'logo_duneuro.png');
     % Run duneuro FEM computation
     [Gain_dn, errMessage] = bst_duneuro(OPTIONS);
+    % Comment in history field
+    strHistory = [strHistory, ' | ', sprintf('Fem head file: %s, |  Cortex file: %s, ',...
+                                                                                OPTIONS.FemFile, OPTIONS.CortexFile) ];
+    if ~OPTIONS.UseTensor
+        strHistory = [strHistory, ' | ', sprintf('FemCond: isotropic, %s', num2str(OPTIONS.FemCond))];
+    else
+        strHistory = [strHistory, ' | ', sprintf('FemCond: anisotropic, %s', 'check the tensor field within the Fem head file')];
+    end
+    strHistory = [strHistory, ' | ', sprintf('Fem source model: %s, type : %s, %s ',...
+                                                                                OPTIONS.SrcModel, OPTIONS.FemType, OPTIONS.SolverType) ];
     % Remove logo from progress bar
     bst_progress('removeimage');
     % If process crashed

--- a/toolbox/forward/bst_headmodeler.m
+++ b/toolbox/forward/bst_headmodeler.m
@@ -503,15 +503,13 @@ if ismember('duneuro', {OPTIONS.MEGMethod, OPTIONS.EEGMethod, OPTIONS.ECOGMethod
     % Run duneuro FEM computation
     [Gain_dn, errMessage] = bst_duneuro(OPTIONS);
     % Comment in history field
-    strHistory = [strHistory, ' | ', sprintf('Fem head file: %s, |  Cortex file: %s, ',...
-                                                                                OPTIONS.FemFile, OPTIONS.CortexFile) ];
+    strHistory = [strHistory, ' | ', sprintf('Fem head file: %s, |  Cortex file: %s, ', OPTIONS.FemFile, OPTIONS.CortexFile) ];
     if ~OPTIONS.UseTensor
         strHistory = [strHistory, ' | ', sprintf('FemCond: isotropic, %s', num2str(OPTIONS.FemCond))];
     else
         strHistory = [strHistory, ' | ', sprintf('FemCond: anisotropic, %s', 'check the tensor field within the Fem head file')];
     end
-    strHistory = [strHistory, ' | ', sprintf('Fem source model: %s, type : %s, %s ',...
-                                                                                OPTIONS.SrcModel, OPTIONS.FemType, OPTIONS.SolverType) ];
+    strHistory = [strHistory, ' | ', sprintf('Fem source model: %s, type : %s, %s ', OPTIONS.SrcModel, OPTIONS.FemType, OPTIONS.SolverType) ];
     % Remove logo from progress bar
     bst_progress('removeimage');
     % If process crashed

--- a/toolbox/forward/panel_headmodel.m
+++ b/toolbox/forward/panel_headmodel.m
@@ -104,6 +104,7 @@ function [bstPanelNew, panelName] = CreatePanel(isMeg, isEeg, isEcog, isSeeg, is
         % Combobox
         jComboMethodECOG = gui_component('ComboBox', jPanelMethod, 'tab hfill', [], [], [], @UpdateComment, []);
         jComboMethodECOG.addItem(BstListItem('openmeeg', '', 'OpenMEEG BEM', []));
+        jComboMethodECOG.addItem(BstListItem('duneuro', '', 'DUNEuro FEM', []));
         jComboMethodECOG.setSelectedIndex(0);
     else
         jCheckMethodECOG = [];
@@ -117,6 +118,7 @@ function [bstPanelNew, panelName] = CreatePanel(isMeg, isEeg, isEcog, isSeeg, is
         % Combobox
         jComboMethodSEEG = gui_component('ComboBox', jPanelMethod, 'tab hfill', [], [], [], @UpdateComment, []);
         jComboMethodSEEG.addItem(BstListItem('openmeeg', '', 'OpenMEEG BEM', []));
+        jComboMethodSEEG.addItem(BstListItem('duneuro', '', 'DUNEuro FEM', []));
         jComboMethodSEEG.setSelectedIndex(0);
     else
         jCheckMethodSEEG = [];

--- a/toolbox/process/functions/process_headmodel.m
+++ b/toolbox/process/functions/process_headmodel.m
@@ -66,11 +66,11 @@ function sProcess = GetDescription() %#ok<DEFNU>
     % Option: ECOG headmodel
     sProcess.options.ecog.Comment = '   - ECOG method:';
     sProcess.options.ecog.Type    = 'combobox';
-    sProcess.options.ecog.Value   = {2, {'<none>', 'OpenMEEG BEM'}};
+    sProcess.options.ecog.Value   = {2, {'<none>', 'OpenMEEG BEM', 'DUNEuro FEM'}};
     % Option: SEEG headmodel
     sProcess.options.seeg.Comment = '   - SEEG method:';
     sProcess.options.seeg.Type    = 'combobox';
-    sProcess.options.seeg.Value   = {2, {'<none>', 'OpenMEEG BEM'}};
+    sProcess.options.seeg.Value   = {2, {'<none>', 'OpenMEEG BEM', 'DUNEuro FEM'}};
     % Options: OpenMEEG Options
     sProcess.options.openmeeg.Comment = {'panel_openmeeg', 'OpenMEEG options: '};
     sProcess.options.openmeeg.Type    = 'editpref';
@@ -126,6 +126,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         switch (sProcess.options.ecog.Value{1})
             case 1,  sMethod.ECOGMethod = '';
             case 2,  sMethod.ECOGMethod = 'openmeeg';   isOpenMEEG = 1;
+            case 3,  sMethod.ECOGMethod = 'duneuro';    isDuneuro = 1;
         end
     else
         sMethod.ECOGMethod = '';
@@ -135,6 +136,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         switch (sProcess.options.seeg.Value{1})
             case 1,  sMethod.SEEGMethod = '';
             case 2,  sMethod.SEEGMethod = 'openmeeg';   isOpenMEEG = 1;
+            case 3,  sMethod.SEEGMethod = 'duneuro';    isDuneuro = 1;
         end
     else
         sMethod.SEEGMethod = '';


### PR DESCRIPTION
Hi, 

This PR adds the possibility to use the DUNEuro computation for sEEG/ECoG from Brainstorm GUI. 
The main change is in the bst_duneuro function, where new parameters are included for the dn binaries.
 
The Duneuro computation is compared with the OpenMeeg in similar scenarios, and the results are satisfying. 

Best,
Takfarinas 