### PR TITLE
Waveclus update

### DIFF
--- a/toolbox/process/functions/process_spikesorting_waveclus.m
+++ b/toolbox/process/functions/process_spikesorting_waveclus.m
@@ -273,7 +273,8 @@ end
 function downloadAndInstallWaveClus()
     waveclusDir = bst_fullfile(bst_get('BrainstormUserDir'), 'waveclus');
     waveclusTmpDir = bst_fullfile(bst_get('BrainstormUserDir'), 'waveclus_tmp');
-    url = 'https://github.com/csn-le/wave_clus/archive/testing.zip';
+    url = 'https://github.com/csn-le/wave_clus/archive/master.zip';
+    
     % If folders exists: delete
     if isdir(waveclusDir)
         file_delete(waveclusDir, 1, 3);
@@ -309,7 +310,7 @@ function downloadAndInstallWaveClus()
     % Get parent folder of the unzipped file
     diropen = dir(fullfile(waveclusTmpDir, 'MATLAB*'));
     idir = find([diropen.isdir] & ~cellfun(@(c)isequal(c(1),'.'), {diropen.name}), 1);
-    newWaveclusDir = bst_fullfile(waveclusTmpDir, diropen(idir).name, 'wave_clus-testing');
+    newWaveclusDir = bst_fullfile(waveclusTmpDir, diropen(idir).name, 'wave_clus-master');
     % Move WaveClus directory to proper location
     file_move(newWaveclusDir, waveclusDir);
     % Delete unnecessary files


### PR DESCRIPTION
We used to use a fixed version of waveclus ever since we first introduced the spikesorter.
Now the updating will be done straight from the latest version of GitHub.

This might be risky in case something breaks compatibility from the Waveclus side.
However, traditionally the inputs-outputs are expected to remain the same and probably Brainstorm shouldn't be affected as is the case as of this push.