### PR TITLE
[bugfix, cat12 segmentation] Keep the correct MRI before segmenting

### DIFF
--- a/toolbox/db/db_delete_anatomy.m
+++ b/toolbox/db/db_delete_anatomy.m
@@ -37,8 +37,8 @@ if ~isKeepMri && ~isempty(sSubject.Anatomy)
     sSubject.Anatomy(1:end) = [];
     sSubject.iAnatomy = [];
 elseif isKeepMri && (length(sSubject.Anatomy) >= 2)
-    ind =  ones(1,length(length(sSubject.Anatomy)));
-    ind(sSubject.iAnatomy) = 0;
+    ind =  true(1,length(sSubject.Anatomy));
+    ind(sSubject.iAnatomy) = false;
     file_delete(file_fullpath({sSubject.Anatomy(ind).FileName}), 1);
     sSubject.Anatomy(ind) = [];
     sSubject.iAnatomy = 1;

--- a/toolbox/db/db_delete_anatomy.m
+++ b/toolbox/db/db_delete_anatomy.m
@@ -37,8 +37,10 @@ if ~isKeepMri && ~isempty(sSubject.Anatomy)
     sSubject.Anatomy(1:end) = [];
     sSubject.iAnatomy = [];
 elseif isKeepMri && (length(sSubject.Anatomy) >= 2)
-    file_delete(file_fullpath({sSubject.Anatomy(2:end).FileName}), 1);
-    sSubject.Anatomy(2:end) = [];
+    ind =  ones(1,length(length(sSubject.Anatomy)));
+    ind(sSubject.Anatomy) = 0;
+    file_delete(file_fullpath({sSubject.Anatomy(ind).FileName}), 1);
+    sSubject.Anatomy(ind) = [];
     sSubject.iAnatomy = 1;
 end
 

--- a/toolbox/db/db_delete_anatomy.m
+++ b/toolbox/db/db_delete_anatomy.m
@@ -38,7 +38,7 @@ if ~isKeepMri && ~isempty(sSubject.Anatomy)
     sSubject.iAnatomy = [];
 elseif isKeepMri && (length(sSubject.Anatomy) >= 2)
     ind =  ones(1,length(length(sSubject.Anatomy)));
-    ind(sSubject.Anatomy) = 0;
+    ind(sSubject.iAnatomy) = 0;
     file_delete(file_fullpath({sSubject.Anatomy(ind).FileName}), 1);
     sSubject.Anatomy(ind) = [];
     sSubject.iAnatomy = 1;

--- a/toolbox/process/functions/process_segment_cat12.m
+++ b/toolbox/process/functions/process_segment_cat12.m
@@ -231,6 +231,7 @@ function [isOk, errMsg] = Compute(iSubject, iAnatomy, nVertices, isInteractive, 
         % Delete anatomy
         isKeepMri = 1;
         sSubject = db_delete_anatomy(iSubject, isKeepMri);
+        iAnatomy = 1;
     end
     
     % ===== VERIFY FIDUCIALS IN MRI =====

--- a/toolbox/process/functions/process_segment_cat12.m
+++ b/toolbox/process/functions/process_segment_cat12.m
@@ -212,6 +212,16 @@ function [isOk, errMsg] = Compute(iSubject, iAnatomy, nVertices, isInteractive, 
     % Get default MRI if not specified
     if isempty(iAnatomy)
         iAnatomy = sSubject.iAnatomy;
+    else
+        sSubject.iAnatomy =iAnatomy;
+        % Keep the MRI that has been selected for segmentation and not the
+        % one beiing as default 
+        
+        bst_set('Subject', iSubject, sSubject);
+        panel_protocols('UpdateNode', 'Subject', iSubject);
+        % Save database
+        db_save();
+
     end
 
     % ===== DELETE EXISTING SURFACES =====


### PR DESCRIPTION
fix #485 

Why is cat12 the only segmentation tool for which we remove all MRI before launching the segmentation? 
 it would be great to only remove existing surfaces and not MRIs (for example if you run cat12 on a resampled MRI; it's always good to keep the original MRI) 