### PR TITLE
bugfix

### DIFF
--- a/toolbox/gui/panel_record.m
+++ b/toolbox/gui/panel_record.m
@@ -1534,7 +1534,7 @@ function JumpToEvent(iEvent, iOccur)
     % Check if event is a "full page" shortcut
     RawViewerOptions = bst_get('RawViewerOptions');
     iShortcut = find(strcmpi(RawViewerOptions.Shortcuts(:,2), events(iEvent).label));
-    isFullPage = ~isempty(iShortcut) && strcmpi(RawViewerOptions.Shortcuts(iShortcut,3), 'page') && (size(events(iEvent).times,1) == 2);
+    isFullPage = ~isempty(iShortcut) && any(strcmpi(RawViewerOptions.Shortcuts(iShortcut,3), 'page')) && (size(events(iEvent).times,1) == 2);
     % If event is outside of the current user time window
     UserTime = GlobalData.UserTimeWindow.Time;
     if (evtTime < UserTime(1)) || (evtTime > UserTime(2))


### PR DESCRIPTION
Fix the following error: 

```
Operands to the || and && operators must be convertible to logical scalar values.
Error in panel_record>JumpToEvent (line 1537)
    isFullPage = ~isempty(iShortcut) && strcmpi(RawViewerOptions.Shortcuts(iShortcut,3), 'page') &&
    (size(events(iEvent).times,1) == 2);

Error in panel_record>CreatePanel/ListOccur_ClickCallback (line 372)
                JumpToEvent();
```

It can happen when iShortcut contains mutiple element(eg K>> strcmpi(RawViewerOptions.Shortcuts(iShortcut,3), 'page')  =  2×1 logical array (0  1) )
