### PR TITLE
Allow rename cluster without GUI interaction

### DIFF
--- a/toolbox/gui/panel_cluster.m
+++ b/toolbox/gui/panel_cluster.m
@@ -613,44 +613,45 @@ function RemoveAllClusters()
     end
 end
 
-
 %% ===== EDIT CLUSTER LABEL =====
-% Rename one and only one selected cluster
-function EditClusterLabel(varargin)
-% Usage : EditClusterLabel()                   : interactive edition of cluster name
-%         EditClusterLabel(newLabel, iCluster) : update label of iCluster to newLabel, if newLabel is unique
+% Usage : EditClusterLabel()                   : Interactive edition of cluster name
+%         EditClusterLabel(newLabel, iCluster) : Update label of iCluster to newLabel, if newLabel is unique
+function EditClusterLabel(newLabel, iCluster)
     global GlobalData;
-    isInteractive = 1;
     % If newLabel and iCluster are provided
-    if (nargin == 2) && ~isempty(varargin{1}) && ~isempty(varargin{1}) 
-        isInteractive = 0;
-        newLabel = varargin{1};
-        SetSelectedClusters(varargin{2});
-    end   
-    % Get selected clusters
-    [sCluster, iCluster] = GetSelectedClusters();
-    % Warning message if no cluster selected
-    if isempty(sCluster)
-        java_dialog('warning', 'No cluster selected.', 'Rename selected cluster');
-        return;
-    % If more than one cluster selected: keep only the first one
-    elseif (length(sCluster) > 1)
-        iCluster = iCluster(1);
-        sCluster = sCluster(1);
-        SetSelectedClusters(iCluster);
-    end
-    if isInteractive
+    if (nargin == 2)
+        % Get input cluster
+        sCluster = GetClusters(iCluster);
+        if isempty(sCluster)
+            error('Invalid cluster index.');
+        elseif strcmpi(newLabel, sCluster.Label)
+            return;
+        elseif any(strcmpi({GlobalData.Clusters.Label}, newLabel))
+            error('Label already exists.');
+        end
+    % Interactive edit
+    else
+        % Get selected clusters
+        [sCluster, iCluster] = GetSelectedClusters();
+        % Warning message if no cluster selected
+        if isempty(sCluster)
+            java_dialog('warning', 'No cluster selected.', 'Rename selected cluster');
+            return;
+        % If more than one cluster selected: keep only the first one
+        elseif (length(sCluster) > 1)
+            iCluster = iCluster(1);
+            sCluster = sCluster(1);
+            SetSelectedClusters(iCluster);
+        end
         % Ask user for a new Cluster Label
         newLabel = java_dialog('input', sprintf('Please enter a new label for cluster "%s":', sCluster.Label), ...
-                                 'Rename selected cluster', [], sCluster.Label);
-    end
-    if isempty(newLabel) || strcmpi(newLabel, sCluster.Label)
-        return
-    end
-    % Check if newLabel already exists
-    if any(strcmpi({GlobalData.Clusters.Label}, newLabel))
-        java_dialog('warning', 'Cluster name already exists.', 'Rename selected cluster');
-        return;
+                               'Rename selected cluster', [], sCluster.Label);
+        if isempty(newLabel) || strcmpi(newLabel, sCluster.Label)
+            return
+        elseif any(strcmpi({GlobalData.Clusters.Label}, newLabel))
+            java_dialog('warning', 'Cluster name already exists.', 'Rename selected cluster');
+            return;
+        end
     end
     % Update cluster definition
     GlobalData.Clusters(iCluster).Label = newLabel;
@@ -659,7 +660,6 @@ function EditClusterLabel(varargin)
     % Select edited clusters (selection was lost during update)
     SetSelectedClusters(iCluster);
 end
-
 
 
 %% ===== SAVE CLUSTERS =====

--- a/toolbox/gui/panel_cluster.m
+++ b/toolbox/gui/panel_cluster.m
@@ -616,8 +616,17 @@ end
 
 %% ===== EDIT CLUSTER LABEL =====
 % Rename one and only one selected cluster
-function EditClusterLabel()
+function EditClusterLabel(varargin)
+% Usage : EditClusterLabel()                   : interactive edition of cluster name
+%         EditClusterLabel(newLabel, iCluster) : update label of iCluster to newLabel, if newLabel is unique
     global GlobalData;
+    isInteractive = 1;
+    % If newLabel and iCluster are provided
+    if (nargin == 2) && ~isempty(varargin{1}) && ~isempty(varargin{1}) 
+        isInteractive = 0;
+        newLabel = varargin{1};
+        SetSelectedClusters(varargin{2});
+    end   
     % Get selected clusters
     [sCluster, iCluster] = GetSelectedClusters();
     % Warning message if no cluster selected
@@ -630,13 +639,15 @@ function EditClusterLabel()
         sCluster = sCluster(1);
         SetSelectedClusters(iCluster);
     end
-    % Ask user for a new Cluster Label
-    newLabel = java_dialog('input', sprintf('Please enter a new label for cluster "%s":', sCluster.Label), ...
-                             'Rename selected cluster', [], sCluster.Label);
+    if isInteractive
+        % Ask user for a new Cluster Label
+        newLabel = java_dialog('input', sprintf('Please enter a new label for cluster "%s":', sCluster.Label), ...
+                                 'Rename selected cluster', [], sCluster.Label);
+    end
     if isempty(newLabel) || strcmpi(newLabel, sCluster.Label)
         return
     end
-    % Check if if already exists
+    % Check if newLabel already exists
     if any(strcmpi({GlobalData.Clusters.Label}, newLabel))
         java_dialog('warning', 'Cluster name already exists.', 'Rename selected cluster');
         return;


### PR DESCRIPTION
Allow rename cluster without GUI interaction, e.g.:

```
[sCluster, iCluster] = panel_cluster('CreateNewCluster', {'F2','F4','FC2','FC4'} );
panel_cluster('EditClusterLabel', 'right_anterior_medial', iCluster);
```