### PR TITLE
Closing brainstorm with still referenced closed windows

### DIFF
--- a/toolbox/core/bst_memory.m
+++ b/toolbox/core/bst_memory.m
@@ -3342,8 +3342,10 @@ function isCancel = UnloadDataSets(iDataSets)
         end
         % Close all the figures
         for iFig = length(GlobalData.DataSet(iDS).Figure):-1:1
-            bst_figures('DeleteFigure', GlobalData.DataSet(iDS).Figure(iFig).hFigure, 'NoUnload', 'NoLayout');
-            drawnow
+            if isfield(GlobalData.DataSet(iDS).Figure(iFig), 'hFigure')
+                bst_figures('DeleteFigure', GlobalData.DataSet(iDS).Figure(iFig).hFigure, 'NoUnload', 'NoLayout');
+                drawnow
+            end
         end
     end
     % Check that dataset still exists

--- a/toolbox/core/bst_memory.m
+++ b/toolbox/core/bst_memory.m
@@ -3342,7 +3342,7 @@ function isCancel = UnloadDataSets(iDataSets)
         end
         % Close all the figures
         for iFig = length(GlobalData.DataSet(iDS).Figure):-1:1
-            if isfield(GlobalData.DataSet(iDS).Figure(iFig), 'hFigure')
+            if isfield(GlobalData.DataSet(iDS).Figure(iFig), 'hFigure') && ~isempty(GlobalData.DataSet(iDS).Figure(iFig).hFigure)
                 bst_figures('DeleteFigure', GlobalData.DataSet(iDS).Figure(iFig).hFigure, 'NoUnload', 'NoLayout');
                 drawnow
             end


### PR DESCRIPTION
Fixing the following issue when trying to close brainstorm and a figure got closed without brainstorm noticing. (Here it happens because some issue happens when closing the MRI viewer when importing an MRI). 

```
>> bst_exit()
Reference to non-existent field 'hFigure'.
Error in bst_memory>UnloadDataSets (line 3345)
            bst_figures('DeleteFigure', GlobalData.DataSet(iDS).Figure(iFig).hFigure, 'NoUnload', 'NoLayout');

Error in bst_memory>UnloadAll (line 3132)
    isCancel = UnloadDataSets(iDSToUnload);

Error in bst_memory (line 72)
eval(macro_method);

Error in bst_exit (line 49)
isCancel = bst_memory('UnloadAll', 'Forced');
```