### PR TITLE
Update process_fooof.m

### DIFF
--- a/toolbox/process/functions/process_fooof.m
+++ b/toolbox/process/functions/process_fooof.m
@@ -57,7 +57,7 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.freqrange.Type    = 'freqrange_static';   % 'freqrange'
     sProcess.options.freqrange.Value   = {[1 40], 'Hz', 1};
     % === POWER LINE
-    sProcess.options.powerline.Comment = {'50 Hz', '60 Hz', 'Ignore power line frequencies:'; '50', '60', ''};
+    sProcess.options.powerline.Comment = {'None', '50 Hz', '60 Hz', 'Ignore power line frequencies:'; '-5', '50', '60', ''};
     sProcess.options.powerline.Type    = 'radio_linelabel';
     sProcess.options.powerline.Value   = '60';
     sProcess.options.powerline.Class   = 'Matlab';


### PR DESCRIPTION
Updated process description and citation.

Added functionality for ignoring power line frequencies and their first two harmonics.

Added option to return spectrum for each channel in FOOOF struct (already present in TF field, but SPM/FT cannot access from running function outside bst)

Removed bst_round dependencies (but maintained functionality; sorry Francois, it was a good script)