### PR TITLE
Add support XDG support for file explorer

### DIFF
--- a/toolbox/misc/bst_which.m
+++ b/toolbox/misc/bst_which.m
@@ -104,6 +104,12 @@ else
             system(['xterm -e "konqueror \"' filepath '\""']);
             return
         end
+        % Any X Desktop Group (XDG) compliant
+        ixXdg = system('which xdg-open');
+        if (ixXdg == 0)          
+            system(['xdg-open "' filepath '"']);
+            return
+        end     
         % Error
         error('No file manager found for your operating system.');
     end


### PR DESCRIPTION
For Linux OSs, the file explorer is called with the command `xdg-open`. 
With this, Brainstorm can use the preferred file explorer in any XGD compliant desktop environment.