### PR TITLE
improved version of iso2mesh option

### DIFF
--- a/toolbox/process/functions/process_fem_mesh.m
+++ b/toolbox/process/functions/process_fem_mesh.m
@@ -55,7 +55,8 @@ function sProcess = GetDescription() %#ok<DEFNU>
                                        '<B>Brain2mesh</B>:<BR>Segment the <B>T1</B> (and <B>T2</B>) <B>MRI</B> with SPM12, mesh with Brain2Mesh<BR>', ...
                                        '<B>SimNIBS</B>:<BR>Call SimNIBS to segment and mesh the <B>T1</B> (and <B>T2</B>) <B>MRI</B>.', ...
                                        '<B>FieldTrip</B>:<BR> Call FieldTrip to create hexahedral mesh of the <B>T1 MRI</B>.'; ...
-                                       'iso2mesh', 'brain2mesh', 'simnibs', 'fieldtrip'};
+                                       '<B>Iso2mesh-2021</B>:<BR>Call iso2mesh (2021 version) to create a tetrahedral mesh from the <B>BEM surfaces</B><BR>',
+                                       'iso2mesh', 'brain2mesh', 'simnibs', 'fieldtrip','iso2mesh-2021'};
     sProcess.options.method.Type    = 'radio_label';
     sProcess.options.method.Value   = 'iso2mesh';
     % Iso2mesh options: 
@@ -135,7 +136,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     end
     % Method
     OPTIONS.Method = sProcess.options.method.Value;
-    if isempty(OPTIONS.Method) || ~ischar(OPTIONS.Method) || ~ismember(OPTIONS.Method, {'iso2mesh','brain2mesh','simnibs','fieldtrip'})
+    if isempty(OPTIONS.Method) || ~ischar(OPTIONS.Method) || ~ismember(OPTIONS.Method, {'iso2mesh','brain2mesh','simnibs','fieldtrip','iso2mesh-2021'})
         bst_report('Error', sProcess, [], 'Invalid method.');
         return
     end
@@ -331,6 +332,175 @@ function [isOk, errMsg] = Compute(iSubject, iMris, isInteractive, OPTIONS)
     
     % ===== GENERATE MESH =====
     switch lower(OPTIONS.Method)
+        % new version of the iso2mesh 
+        case 'iso2mesh-2021'
+          % Install iso2mesh if needed
+            if ~exist('iso2meshver', 'file') || ~isdir(bst_fullfile(bst_fileparts(which('iso2meshver')), 'doc'))
+                errMsg = InstallIso2mesh(isInteractive);
+                if ~isempty(errMsg) || ~exist('iso2meshver', 'file') || ~isdir(bst_fullfile(bst_fileparts(which('iso2meshver')), 'doc'))
+                    return;
+                end
+            end                    
+            % If surfaces are not passed in input: get default surfaces
+            if isempty(OPTIONS.BemFiles)
+                if ~isempty(sSubject.iScalp) && ~isempty(sSubject.iOuterSkull) && ~isempty(sSubject.iInnerSkull)
+                    OPTIONS.BemFiles = {...
+                        sSubject.Surface(sSubject.iInnerSkull).FileName, ...
+                        sSubject.Surface(sSubject.iOuterSkull).FileName, ...
+                        sSubject.Surface(sSubject.iScalp).FileName};
+                    TissueLabels = {'brain', 'skull', 'scalp'};
+                else
+                    errMsg = ['Method "' OPTIONS.Method '" requires three surfaces: head, inner skull and outer skull.' 10 ...
+                        'Create them with process "Generate BEM surfaces" first.'];
+                    return;
+                end
+            % If surfaces are given: get their labels and sort from inner to outer
+            else
+                % Get tissue label
+                for iBem = 1:length(OPTIONS.BemFiles)
+                    [sSubject, iSubject, iSurface] = bst_get('SurfaceFile', OPTIONS.BemFiles{iBem});
+                   
+                   % correct the labels to avoid error on the display (MNE surfaces labeles)
+                   label = sSubject.Surface(iSurface).Comment
+                   if  ~isempty(strfind(label, 'inner')) && ~isempty(strfind(label, 'skull'))
+                        label = 'csf';
+                   end
+                   if  ~isempty(strfind(label, 'outer')) && ~isempty(strfind(label, 'skull'))
+                       label = 'skull';
+                   end
+                   if  ~isempty(strfind(label, 'inner')) && ~isempty(strfind(label, 'skin'))
+                       label = 'skull'; %
+                   end
+                   if  ~isempty(strfind(label, 'outer')) && ~isempty(strfind(label, 'skin'))
+                       label = 'skin'; % or 'scalp'
+                   end                    
+                    TissueLabels{iBem} = label;
+                end        
+            end      
+            % Load surfaces
+            bst_progress('text', 'Loading surfaces...');
+            bemMerge = {};
+            disp(' ');
+            nBem = length(OPTIONS.BemFiles);
+            distance_in = zeros(1,nBem);
+            for iBem = 1:nBem                               
+                disp(sprintf('FEM> %d. %5s: %s', iBem, TissueLabels{iBem}, OPTIONS.BemFiles{iBem}));        
+                BemMat = in_tess_bst(OPTIONS.BemFiles{iBem});
+                bemMerge = cat(2, bemMerge, BemMat.Vertices, BemMat.Faces);
+                % compute the distances
+                if iBem ==1
+                    center_inner = mean(bemMerge{1}, 1);
+                end
+                faceList = unique(BemMat.Faces);
+                nodeList = BemMat.Vertices(faceList,:);
+                % Find the largest distance between two point
+                maxYcoor = max(nodeList(:,2));
+                minYcoor = min(nodeList(:,2));
+                maxYpoint = [center_inner(1) maxYcoor center_inner(3)];
+                minYpoint = [center_inner(1) minYcoor center_inner(3)];
+                % Find the nearest node on the mesh and update
+                k = dsearchn(nodeList,[maxYpoint;minYpoint]);
+                maxYpoint = nodeList(k(1),:); minYpoint = nodeList(k(2),:);
+                distance_in(iBem) = norm(maxYpoint-minYpoint);
+                listPointasSeed(iBem,:) = maxYpoint;
+            end
+            %  Sort from inner to outer
+                [tmp, orderIn] = sort(distance_in);
+                distance_in = distance_in(orderIn);
+             % update the reorder of the labels from inner to outer
+                TissueLabels = TissueLabels(orderIn);
+                listPointasSeed = listPointasSeed(orderIn,:);
+                listPointasSeed = listPointasSeed - [0 0.002 0];
+                listPointasSeed(1,:) = center_inner;
+            disp(' ');
+            % Merge all the surfaces
+            bst_progress('text', ['Merging surfaces (Iso2mesh/' OPTIONS.MergeMethod ')...']);
+            switch (OPTIONS.MergeMethod)
+                % Faster and simpler: Simple concatenation without intersection checks
+                case 'mergemesh'
+                    % Concatenate meshes
+                    [newnode, newelem] = mergemesh(bemMerge{:});
+                    % Remove duplicated elements
+                    % newelem = unique(sort(newelem,2),'rows');
+                % Slower and more robust: Concatenates and checks for intersections (split intersecting elements)
+                case 'mergesurf'
+                    try
+                        [newnode, newelem] = mergesurf(bemMerge{:});
+                    catch
+                        errMsg = 'Problem with the function MergeSurf. You can try with MergeMesh.';
+                        bst_progress('stop');
+                        return;
+                    end
+                otherwise
+                    error(['Invalid merge method: ' OPTIONS.MergeMethod]);
+            end
+
+            % Find the intersection between the vertical axis (from the head center to the vertex) and all the BEM layers
+            regions = listPointasSeed;
+            % Create tetrahedral mesh
+            bst_progress('text', 'Creating 3D mesh (Iso2mesh/surf2mesh)...');
+            factor_bst = 1.e-6;
+            [node,elem] = surf2mesh(newnode, newelem, min(newnode), max(newnode),...
+                OPTIONS.KeepRatio, factor_bst .* OPTIONS.MaxVol, (regions), [], [], 'tetgen1.5');            
+            % Removing the label 0 (Tetgen 1.4) or higher than number of layers (Tetgen 1.5)
+            bst_progress('text', 'Fixing 3D mesh...');
+%             iOther = find((elem(:,5) == 0) & (elem(:,5) > nBem));
+%             if ~isempty(iOther) && (length(iOther) < 0.1 * length(elem))
+%                 elem(iOther,:) = [];
+%             end
+            % ==> do not remove any elements, it may corrumpt the mesh,
+            % this new version identifies correctely the elelemts 
+            
+            % Check labelling from 1 to nBem
+            allLabels = unique(elem(:,5));
+            % id =6; figure; plotmesh(node,elem(elem(:,5)==id,:),'facealpha',0.2,'edgecolor','none'); hold on; plotmesh(orig,'ko') 
+            % Process the outputs:  compute the distances
+            bst_progress('text', 'Identification of the 3D volumes...');
+            distance_out= zeros(1,length(allLabels));
+            for ind = 1: length(allLabels) 
+                elemList = elem(elem(:,5)==allLabels(ind),1:end-1);
+                elemList = unique(elemList(:)); % figure; plotmesh(node(elemList,:),'r.');xlabel('x');ylabel('y');zlabel('z');
+                nodeList = node(elemList,:);
+                maxYcoor = max(nodeList(:,2));
+                minYcoor = min(nodeList(:,2));
+                maxYpoint = [center_inner(1) maxYcoor center_inner(3)];
+                minYpoint = [center_inner(1) minYcoor center_inner(3)];
+                k = dsearchn(nodeList,[maxYpoint;minYpoint]);
+                maxYpoint = nodeList(k(1),:); minYpoint = nodeList(k(2),:);
+                % figure; plotmesh(node(elemList,:),'r.');xlabel('x');ylabel('y');zlabel('z');hold on; plotmesh([maxYpoint;minYpoint],'bo') 
+                distance_out(ind) = norm(maxYpoint-minYpoint);
+            end
+            % sort weired elements, works in all case even when there are
+            % more output tissues than inputs
+           distOut_tmp = distance_out;
+           for ind = 1 : length(distance_in)
+               tmp = find(round(distOut_tmp,3)<=round(distance_in(ind),3));
+               distOut_tmp(tmp) = ind;
+           end
+            % replace with the correct ID
+            tmp = elem;
+            tmp(:,5) = tmp(:,5) +10; % translation to avoind overlapping
+            allLabels = unique(tmp(:,5));
+            for  ind = 1: length(allLabels) 
+                tmp(tmp(:,5) == allLabels(ind),5) = distOut_tmp(ind);
+            end        
+            % check again just in case
+             allLabels = unique(tmp(:,5));
+            if ~isequal(allLabels(:)', 1:nBem)
+                errMsg = ['Problem with tissue labels: Brainstorm cannot understand the output labels (' num2str(allLabels(:)') ').'];
+                bst_progress('stop');
+                return;
+            end
+            elem = tmp;
+            % Mesh check and repair
+            [no,el] = removeisolatednode(node,elem(:,1:4));
+            % Orientation required for the FEM computation (at least with SimBio, maybe not for Duneuro)
+            newelem = meshreorient(no, el(:,1:4));
+            elem = [newelem elem(:,5)];
+            node = no; % need to updates the new list of nodes (it's wiered that it was working before)
+            % Only tetra could be generated from this method
+            OPTIONS.MeshType = 'tetrahedral';     
+        
         % Compute from OpenMEEG BEM layers: head, outerskull, innerskull
         case 'iso2mesh'
             % Install/load iso2mesh plugin
@@ -867,7 +1037,14 @@ function ComputeInteractive(iSubject, iMris, BemFiles) %#ok<DEFNU>
     OPTIONS = GetDefaultOptions();
     % If BEM surfaces are selected, the only possible method is "iso2mesh"
     if ~isempty(BemFiles) && iscell(BemFiles)
-        OPTIONS.Method = 'iso2mesh';
+        res = java_dialog('question', [...
+            '<HTML><B>Iso2mesh</B>:<BR>Call iso2mesh to create a tetrahedral mesh from the <B>BEM surfaces</B><BR>' ...
+            'generated with Brainstorm (head, inner skull, outer skull).<BR>' ...
+            '<HTML><B>Iso2mesh-2021</B>:<BR>New implementation that can be used if the previous iso2mesh fails<BR>' ...
+            '<FONT COLOR="#707070"><I>Iso2mesh is downloaded and installed automatically when needed.</I></FONT><BR><BR>' ...
+            ], 'FEM mesh generation method', [], {'iso2mesh','iso2mesh-2021'}, 'iso2mesh');
+        
+        OPTIONS.Method = res;
         OPTIONS.BemFiles = BemFiles;
     % Otherwise: Ask for method to use
     else
@@ -885,7 +1062,10 @@ function ComputeInteractive(iSubject, iMris, BemFiles) %#ok<DEFNU>
             '<FONT COLOR="#707070"><I>ROAST is downloaded and installed automatically when needed.</I></FONT><BR><BR>'...
             '<B>FieldTrip</B>:<BR>Call FieldTrip to segment and mesh the <B>T1</B> MRI.<BR>' ...
             '<FONT COLOR="#707070"><I>FieldTrip is downloaded and installed automatically when needed.</I></FONT><BR><BR>' ...
-            ], 'FEM mesh generation method', [], {'Iso2mesh','Brain2Mesh','SimNIBS','ROAST','FieldTrip'}, 'Iso2mesh');
+            '<HTML><B>Iso2mesh-2021</B>:<BR>Call iso2mesh to create a tetrahedral mesh from the <B>BEM surfaces</B><BR>' ...
+            'generated with Brainstorm (head, inner skull, outer skull).<BR>' ...
+            '<FONT COLOR="#707070"><I>Iso2mesh is downloaded and installed automatically when needed.</I></FONT><BR><BR>' ...
+            ], 'FEM mesh generation method', [], {'Iso2mesh','Brain2Mesh','SimNIBS','ROAST','FieldTrip','Iso2mesh-2021'}, 'Iso2mesh');
         if isempty(res)
             return
         end
@@ -894,6 +1074,34 @@ function ComputeInteractive(iSubject, iMris, BemFiles) %#ok<DEFNU>
     
     % Other options: Switch depending on the method
     switch (OPTIONS.Method)
+        case 'iso2mesh-2021'
+            % Ask merging method
+            res = java_dialog('question', [...
+                '<HTML>Iso2mesh function used to merge the input surfaces:<BR><BR>', ...
+                '<B>MergeMesh</B>: Default option (faster).<BR>' ...
+                'Simply concatenates the meshes without any intersection checks.<BR><BR>' ...
+                '<B>MergeSurf</B>: Advanced option (slower).<BR>' ...
+                'Concatenates and checks for intersections, split intersecting elements.<BR><BR>' ...
+                ], 'FEM mesh generation (Iso2mesh)', [], {'MergeMesh','MergeSurf'}, 'MergeMesh');
+            if isempty(res)
+                return
+            end
+            OPTIONS.MergeMethod = lower(res);
+            % Ask BEM meshing options
+            res = java_dialog('input', {'Max tetrahedral volume (10=coarse, 0.0001=fine):', 'Percentage of elements kept (1-100%):'}, ...
+                'FEM mesh', [], {num2str(OPTIONS.MaxVol), num2str(OPTIONS.KeepRatio)});
+            if isempty(res)
+                return
+            end
+            % Get new values
+            OPTIONS.MaxVol    = str2num(res{1});
+            OPTIONS.KeepRatio = str2num(res{2}) ./ 100;
+            if isempty(OPTIONS.MaxVol) || (OPTIONS.MaxVol < 0.000001) || (OPTIONS.MaxVol > 20) || ...
+                    isempty(OPTIONS.KeepRatio) || (OPTIONS.KeepRatio < 0.01) || (OPTIONS.KeepRatio > 1)
+                bst_error('Invalid options.', 'FEM mesh', 0);
+                return
+            end
+            
         case 'iso2mesh'
             % Ask merging method
             res = java_dialog('question', [...


### PR DESCRIPTION
Hi all,

This is the recovered code version that I lost from from this PR : https://github.com/brainstorm-tools/brainstorm3/pull/422

This PR is about the issue observed when the iso2mesh option is used, and surf2mesh produces more element labels than the input surfaces.
link to the reported issue: https://neuroimage.usc.edu/forums/t/duneuro-error-calculation/28965/6?u=tmedani

The change on this code will identify any output label based on the distance comparison between the inputs surfaces and the outputs labels.

It fixes also the tissue labels from the MNE bem surfaces.

I believe that is much robust than the previous version.

This change can be also useful for custom mesh generation for sEEG/iEEG models.

Thanks :)



