### PR TITLE
fix sFileIn variable undefined

### DIFF
--- a/toolbox/io/import_raw.m
+++ b/toolbox/io/import_raw.m
@@ -312,7 +312,7 @@ for iFile = 1:length(RawFiles)
             % Display message in console
             disp(['BST> File converted to binary .bst format: ' ExportFile]);
         else
-            sFileOut = sFileIn;
+            sFileOut = sFile;
         end
         
         % ===== SAVE LINK FILE =====


### PR DESCRIPTION
When importing a bids dataset there is a variable in ```io/import_raw.m``` named ```sFileIn``` which is undefined and therefore an error is thrown.

I think ```sFileIn``` should be ```sFile```.

See: https://github.com/brainstorm-tools/brainstorm3/blob/822dab0d66f8dbab0685f491b34f1b946095a4d7/toolbox/io/import_raw.m#L315

