### PR TITLE
Bugfix: Baseline option was ignored if [] when present at process_imp…

### DIFF
--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -2456,6 +2456,9 @@ function sProcesses = OptimizePipeline(sProcesses)
         switch (func2str(sProcesses(iProcess).Function))
             case 'process_baseline'
                 sProcesses(iImport).options.baseline = sProcesses(iProcess).options.baseline;
+                if isempty(sProcesses(iImport).options.baseline.Value{1})
+                    sProcesses(iImport).options.baseline.Value{1} = 'all';
+                end
                 sProcesses(iImport).options.blsensortypes = sProcesses(iProcess).options.sensortypes;
             case 'process_resample'
                 sProcesses(iImport).options.freq = sProcesses(iProcess).options.freq;
@@ -2501,6 +2504,9 @@ function sProcesses = OptimizePipelineRevert(sProcesses) %#ok<DEFNU>
         sProcAdd(end) = struct_copy_fields(sProcAdd(end), process_baseline('GetDescription'), 1);
         % Set options
         sProcAdd(end).options.baseline.Value = sProcesses(iImport).options.baseline.Value;
+        if strcmp(sProcAdd(end).options.baseline.Value{1}, 'all')
+            sProcAdd(end).options.baseline.Value{1} = [];
+        end
         sProcAdd(end).options.sensortypes.Value = sProcesses(iImport).options.blsensortypes.Value;
         % Remove option from initial process
         sProcesses(iImport).options = rmfield(sProcesses(iImport).options, 'baseline');

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -2504,7 +2504,7 @@ function sProcesses = OptimizePipelineRevert(sProcesses) %#ok<DEFNU>
         sProcAdd(end) = struct_copy_fields(sProcAdd(end), process_baseline('GetDescription'), 1);
         % Set options
         sProcAdd(end).options.baseline.Value = sProcesses(iImport).options.baseline.Value;
-        if strcmp(sProcAdd(end).options.baseline.Value{1}, 'all')
+        if isequal(sProcAdd(end).options.baseline.Value{1}, 'all')
             sProcAdd(end).options.baseline.Value{1} = [];
         end
         sProcAdd(end).options.sensortypes.Value = sProcesses(iImport).options.blsensortypes.Value;

--- a/toolbox/process/functions/process_import_data_epoch.m
+++ b/toolbox/process/functions/process_import_data_epoch.m
@@ -197,7 +197,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
         % BaselineRange
-        if strcmp(sProcess.options.baseline.Value{1}, 'all')
+        if isequal(sProcess.options.baseline.Value{1}, 'all')
             ImportOptions.RemoveBaseline = 'all';
             ImportOptions.BaselineRange  = [];
         else

--- a/toolbox/process/functions/process_import_data_epoch.m
+++ b/toolbox/process/functions/process_import_data_epoch.m
@@ -197,11 +197,12 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
         % BaselineRange
-        if ~isempty(sProcess.options.baseline.Value{1})
+        if strcmp(sProcess.options.baseline.Value{1}, 'all')
+            ImportOptions.RemoveBaseline = 'all';
+            ImportOptions.BaselineRange  = [];
+        else
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
-        else
-            ImportOptions.RemoveBaseline = 'all';
         end
         % BaselineSensorType
         if isfield(sProcess.options, 'blsensortypes') && ~isempty(sProcess.options.blsensortypes.Value)           

--- a/toolbox/process/functions/process_import_data_epoch.m
+++ b/toolbox/process/functions/process_import_data_epoch.m
@@ -200,7 +200,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         if isequal(sProcess.options.baseline.Value{1}, 'all')
             ImportOptions.RemoveBaseline = 'all';
             ImportOptions.BaselineRange  = [];
-        else
+        elseif ~isempty(sProcess.options.baseline.Value{1})
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
         end

--- a/toolbox/process/functions/process_import_data_event.m
+++ b/toolbox/process/functions/process_import_data_event.m
@@ -234,7 +234,7 @@ function OutputFiles = Run(sProcess, sInput) %#ok<DEFNU>
         if isequal(sProcess.options.baseline.Value{1}, 'all')
             ImportOptions.RemoveBaseline = 'all';
             ImportOptions.BaselineRange  = [];
-        else
+        elseif ~isempty(sProcess.options.baseline.Value{1})
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
         end

--- a/toolbox/process/functions/process_import_data_event.m
+++ b/toolbox/process/functions/process_import_data_event.m
@@ -231,7 +231,7 @@ function OutputFiles = Run(sProcess, sInput) %#ok<DEFNU>
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
         % BaselineRange
-        if strcmp(sProcess.options.baseline.Value{1}, 'all')
+        if isequal(sProcess.options.baseline.Value{1}, 'all')
             ImportOptions.RemoveBaseline = 'all';
             ImportOptions.BaselineRange  = [];
         else

--- a/toolbox/process/functions/process_import_data_event.m
+++ b/toolbox/process/functions/process_import_data_event.m
@@ -231,11 +231,12 @@ function OutputFiles = Run(sProcess, sInput) %#ok<DEFNU>
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
         % BaselineRange
-        if ~isempty(sProcess.options.baseline.Value{1})
+        if strcmp(sProcess.options.baseline.Value{1}, 'all')
+            ImportOptions.RemoveBaseline = 'all';
+            ImportOptions.BaselineRange  = [];
+        else
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
-        else
-            ImportOptions.RemoveBaseline = 'all';
         end
         % BaselineSensorType
         if isfield(sProcess.options, 'blsensortypes') && ~isempty(sProcess.options.blsensortypes.Value)           

--- a/toolbox/process/functions/process_import_data_time.m
+++ b/toolbox/process/functions/process_import_data_time.m
@@ -192,7 +192,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         if isequal(sProcess.options.baseline.Value{1}, 'all')
             ImportOptions.RemoveBaseline = 'all';
             ImportOptions.BaselineRange  = [];
-        else
+        elseif ~isempty(sProcess.options.baseline.Value{1})
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
         end

--- a/toolbox/process/functions/process_import_data_time.m
+++ b/toolbox/process/functions/process_import_data_time.m
@@ -189,7 +189,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
         % BaselineRange
-        if strcmp(sProcess.options.baseline.Value{1}, 'all')
+        if isequal(sProcess.options.baseline.Value{1}, 'all')
             ImportOptions.RemoveBaseline = 'all';
             ImportOptions.BaselineRange  = [];
         else

--- a/toolbox/process/functions/process_import_data_time.m
+++ b/toolbox/process/functions/process_import_data_time.m
@@ -189,11 +189,12 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % Extra options: Remove DC Offset
     if isfield(sProcess.options, 'baseline') && ~isempty(sProcess.options.baseline.Value)
         % BaselineRange
-        if ~isempty(sProcess.options.baseline.Value{1})
+        if strcmp(sProcess.options.baseline.Value{1}, 'all')
+            ImportOptions.RemoveBaseline = 'all';
+            ImportOptions.BaselineRange  = [];
+        else
             ImportOptions.RemoveBaseline = 'time';
             ImportOptions.BaselineRange  = sProcess.options.baseline.Value{1};
-        else
-            ImportOptions.RemoveBaseline = 'all';
         end
         % BaselineSensorType
         if isfield(sProcess.options, 'blsensortypes') && ~isempty(sProcess.options.blsensortypes.Value)           


### PR DESCRIPTION
`baseline` option was ignored if `[]` when passed with `process_import_data_{epoch, event, time}` in script generated with Brainstorm. The behaviour should be to apply DC removal with the `All file` option checked.