### PR TITLE
Fix for robust_ap_fit

### DIFF
--- a/toolbox/process/functions/process_fooof.m
+++ b/toolbox/process/functions/process_fooof.m
@@ -489,7 +489,7 @@ function aperiodic_params = robust_ap_fit(freqs, power_spectrum, aperiodic_mode)
         case 'fixed'  % no knee
             aperiodic_params = fminsearch(@error_expo_nk_function, guess_vec, options, freqs_ignore, spectrum_ignore);
         case 'knee'
-            aperiodic_params = fminsearch(@error_expo_function, guess_vec, options, freqs, power_spectrum);
+            aperiodic_params = fminsearch(@error_expo_function, guess_vec, options, freqs_ignore, spectrum_ignore);
     end
 end
 


### PR DESCRIPTION
Bug specific for knee option. When doing second line fit, exclude certain frequencies and power values.

#495 