### PR TITLE
Remove centering around 0 in normalized PTE results

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -605,7 +605,6 @@ for iFile = 1:length(FilesA)
                 [dPTE, PTE] = PhaseTE_MF(permute(DataAband, [2 1]));
                 if OPTIONS.isNormalized
                     R(:,:,iBand) = dPTE;
-                    R(:,:,iBand) = R(:,:,iBand) - 0.5; % Center result around 0
                 else
                     R(:,:,iBand) = PTE;
                 end


### PR DESCRIPTION
Removes the centering around 0 for normalized PTE (dPTE) values, as it can lead to wrong interpretations, as reported in: https://neuroimage.usc.edu/forums/t/confusing-values-of-normalized-pte/32069

Normalized values are computed as in [Hillebrand et al., 2016](https://www.pnas.org/content/113/14/3867). 

For example, normalized PTE values (before centering around 0) of dPTExy = 0.9 and dPTEyx = 0.1 indicate that information goes preferentially from x to y. Removing 0.5 on both metrics results in dPTExy = 0.4 and dPTEyx = -0.4, while the numeric difference between the metrics is kept, the magnitude of the metric meaning does not look as clear.