### PR TITLE
Fix ignored scouts in process_henv1n

### DIFF
--- a/toolbox/process/functions/process_corr1n.m
+++ b/toolbox/process/functions/process_corr1n.m
@@ -151,7 +151,7 @@ function OPTIONS = GetConnectOptions(sProcess, sInputA) %#ok<DEFNU>
     % Connectivity type: [1xN] or [NxN]
     isConnNN = ismember(OPTIONS.ProcessName, {'process_corr1n', 'process_cohere1n', 'process_granger1n',...
         'process_spgranger1n', 'process_plv1n', 'process_corr1n_time', 'process_cohere1n_time',...
-        'process_pte1n', 'process_aec1n'});
+        'process_pte1n', 'process_aec1n', 'process_henv1n'});
     
     % === TIME WINDOW ===
     if isfield(sProcess.options, 'timewindow') && isfield(sProcess.options.timewindow, 'Value') && iscell(sProcess.options.timewindow.Value) && ~isempty(sProcess.options.timewindow.Value)

--- a/toolbox/process/functions/process_henv1n.m
+++ b/toolbox/process/functions/process_henv1n.m
@@ -108,8 +108,6 @@ function OutputFiles = Run(sProcess, sInputA) %#ok<DEFNU>
     if isempty(OPTIONS)
         return
     end
-    OPTIONS.TargetA = OPTIONS.TargetB;
-    OPTIONS.TargetB = [];
 
     % === Metric options
     OPTIONS.Method        = 'henv';


### PR DESCRIPTION
Fix bug in [process_henv1n](../blob/master/toolbox/process/functions/process_henv1n.m) that ignored the selected scouts.
Bug mentioned [here](../issues/142#issuecomment-782818111) (in #142) 