### PR TITLE
fix NIRS export

### DIFF
--- a/toolbox/io/out_channel_nirs_brainsight.m
+++ b/toolbox/io/out_channel_nirs_brainsight.m
@@ -58,100 +58,13 @@ end
 % Convert to MRI coordinates if available
 if nargin >= 3
     sMri = in_mri_bst(MriFile);
-    volDim = size(sMri.Cube(:,:,:,1));
-    pixDim = sMri.Voxsize;
     
-    % Same code as in out_mri_nii.m to make sure exported coordinates have the
-    % same origin as exported MRI
-    % Use existing matrices (from the header)
-if isfield(sMri, 'Header') && isfield(sMri.Header, 'nifti') && all(isfield(sMri.Header.nifti, {'qform_code', 'sform_code', 'quatern_b', 'quatern_c', 'quatern_d', 'qoffset_x', 'qoffset_y', 'qoffset_z', 'srow_x', 'srow_y', 'srow_z'})) && isfield(sMri.Header, 'dim') && isfield(sMri.Header.dim, 'pixdim')
-    sform = [sMri.Header.nifti.srow_x ;  sMri.Header.nifti.srow_y ; sMri.Header.nifti.srow_z];
-else
-   % === QFORM ===
-    % XFORM_SCANNER: Scanner-based referential: from the vox2ras matrix
-    if isfield(sMri, 'InitTransf') && ~isempty(sMri.InitTransf) && any(ismember(sMri.InitTransf(:,1), 'vox2ras'))
-        nifti.qform_code = 1;  % NIFTI_XFORM_SCANNER_ANAT
-        % Use directly the unmodified vox2ras from the original file
-        iTransf = find(strcmpi(sMri.InitTransf(:,1), 'vox2ras'));
-        nifti.qform = sMri.InitTransf{iTransf(1),2};
-        % Convert from 4x4 transformations to quaternions
-        R = nifti.qform(1:3, 1:3);
-        T = nifti.qform(1:3, 4);
-        a = 0.5  * sqrt(1 + R(1,1) + R(2,2) + R(3,3));
-     	nifti.quatern_b = 0.25 * (R(3,2) - R(2,3)) / a;
-     	nifti.quatern_c = 0.25 * (R(1,3) - R(3,1)) / a;
-        nifti.quatern_d = 0.25 * (R(2,1) - R(1,2)) / a;
-        nifti.qoffset_x = T(1);
-        nifti.qoffset_y = T(2);
-        nifti.qoffset_z = T(3);
-    else
-        nifti.qform_code = 0;
-     	nifti.quatern_b = 0;
-     	nifti.quatern_c = 0;
-        nifti.quatern_d = 0;
-        nifti.qoffset_x = 0;
-        nifti.qoffset_y = 0;
-        nifti.qoffset_z = 0;
-    end  
-    
-        % === SFORM ===
-    % If there is a QFORM, do not define SFORM to avoid ambiguities
-    if (nifti.qform_code ~= 0)
-        nifti.sform_code = 0;
-        nifti.srow_x = [0 0 0 0];
-        nifti.srow_y = [0 0 0 0];
-        nifti.srow_z = [0 0 0 0];
-    % XFORM_MNI_152: Normalized coordinates (NCS field)
-    elseif isfield(sMri, 'NCS') && isfield(sMri.NCS, 'R') && ~isempty(sMri.NCS.R) && isfield(sMri.NCS, 'T') && ~isempty(sMri.NCS.T)
-        nifti.sform_code = 4;   % NIFTI_XFORM_MNI_152
-        mri2world = cs_convert(sMri, 'mri', 'mni');
-    % XFORM_ALIGNED: If no scanner coordinates (qform) or MNI normalization (sform): Just center the image on AC or the middle of the volume
-    else
-        nifti.sform_code = 2;   % NIFTI_XFORM_ALIGNED_ANAT
-        if isfield(sMri, 'NCS') && isfield(sMri.NCS, 'AC') && ~isempty(sMri.NCS.AC) 
-            Origin = sMri.NCS.AC;
-        elseif isfield(sMri, 'NCS') && isfield(sMri.NCS, 'Origin') && ~isempty(sMri.NCS.Origin)
-            Origin = sMri.NCS.Origin;
-        else
-            Origin = volDim .* sMri.Voxsize / 2;
-        end
-        mri2world = [...
-            1, 0, 0, -Origin(1) ./ 1000; ...
-            0, 1, 0, -Origin(2) ./ 1000; ...
-            0, 0, 1, -Origin(3) ./ 1000; 
-            0, 0, 0, 1];
+    src_coords = cs_convert(sMri, 'scs', 'world', src_coords)*1000;
+    det_coords = cs_convert(sMri, 'scs', 'world', det_coords)*1000;
+    if ~isempty(fidu_coords)
+        fidu_coords = cs_convert(sMri, 'scs', 'world', fidu_coords)*1000;
     end
-    % Convert Brainstorm transformation to nifti vox2ras
-    if (nifti.sform_code ~= 0)
-        % Convert from MRI(meters) to MRI(millimeters)
-        vox2ras = mri2world;
-        vox2ras(1:3,4) = vox2ras(1:3,4) .* 1000;
-        % Convert from MRI(mm) to voxels
-        vox2ras = vox2ras * diag([sMri.Voxsize, 1]);
-        % Change reference from (0,0,0) to (1,1,1)
-        nifti.sform = vox2ras * [1 0 0 1; 0 1 0 1; 0 0 1 1; 0 0 0 1];
-        % Saved in sform format
-        nifti.srow_x = nifti.sform(1,:);
-        nifti.srow_y = nifti.sform(2,:);
-        nifti.srow_z = nifti.sform(3,:);
-    end
-    sform = [nifti.srow_x ;  nifti.srow_y ; nifti.srow_z];
-    qform = nifti.qform;
-end    
-    if(nifti.qform_code ~= 0)
-        src_coords = (qform * [cs_convert(sMri, 'scs', 'mri', src_coords)*1000 ones(size(src_coords,1), 1)]')';
-        det_coords = (qform * [cs_convert(sMri, 'scs', 'mri', det_coords)*1000 ones(size(det_coords,1), 1)]')';
-        if ~isempty(fidu_coords)
-            fidu_coords = (qform * [cs_convert(sMri, 'scs', 'mri', fidu_coords)*1000 ones(size(fidu_coords,1), 1)]')';
-        end
-    else
-        src_coords = (sform * [cs_convert(sMri, 'scs', 'mri', src_coords)*1000 ones(size(src_coords,1), 1)]')';
-        det_coords = (sform * [cs_convert(sMri, 'scs', 'mri', det_coords)*1000 ones(size(det_coords,1), 1)]')';
-        if ~isempty(fidu_coords)
-            fidu_coords = (sform * [cs_convert(sMri, 'scs', 'mri', fidu_coords)*1000 ones(size(fidu_coords,1), 1)]')';
-        end
-    end    
-end
+end 
 
 % Format header
 header = sprintf(['# Version: 5\n# Coordinate system: NIftI-Aligned\n# Created by: Brainstorm (nirstorm plugin)\n' ...


### PR DESCRIPTION
This PR fixes an issue when, when exporting an MRI and a NIRS montage, the two would end up not aligned in Brainsight software.  This is linked to the change made here: https://github.com/brainstorm-tools/brainstorm3/commit/891c3640b7e8baed3e6287903c4c523dd5479956


A small summary of my current understanding:  MRI is stored in ?  coordinate.  MRI also contains two transformations; qform; and sform: qform transform the voxel coordinate to scanner space. sform transform voxel coordinate to standard space (MNI).   When both transformation exist, brainstorm is only saving qform. (so transformation to scanner space). 


When exporting nirs optodes coordinate, we first convert the SCS coordinate to MRI coordinate. then we convert the MRI coordinate to the same system of coordinate used when exporting the MRI.  Currently, Brainstorm is always exporting the NIRS optodes to standard space (using sform). We need to export to scanner space when Brainstorm is exporting the QFORM.  


The two questions I still haven't figure out: 
- Why do some subjects have qform, some don't?  (We had the problem of alignment only on a few subjects). At first, I would have thought the opposite: all subjects have qform (we know scanner coordinate), and some also have sform (to know MNI coordinate). But it seems to be the opposite? 
- Why Brainstorm is only saving the qform, when it exists, and not qform and sform ? 
Based on https://nifti.nimh.nih.gov/nifti-1/documentation/faq#Q19 it seems more logical

> Q19. Why does NIfTI-1 allow for two coordinate systems (the qform and sform)? (Mark Jenkinson)
> The basic idea behind having two coordinate systems is to allow the image to store information about (1) the scanner coordinate system used in the acquisition of the volume (in the qform) and (2) the relationship to a standard coordinate system - e.g. MNI coordinates (in the sform).
> 
> The qform allows orientation information to be kept for alignment purposes without losing volumetric information since the qform only stores a rigid-body transformation which preserves volume. On the other hand, the sform stores a general affine transformation which can map the image coordinates into a standard coordinate system, like Talairach or MNI, without the need to resample the image.
> 
> By having both coordinate systems, it is possible to keep the original data (without resampling), along with information on how it was acquired (qform) and how it relates to other images via a standard space (sform). This ability is advantageous for many analysis pipelines, and has previously required storing additional files along with the image files. By using NIfTI-1 this extra information can be kept in the image files themselves.
> Note: the qform and sform also store information on whether the coordinate system is left-handed or right-handed (see [Q15](https://nifti.nimh.nih.gov/nifti-1/documentation/faq#Q15)) and so when both are set they must be consistent, otherwise the handedness of the coordinate system (often used to distinguish left-right order) is unknown and the results of applying operations to such an image are unspecified.


Few usefull links: 
https://community.mrtrix.org/t/nifti-transform-ambiguity/2254

https://community.mrtrix.org/t/clarification-on-qform-and-sform/3291/2

https://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields/nifti1fields_pages/qsform_brief_usage