### PR TITLE
fix load of plugin

### DIFF
--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -769,7 +769,13 @@ function [PlugDesc, SearchPlugs] = GetInstalled(SelPlug)
     % Process folders containing a plugin.mat file
     for iDir = 1:length(PlugList)
         % Process only folders
-        PlugDir = bst_fullfile(UserPluginsDir, PlugList(iDir).name);
+    
+        if isstruct(PlugList(iDir).name)
+           PlugDir = bst_fullfile(UserPluginsDir, PlugList(iDir).name.Name);
+        else
+            PlugDir = bst_fullfile(UserPluginsDir, PlugList(iDir).name);
+        end    
+            
         if ~isdir(PlugDir) || (PlugList(iDir).name(1) == '.')
             continue;
         end


### PR DESCRIPTION
Fix the following error when trying to load a plugin:

```
Undefined operator '==' for input arguments of type 'struct'.
Error in bst_plugin>GetInstalled (line 774)
        if ~isdir(PlugDir) || (PlugList(iDir).name(1) == '.')
Error in bst_plugin>Unload (line 1741)
    InstPlugDesc = GetInstalled(PlugDesc);
Error in bst_plugin>Unload (line 1771)
            Unload(AllPlugs(iPlug));
Error in bst_plugin>Load (line 1641)
            Unload(PlugDesc.UnloadPlugs{iPlug});
Error in bst_plugin>LoadInteractive (line 1720)
    [isOk, errMsg, PlugDesc] = Load(PlugDesc);
Error in bst_plugin>@(h,ev)LoadInteractive(Plug.Name) (line 1973)
            j(ij).load = gui_component('MenuItem', j(ij).menu, [], 'Load', IconLoader.ICON_GOOD, [], @(h,ev)LoadInteractive(Plug.Name), fontSize);
```

For some reason, sometimes PlugList(iDir).name is a struct