### PR TITLE
Wrap unzip function with bst_unzip to globally manage features 

### DIFF
--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -1073,7 +1073,7 @@ function [isOk, errMsg, PlugDesc] = Install(PlugName, isInteractive, minVersion)
     % Unzip file
     switch (pkgFormat)
         case 'zip'
-            unzip(pkgFile, PlugPath);
+            bst_unzip(pkgFile, PlugPath);
         case 'tgz'
             if ispc
                 untar(pkgFile, PlugPath);

--- a/toolbox/misc/bst_unzip.m
+++ b/toolbox/misc/bst_unzip.m
@@ -24,19 +24,25 @@ function varargout = bst_unzip(zipFilename, varargin)
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Juan GPC, 2021
+% Authors: Juan GPC, Francois Tadel, 2021
 
 narginchk(1,2);
 nargoutchk(0,1);
 
-disp(['BST> Unzipping plugin file: ' zipFilename]);
 try
     varargout = unzip(zipFilename, varargin{:});
 catch
-    disp('BST> Problem unzipping the file. Attempting rollback to previous unzip function. [feature(''ZIPV2'',''off'')]');
-    feature('ZIPV2','off')
-    varargout = unzip(zipFilename, varargin{:});
-    feature('ZIPV2','on')
+    if ~file_exist(zipFilename)
+        error(['File does not exist: ' zipFilename]);
+    elseif (bst_get('MatlabVersion') >= 910)
+        disp(['BST> Error unzipping the file: ' zipFilename]);
+        disp('BST> Attempting rollback to previous unzip function. [feature(''ZIPV2'',''off'')]');
+        feature('ZIPV2','off')
+        varargout = unzip(zipFilename, varargin{:});
+        feature('ZIPV2','on')
+    else
+        error(['Error unzipping the file: ' zipFilename 10 lasterr]);
+    end
 end
 
 

--- a/toolbox/misc/bst_unzip.m
+++ b/toolbox/misc/bst_unzip.m
@@ -1,0 +1,42 @@
+function varargout = bst_unzip(zipFilename, varargin)
+% BST_UNZIP: Unzip wrapper function.
+% This function abstracts the activation of different features regarding unzipping 
+% within matlab. Depending on behaviour it retries the unzip call with previous versions.
+%
+% USAGE: fileNames = bst_unzip(zipFileName)
+%        fileNames = bst_unzip(zipFileName, outputFolder)
+%
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2021 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Juan GPC, 2021
+
+narginchk(1,2);
+nargoutchk(0,1);
+
+disp(['BST> Unzipping plugin file: ' zipFilename]);
+try
+    varargout = unzip(zipFilename, varargin{:});
+catch
+    disp('BST> Problem unzipping the file. Attempting rollback to previous unzip function. [feature(''ZIPV2'',''off'')]');
+    feature('ZIPV2','off')
+    varargout = unzip(zipFilename, varargin{:});
+    feature('ZIPV2','on')
+end
+
+


### PR DESCRIPTION
Hi, 

After finding some problems unzipping a zip file downloaded from github [issue](https://github.com/brainstorm-tools/brainstorm3/issues/431#issuecomment-898508442), I've found this solution.  Not everyone is experiencing this problem (actually only me 😄 ) but, just in case. 

Apparently Matlab is changing its unzip function while adapting to a java-less life. And this new version might not be as universally compatible as the old unzip version. While this new version becomes more stable, we can: 

- use this bst_unzip function which basically wraps the unzip call.  I like this abstraction because I see no reason why any function using unzip should know or care about different versions of unzip, java dependencies, etc... 
- if a feature (i.e. ZIPV2) fails once, it is probably going to fail more than once. So it can globally be managed either through some settings parameter or some static variable inside the function ("persistent"). That's not implemented right now.
- I see that there are 30 calls to unzip right now in the repo. Some with 1 input parameter (zipFilename) or 2 (zipFilename, outputFolder). bst_unzip is compatible with both formats.
- Imho the complete switch [here ](https://github.com/brainstorm-tools/brainstorm3/blob/08c766c27db3f54f2b1378a8a250de84f1c08d53/toolbox/core/bst_plugin.m#L1074)could be abstracted with a bst_unpackage file. I see no reason why plugin should know or care about zip/tar/ispc/system calls, etc... (this hasn't been done). 

If you want to drop this. That's ok. Just trying to help. 