### PR TITLE
Add MCXlab as plugin

### DIFF
--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -157,7 +157,7 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end+1)              = GetStruct('mcxlab');
     PlugDesc(end).Version        = '2020';
     PlugDesc(end).Category       = 'Forward';
-    PlugDesc(end).AutoUpdate     = 1;
+    PlugDesc(end).AutoUpdate     = 2;
     switch(OsType)
         case 'linux64'
             PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-linux-x86_64-v2020.zip';

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -153,6 +153,25 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).CompiledStatus = 1;
     PlugDesc(end).LoadFolders    = {'bin'};
     
+    
+    PlugDesc(end+1)              = GetStruct('mcxlab');
+    PlugDesc(end).Version        = '2020';
+    PlugDesc(end).Category       = 'Forward';
+    PlugDesc(end).AutoUpdate     = 1;
+    switch(OsType)
+        case 'linux64'
+            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-linux-x86_64-v2020.zip';
+        case 'mac64'
+            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-osx-x86_64-v2020.zip';
+        case 'win64'
+            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-win-x86_64-v2020.zip';
+            
+    end
+    PlugDesc(end).TestFile       = 'mcxlab.m';
+    PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
+    PlugDesc(end).CompiledStatus = 1;
+    PlugDesc(end).LoadFolders    = {'*'};
+    
     % === INVERSE: BRAINENTROPY ===
     PlugDesc(end+1)              = GetStruct('brainentropy');
     PlugDesc(end).Version        = 'github-master';

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -171,7 +171,7 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
     PlugDesc(end).CompiledStatus = 0;
     PlugDesc(end).LoadFolders    = {'*'};
-    PlugDesc(end).UnloadPlugs    = 'mcxlab-cl';
+    PlugDesc(end).UnloadPlugs    = {'mcxlab-cl'};
     
         
     PlugDesc(end+1)              = GetStruct('mcxlab-cl');
@@ -191,7 +191,7 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
     PlugDesc(end).CompiledStatus = 1;
     PlugDesc(end).LoadFolders    = {'*'};
-    PlugDesc(end).UnloadPlugs    = 'mcxlab-cuda';
+    PlugDesc(end).UnloadPlugs    = {'mcxlab-cuda'};
     
     
     % === INVERSE: BRAINENTROPY ===

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -154,7 +154,7 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).LoadFolders    = {'bin'};
     
     
-    PlugDesc(end+1)              = GetStruct('mcxlab');
+    PlugDesc(end+1)              = GetStruct('mcxlab-cuda');
     PlugDesc(end).Version        = '2020';
     PlugDesc(end).Category       = 'Forward';
     PlugDesc(end).AutoUpdate     = 2;
@@ -169,8 +169,30 @@ function PlugDesc = GetSupported(SelPlug)
     end
     PlugDesc(end).TestFile       = 'mcxlab.m';
     PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
+    PlugDesc(end).CompiledStatus = 0;
+    PlugDesc(end).LoadFolders    = {'*'};
+    PlugDesc(end).UnloadPlugs    = 'mcxlab-cl';
+    
+        
+    PlugDesc(end+1)              = GetStruct('mcxlab-cl');
+    PlugDesc(end).Version        = '2020';
+    PlugDesc(end).Category       = 'Forward';
+    PlugDesc(end).AutoUpdate     = 2;
+    switch(OsType)
+        case 'linux64'
+            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlabcl-linux-x86_64-v2020.zip';
+        case 'mac64'
+            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlabcl-osx-x86_64-v2020.zip';
+        case 'win64'
+            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlabcl-win-x86_64-v2020.zip';
+            
+    end
+    PlugDesc(end).TestFile       = 'mcxlabcl.m';
+    PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
     PlugDesc(end).CompiledStatus = 1;
     PlugDesc(end).LoadFolders    = {'*'};
+    PlugDesc(end).UnloadPlugs    = 'mcxlab-cuda';
+    
     
     % === INVERSE: BRAINENTROPY ===
     PlugDesc(end+1)              = GetStruct('brainentropy');

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -153,47 +153,6 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).CompiledStatus = 1;
     PlugDesc(end).LoadFolders    = {'bin'};
     
-    
-    PlugDesc(end+1)              = GetStruct('mcxlab-cuda');
-    PlugDesc(end).Version        = '2020';
-    PlugDesc(end).Category       = 'Forward';
-    PlugDesc(end).AutoUpdate     = 2;
-    switch(OsType)
-        case 'linux64'
-            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-linux-x86_64-v2020.zip';
-        case 'mac64'
-            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-osx-x86_64-v2020.zip';
-        case 'win64'
-            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlab-win-x86_64-v2020.zip';
-            
-    end
-    PlugDesc(end).TestFile       = 'mcxlab.m';
-    PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
-    PlugDesc(end).CompiledStatus = 0;
-    PlugDesc(end).LoadFolders    = {'*'};
-    PlugDesc(end).UnloadPlugs    = {'mcxlab-cl'};
-    
-        
-    PlugDesc(end+1)              = GetStruct('mcxlab-cl');
-    PlugDesc(end).Version        = '2020';
-    PlugDesc(end).Category       = 'Forward';
-    PlugDesc(end).AutoUpdate     = 2;
-    switch(OsType)
-        case 'linux64'
-            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlabcl-linux-x86_64-v2020.zip';
-        case 'mac64'
-            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlabcl-osx-x86_64-v2020.zip';
-        case 'win64'
-            PlugDesc(end).URLzip   = 'http://mcx.space/nightly/release/v2020/mcxlabcl-win-x86_64-v2020.zip';
-            
-    end
-    PlugDesc(end).TestFile       = 'mcxlabcl.m';
-    PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
-    PlugDesc(end).CompiledStatus = 0;
-    PlugDesc(end).LoadFolders    = {'*'};
-    PlugDesc(end).UnloadPlugs    = {'mcxlab-cuda'};
-    
-    
     % === INVERSE: BRAINENTROPY ===
     PlugDesc(end+1)              = GetStruct('brainentropy');
     PlugDesc(end).Version        = 'github-master';
@@ -336,6 +295,30 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).GetVersionFcn  = 'nst_get_version';
     PlugDesc(end).RequiredPlugs  = {'brainentropy'};
     PlugDesc(end).MinMatlabVer   = 803;   % 2014a
+    
+    % === MCXLAB CUDA ===
+    PlugDesc(end+1)              = GetStruct('mcxlab-cuda');
+    PlugDesc(end).Version        = '2021.12.04';
+    PlugDesc(end).Category       = 'fNIRS';
+    PlugDesc(end).AutoUpdate     = 1;
+    PlugDesc(end).URLzip         = 'http://mcx.space/nightly/release/git20211204/mcxlab-allinone-x86_64-git20211204.zip';
+    PlugDesc(end).TestFile       = 'mcxlab.m';
+    PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
+    PlugDesc(end).CompiledStatus = 0;
+    PlugDesc(end).LoadFolders    = {'*'};
+    PlugDesc(end).UnloadPlugs    = {'mcxlab-cl'};
+
+    % === MCXLAB CL ===
+    PlugDesc(end+1)              = GetStruct('mcxlab-cl');
+    PlugDesc(end).Version        = '2020';
+    PlugDesc(end).Category       = 'fNIRS';
+    PlugDesc(end).AutoUpdate     = 0;
+    PlugDesc(end).URLzip         = 'http://mcx.space/nightly/release/v2020/lite/mcxlabcl-allinone-x86_64-v2020.zip';
+    PlugDesc(end).TestFile       = 'mcxlabcl.m';
+    PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
+    PlugDesc(end).CompiledStatus = 2;
+    PlugDesc(end).LoadFolders    = {'*'};
+    PlugDesc(end).UnloadPlugs    = {'mcxlab-cuda'};
     
     % === FIELDTRIP ===
     PlugDesc(end+1)              = GetStruct('fieldtrip');

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -189,7 +189,7 @@ function PlugDesc = GetSupported(SelPlug)
     end
     PlugDesc(end).TestFile       = 'mcxlabcl.m';
     PlugDesc(end).URLinfo        = 'http://mcx.space/wiki/';
-    PlugDesc(end).CompiledStatus = 1;
+    PlugDesc(end).CompiledStatus = 0;
     PlugDesc(end).LoadFolders    = {'*'};
     PlugDesc(end).UnloadPlugs    = {'mcxlab-cuda'};
     


### PR DESCRIPTION
Hello @ftadel, 
This PR is adding Mcxlab to the plugin system. MCXlab is a toolbox used to compute the forward model in nirs. It would be very helpful to include it in brainstorm as it will facilitate the installation for the current users using Matlab and allow users without Matlab to use it from the compile version ( not possible currently)


Let me know if you have questions
Edouard