### PR TITLE
report an error when unable to connect to brainstorm server

### DIFF
--- a/toolbox/gui/gui_brainstorm.m
+++ b/toolbox/gui/gui_brainstorm.m
@@ -1645,6 +1645,7 @@ function status = CloneProble(bstDir)
                 bst_error('Invalid username or password.', 'Brainstorm login', 0);
             end
         catch
+            bst_error('Could not establish a secure connection to Brainstorm server', 'Brainstorm login', 0);
             status = 0;
         end
         bst_progress('stop');


### PR DESCRIPTION
This PR is here to display an error if, after the login, Brainstorm is unable to reach the Brainstorm server. 

I reset my brainstorm installation this morning to use another database, and after I was putting my login information, nothing was happening. The reason was that the send request was not working (see error below). I think it should be reported to the user. 

```
Error using matlab.net.http.RequestMessage/send (line 408)
Could not establish a secure connection to "neuroimage.usc.edu". The reason is "error:14090086:SSL
routines:ssl3_get_server_certificate:certificate verify failed". Check your certificate file
(/util/packages/matlab/R2017a/sys/certificates/ca/rootcerts.pem) for expired, missing or invalid certificates.

```


