### PR TITLE
scaling the MEG gain matrix

### DIFF
--- a/toolbox/forward/bst_duneuro.m
+++ b/toolbox/forward/bst_duneuro.m
@@ -592,6 +592,8 @@ end
 Gain = NaN * zeros(length(cfg.Channel), 3 * length(cfg.GridLoc));
 if isMeg
     Gain(cfg.iMeg,:) = GainMeg; 
+    % scaling the MEG Gain matrix 
+    Gain(cfg.iMeg,:) = GainMeg/1000; 
 end 
 if (isEeg || isEcog || isSeeg) 
     Gain(cfg.iEeg,:) = GainEeg; 


### PR DESCRIPTION
This is an observed problem with the amplitude units of the cortical activation when using the MEG FEM. 
when scaling the gain matrix by /1000 the units are corrected. 