### PR TITLE
Bugfix: Specific channels for baseline when combining import+removeDC

### DIFF
--- a/toolbox/db/db_template.m
+++ b/toolbox/db/db_template.m
@@ -534,7 +534,8 @@ switch lower(structureName)
             'EventsTrackMode',  'ask', ...    % {'value','bit','ttl','rttl','ignore','ask'} 
             'EventsTypes',      '', ...       % String with a list of eventtypes to use to group the epochs (EEGLAB only)
             'DisplayMessages',  1, ...        % If 0, do not show any of the message boxes that the user would normally see
-            'Precision',        []);          % Precision when reading the file {'double' (default), 'single'} (only for supported file formats)
+            'Precision',        [], ...       % Precision when reading the file {'double' (default), 'single'} (only for supported file formats)
+            'BaselineSensorType', '');        % Sensor types (or names) to for baseline correction if RemoveBaseline is {all, time}
         
     % ==== COLORMAPS ====
     case 'colormap'

--- a/toolbox/db/db_template.m
+++ b/toolbox/db/db_template.m
@@ -525,6 +525,7 @@ switch lower(structureName)
             'UseSsp',           1, ...                 % Get and apply SSP (Signal Space Projection) vectors if available
             'RemoveBaseline',   'no', ...              % Method used to remove baseline of each channel: {no, all, time, sample}
             'BaselineRange',    [], ...                % [tStart,tStop] If RemoveBaseline is 'time'; Else ignored
+            'BaselineSensorType', '', ...              % Sensor types (or names) to for baseline correction if RemoveBaseline is {all, time}
             'events',           [], ...                % Events structure: (label, epochs, samples, times, reactTimes, select)
             'CreateConditions', 0, ...                 % {0,1} If 1, create new conditions in Brainstorm database if it is more convenient
             'ChannelReplace',   1, ...        % If 1, prompts for automatic replacement of an existing channel file. If 2, replace it automatically. If 0, do not do it.
@@ -534,8 +535,8 @@ switch lower(structureName)
             'EventsTrackMode',  'ask', ...    % {'value','bit','ttl','rttl','ignore','ask'} 
             'EventsTypes',      '', ...       % String with a list of eventtypes to use to group the epochs (EEGLAB only)
             'DisplayMessages',  1, ...        % If 0, do not show any of the message boxes that the user would normally see
-            'Precision',        [], ...       % Precision when reading the file {'double' (default), 'single'} (only for supported file formats)
-            'BaselineSensorType', '');        % Sensor types (or names) to for baseline correction if RemoveBaseline is {all, time}
+            'Precision',        []);          % Precision when reading the file {'double' (default), 'single'} (only for supported file formats)
+                    
         
     % ==== COLORMAPS ====
     case 'colormap'

--- a/toolbox/io/in_fread.m
+++ b/toolbox/io/in_fread.m
@@ -36,6 +36,8 @@ function [F, TimeVector,DisplayUnits] = in_fread(sFile, ChannelMat, iEpoch, Samp
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2009-2021
+%          Raymundo Cassani, 2022
+
 
 %% ===== PARSE INPUTS =====
 if (nargin < 6)
@@ -340,6 +342,10 @@ if ~isempty(ImportOptions) && ~isempty(ImportOptions.RemoveBaseline)
         else
             iChanBl = 1:size(F,1);
         end
+        % Select channels based on sensor types (or names) for baseline correction
+        iChanBlSensorType = channel_find(ChannelMat.Channel, ImportOptions.BaselineSensorType);
+        % Selected channels minus excluded
+        iChanBl = intersect(iChanBlSensorType, iChanBl); 
         % Compute baseline
         blValue = mean(F(iChanBl,iTimesBl), 2);
         % Remove from recordings

--- a/toolbox/io/in_fread.m
+++ b/toolbox/io/in_fread.m
@@ -342,10 +342,13 @@ if ~isempty(ImportOptions) && ~isempty(ImportOptions.RemoveBaseline)
         else
             iChanBl = 1:size(F,1);
         end
-        % Select channels based on sensor types (or names) for baseline correction
-        iChanBlSensorType = channel_find(ChannelMat.Channel, ImportOptions.BaselineSensorType);
-        % Selected channels minus excluded
-        iChanBl = intersect(iChanBlSensorType, iChanBl); 
+        % Sensor selection for the baseline correction
+        if ~isempty(ImportOptions) && isfield(ImportOptions, 'BaselineSensorType') && ~isempty(ImportOptions.BaselineSensorType)
+            % Select channels based on sensor types (or names) for baseline correction
+            iChanBlSensorType = channel_find(ChannelMat.Channel, ImportOptions.BaselineSensorType);
+            % Selected channels minus excluded
+            iChanBl = intersect(iChanBlSensorType, iChanBl);
+        end
         % Compute baseline
         blValue = mean(F(iChanBl,iTimesBl), 2);
         % Remove from recordings

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -2464,7 +2464,7 @@ function sProcesses = OptimizePipeline(sProcesses)
         end
         % Force overwrite
         if isfield(sProcesses(iProcess).options, 'overwrite') && ~sProcesses(iProcess).options.overwrite.Value
-            strWarning = [10 ' - Forcing overwrite option: Intermediate files are not saved in the database.'];
+            strWarning = [strWarning 10 ' - Forcing overwrite option: Intermediate files are not saved in the database.'];
         end
         % Merge processes
         iRemove(end+1) = iProcess;

--- a/toolbox/process/functions/process_import_data_epoch.m
+++ b/toolbox/process/functions/process_import_data_epoch.m
@@ -20,6 +20,7 @@ function varargout = process_import_data_epoch( varargin )
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2012-2017
+%          Raymundo Cassani, 2022
 
 eval(macro_method);
 end
@@ -105,6 +106,11 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.baseline.Type    = 'baseline';
     sProcess.options.baseline.Value   = [];
     sProcess.options.baseline.Hidden  = 1;
+    % Sensor types to remove DC offset (not displayed)
+    sProcess.options.blsensortypes.Comment = 'Sensor types or names (empty=all): ';
+    sProcess.options.blsensortypes.Type    = 'text';
+    sProcess.options.blsensortypes.Value   = 'MEG, EEG';
+    sProcess.options.blsensortypes.Hidden  = 1;
 end
 
 
@@ -190,12 +196,19 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     ImportOptions.DisplayMessages  = 0;
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
+        % BaselineRange
         if ~isempty(sProcess.options.baseline.Value{1})
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
         else
             ImportOptions.RemoveBaseline = 'all';
         end
+        % BaselineSensorType
+        if isfield(sProcess.options, 'blsensortypes') && ~isempty(sProcess.options.blsensortypes.Value)           
+            ImportOptions.BaselineSensorType  = sProcess.options.blsensortypes.Value;
+        else
+            ImportOptions.BaselineSensorType = '';
+        end       
     else
         ImportOptions.RemoveBaseline = 'no';
     end

--- a/toolbox/process/functions/process_import_data_event.m
+++ b/toolbox/process/functions/process_import_data_event.m
@@ -20,6 +20,7 @@ function varargout = process_import_data_event( varargin )
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2012-2022
+%          Raymundo Cassani, 2022
 
 eval(macro_method);
 end
@@ -118,6 +119,11 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.baseline.Type    = 'baseline';
     sProcess.options.baseline.Value   = [];
     sProcess.options.baseline.Hidden  = 1;
+    % Sensor types to remove DC offset (not displayed)
+    sProcess.options.blsensortypes.Comment = 'Sensor types or names (empty=all): ';
+    sProcess.options.blsensortypes.Type    = 'text';
+    sProcess.options.blsensortypes.Value   = 'MEG, EEG';
+    sProcess.options.blsensortypes.Hidden  = 1;
 end
 
 
@@ -224,12 +230,19 @@ function OutputFiles = Run(sProcess, sInput) %#ok<DEFNU>
     ImportOptions.DisplayMessages   = 0;
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
+        % BaselineRange
         if ~isempty(sProcess.options.baseline.Value{1})
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
         else
             ImportOptions.RemoveBaseline = 'all';
         end
+        % BaselineSensorType
+        if isfield(sProcess.options, 'blsensortypes') && ~isempty(sProcess.options.blsensortypes.Value)           
+            ImportOptions.BaselineSensorType  = sProcess.options.blsensortypes.Value;
+        else
+            ImportOptions.BaselineSensorType = '';
+        end       
     else
         ImportOptions.RemoveBaseline = 'no';
     end

--- a/toolbox/process/functions/process_import_data_time.m
+++ b/toolbox/process/functions/process_import_data_time.m
@@ -20,6 +20,7 @@ function varargout = process_import_data_time( varargin )
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2012-2015
+%          Raymundo Cassani, 2022
 
 eval(macro_method);
 end
@@ -104,6 +105,11 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.baseline.Type    = 'baseline';
     sProcess.options.baseline.Value   = [];
     sProcess.options.baseline.Hidden  = 1;
+    % Sensor types to remove DC offset (not displayed)
+    sProcess.options.blsensortypes.Comment = 'Sensor types or names (empty=all): ';
+    sProcess.options.blsensortypes.Type    = 'text';
+    sProcess.options.blsensortypes.Value   = 'MEG, EEG';
+    sProcess.options.blsensortypes.Hidden  = 1;
 end
 
 
@@ -176,18 +182,25 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     ImportOptions.CreateConditions = 1;
     ImportOptions.ChannelReplace   = ChannelReplace;
     ImportOptions.ChannelAlign     = ChannelAlign;
-   ImportOptions.IgnoreShortEpochs = 2 * sProcess.options.ignoreshort.Value;
+    ImportOptions.IgnoreShortEpochs = 2 * sProcess.options.ignoreshort.Value;
     ImportOptions.EventsMode       = 'ignore';
     ImportOptions.EventsTrackMode  = 'value';
     ImportOptions.DisplayMessages  = 0;
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
+        % BaselineRange
         if ~isempty(sProcess.options.baseline.Value{1})
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
         else
             ImportOptions.RemoveBaseline = 'all';
         end
+        % BaselineSensorType
+        if isfield(sProcess.options, 'blsensortypes') && ~isempty(sProcess.options.blsensortypes.Value)           
+            ImportOptions.BaselineSensorType  = sProcess.options.blsensortypes.Value;
+        else
+            ImportOptions.BaselineSensorType = '';
+        end       
     else
         ImportOptions.RemoveBaseline = 'no';
     end


### PR DESCRIPTION
* Allow to removing DC offset for specific channel types (or names) when `process_baseline` is combined with `process_import_data_event`, `process_import_data_time` or `process_import_data_epoch`

* Additional field handled `OptimizePipeline` and `OptimizePipelineRevert` in `bst_process`
 