### PR TITLE
Connectivity: Dynamic load of input files for coherence

### DIFF
--- a/toolbox/process/functions/process_extract_scout.m
+++ b/toolbox/process/functions/process_extract_scout.m
@@ -323,6 +323,9 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         % Replicate if no time
         if (length(sMat.Time) == 1)
             sMat.Time = [0,1];
+        elseif isempty(sMat.Time)
+            bst_report('Error', sProcess, sInputs(iInput), 'Invalid time selection.');
+            continue;
         end
         if ~isempty(matValues) && (size(matValues,2) == 1)
             matValues = [matValues, matValues];


### PR DESCRIPTION
@rcassani @HosseinShahabi 

This PR has the objective of loading the input files within bst_coh_2021 instead of pre-loading everything in advance, and therefore filling up the memory. 

Instead reading the files in bst_connectivity, it saves the function call used to read the file, and passes it to bst_coh_2021, which executes the loading call when needed. This approach should be scalable to any number of trials, and should solve the issue mentioned by @rcassani in the tutorial: 
https://neuroimage.usc.edu/brainstorm/Tutorials/CorticomuscularCoherence#Coherence:_EMG_x_Scouts

I had to move around all the input checks in bst_coh_2021, because now we don't know the size of the data at the beginning of the execution of the function. We only know the number of samples and signals when we actually execute the call to load the data, and we never have all the trials loaded in memory at once anymore.

Does it seem like a good solution?
Could you please double-check it works on some examples?