### PR TITLE
[Cat12] Call spm_jobman('initcfg') before creating the batch file

### DIFF
--- a/toolbox/process/functions/process_segment_cat12.m
+++ b/toolbox/process/functions/process_segment_cat12.m
@@ -274,9 +274,22 @@ function [isOk, errMsg] = Compute(iSubject, iAnatomy, nVertices, isInteractive, 
         % Save modification on hard drive
         bst_save(file_fullpath(T1FileBst), sMri, 'v7');
     end
-
+    
+    
     % ===== CALL CAT12 SEGMENTATION =====
     bst_progress('text', '<HTML>Starting SPM batch... &nbsp;&nbsp;&nbsp;<FONT COLOR="#707070"><I>(see command window)</I></FONT>');
+    
+   % Switch to CAT12 expert mode
+    cat12('expert');
+    % Hide CAT12 figures
+    set([findall(0, 'Type', 'Figure', 'Tag', 'Interactive'), ...
+         findall(0, 'Type', 'Figure', 'Tag', 'CAT'), ...
+         findall(0, 'Type', 'Figure', 'Tag', 'Graphics')], 'Visible', 'off');
+     
+    % Initialize SPM batch
+    spm_jobman('initcfg');
+    
+    
     % Create SPM batch
     matlabbatch{1}.spm.tools.cat.estwrite.data = {NiiFile};
     matlabbatch{1}.spm.tools.cat.estwrite.nproc = 0;                % Blocking call to CAT12
@@ -350,14 +363,7 @@ function [isOk, errMsg] = Compute(iSubject, iAnatomy, nVertices, isInteractive, 
         matlabbatch{2}.spm.tools.cat.stools.surfextract.nproc = 0;  % Blocking call to CAT12
     end
 
-    % Switch to CAT12 expert mode
-    cat12('expert');
-    % Hide CAT12 figures
-    set([findall(0, 'Type', 'Figure', 'Tag', 'Interactive'), ...
-         findall(0, 'Type', 'Figure', 'Tag', 'CAT'), ...
-         findall(0, 'Type', 'Figure', 'Tag', 'Graphics')], 'Visible', 'off');
-    % Run SPM batch
-    spm_jobman('initcfg');
+
     spm_jobman('run',matlabbatch);
     % Close CAT12 figures
     close([findall(0, 'Type', 'Figure', 'Tag', 'Interactive'), ...


### PR DESCRIPTION
Hello Francois, 

it seems that in some case, matlabbatch (responsible for the function cfg_dep) is not in the matlab path before executing cfg_dep.

This folder is included in the path when calling spm_jobman('initcfg') (line 169 of spm_jobman) I therefore think it should be called before creating the cat12 batch

Regards, 
Edouard