### PR TITLE
Reading CTF comp from fiff file

### DIFF
--- a/external/mne/matlab/fiff_read_ctf_comp.m
+++ b/external/mne/matlab/fiff_read_ctf_comp.m
@@ -103,7 +103,6 @@ for k = 1:length(comps)
     one.save_calibrated = calibrated;
     one.rowcals = ones(1,size(mat.data,1));
     one.colcals = ones(1,size(mat.data,2));
-    one = fiff_rename_comp(one, ch_rename);
     if ~calibrated
         %
         %   Calibrate...
@@ -143,6 +142,7 @@ for k = 1:length(comps)
     compdata(k)    = one;
     clear('row_cals');
     clear('col_cals');
+    one = fiff_rename_comp(one, ch_rename);
 end
 
 if length(compdata) > 0

--- a/external/mne/matlab/fiff_rename_comp.m
+++ b/external/mne/matlab/fiff_rename_comp.m
@@ -1,4 +1,4 @@
-function comp = fiff_rename_comp(one, ch_rename)
+function comp = fiff_rename_comp(comp, ch_rename)
 
 me='MNE:fiff_rename_comp';
 


### PR DESCRIPTION
I work at mgh under @mshamalainen. I'm trying to read a fiff file with raw data that has ctf compensator information (Fiff tag kinds 3580, 3581, 3582), but was unable to. To get the data loaded in, I:

- Renamed unused input variable 'one' in fiff_rename_comp to 'comp', the output variable, due to:

<img width="317" alt="comp" src="https://user-images.githubusercontent.com/34070103/158430247-49ec75bc-7972-4db1-b6e9-e7661ed568b8.png">

- Moved the call to fiff_rename_comp in fiff_read_ctf_comp to after the 'data' member of the input variable gets populated, due to:

<img width="311" alt="data" src="https://user-images.githubusercontent.com/34070103/158430332-8a76ee27-6ec0-4673-8eee-782badfad256.png">

After these changes I was able to load in the file. I noticed these same functions are used in mne-matlab, so this might also be present there.