### PR TITLE
Set fFactor according to DisplayUnits in bst_colormaps

### DIFF
--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -1432,6 +1432,12 @@ function ConfigureColorbar(hFig, ColormapType, DataType, DisplayUnits) %#ok<DEFN
             if ~isempty(DisplayUnits)
                 if strcmp(DisplayUnits,'t')
                     fFactor = 1;
+                elseif strcmp(DisplayUnits,'fT')
+                    fFactor = 1e15;                  
+                elseif strcmp(DisplayUnits,'\muV')
+                    fFactor = 1e6;                  
+                elseif strcmp(DisplayUnits,'mV')
+                    fFactor = 1e3;                                      
                 elseif ~isempty(strfind(DisplayUnits,'mol'))
                      fmax = max(abs(dataBounds));
                      if round(log10(fmax)) < -3


### PR DESCRIPTION
Fix wrong behaviour of `Invalid scale` for colormap.
To reproduce: 
1. Display time series for MEG or EEG data and set Display mode to Butterfly
2. Now open the same data as 3D/2D cap or 2D Disc
3. The colormap in the new figure indicates `Invalid scale`