### PR TITLE
bug correction, recompute the MEG location as a mean of the IP

### DIFF
--- a/toolbox/forward/bst_duneuro.m
+++ b/toolbox/forward/bst_duneuro.m
@@ -91,15 +91,17 @@ if isMeg
         for iChan = 1 : length(cfg.iMeg)
             group = MegChannels(MegChannels(:,1) == iChan,:);
             groupPositive = group(group(:,end)>0,:);
-            groupNegative = group(group(:,end)<0,:);
+            groupNegative = group(group(:,end)<0,:);            
             if ~isempty(groupPositive)
-                equivalentPositionPostive = sum(repmat(abs(groupPositive(:,end)),[1 3])  .* groupPositive(:,2:4));
+                %equivalentPositionPostive = sum(repmat(abs(groupPositive(:,end)),[1 3])  .* groupPositive(:,2:4));
+                equivalentPositionPostive = mean(groupPositive(:,2:4));
                 MegChannelsTemp = [MegChannelsTemp; iChan  equivalentPositionPostive groupPositive(1,5:7)  sum(groupPositive(:,end))];
             end
             if ~isempty(groupNegative)
-                equivalentPositionNegative = sum(repmat(abs(groupNegative(:,end)),[1 3])  .* groupNegative(:,2:4));
+                %equivalentPositionNegative = sum(repmat(abs(groupNegative(:,end)),[1 3])  .* groupNegative(:,2:4));
+                equivalentPositionNegative = mean(groupNegative(:,2:4));
                 MegChannelsTemp = [MegChannelsTemp; iChan  equivalentPositionNegative groupNegative(1,5:7)  sum(groupNegative(:,end))];
-            end 
+            end
         end
         MegChannels = MegChannelsTemp;
     end


### PR DESCRIPTION
Change the way to compute the position of the MEG sensors without the weights, in some case the weights of the gradiometers 
the error appears with the Neuromag gradiometer, the weights are not simply [0.5 0.5 -0.5 -0.5], but [29.76 29.76 -29.76 -29.76] ,
this correction o does not use the weights. 