### PR TITLE
Bugfix: Progress bar does not always hide

### DIFF
--- a/toolbox/core/bst_progress.m
+++ b/toolbox/core/bst_progress.m
@@ -152,8 +152,13 @@ if isempty(pBar)
     GlobalData.Program.ProgressBar = pBar;
 end
 
-% Linux: the dialog needs to be displayed for a short period before being hidden
+% Linux: need to print something on the command window (don't know why...)
 if strcmpi(commandName, 'stop') && ismember(computer('arch'), {'glnx86', 'glnxa64'})
+    drawnow();
+    fprintf(' ');
+    fprintf('\b');
+    drawnow();
+    % The dialog needs to be displayed for a short period before being hidden
     pause(0.05);
 end
 

--- a/toolbox/core/bst_progress.m
+++ b/toolbox/core/bst_progress.m
@@ -152,12 +152,9 @@ if isempty(pBar)
     GlobalData.Program.ProgressBar = pBar;
 end
 
-% Linux: need to print something on the command window (don't know why...)
+% Linux: the dialog needs to be displayed for a short period before being hidden
 if strcmpi(commandName, 'stop') && ismember(computer('arch'), {'glnx86', 'glnxa64'})
-    drawnow();
-    fprintf(' ');
-    fprintf('\b');
-    drawnow();
+    pause(0.05);
 end
 
 


### PR DESCRIPTION
Replaces the writing and erasing on the command window with a 50 ms delay.
Linux systems without this bug problem are not affected.
Bug reported for OpenJDK in https://bugs.openjdk.java.net/browse/JDK-6483868