### PR TITLE
Add erpimage display option to matrix and matrixlist nodes

### DIFF
--- a/toolbox/gui/view_erpimage.m
+++ b/toolbox/gui/view_erpimage.m
@@ -177,6 +177,38 @@ switch (FileType)
         isStat = strcmpi(FileType, 'ptimefreq');
         TsInfo = [];
         PageName = '$freq';
+    
+    % ===== MATRIX =====
+    case 'matrix'
+        % Load data file
+        [iDS, iMatrix] = bst_memory('LoadMatrixFile', DataFiles{1});
+        if isempty(iDS)
+            return;
+        end 
+        % Get time vector
+        Time = bst_memory('GetTimeVector', iDS);
+        % Row names = channel names
+        RowNames = [GlobalData.DataSet(iDS).Matrix(iMatrix).Description(:)]';
+        % Read matrix file
+        sMat = in_bst_matrix(DataFiles{1}, 'Value');     
+        % Get Value
+        F = sMat.Value; 
+        % Display units
+        DisplayUnits = GlobalData.DataSet(iDS).Measures.DisplayUnits;   
+        % Colormap 
+        ColormapType = [];
+        if isNewFig
+            % New time series appdata structure
+            TsInfo = db_template('TsInfo');
+            TsInfo.FileName    = DataFiles{1};
+            TsInfo.Modality    = Modality;
+            TsInfo.DisplayMode = 'image';
+        else
+            % Get time series appdata structure from existing figure
+            TsInfo = getappdata(hFig, 'TsInfo');
+        end       
+        iChanModality = [];
+        isStat = strcmpi(FileType, 'pmatrix');
 end
 
 
@@ -208,27 +240,46 @@ switch lower(DisplayMode)
         bst_progress('start', 'ERP image', 'Loading data...', 1, length(DataFiles));
         % Load all the other files
         for i = 1:length(DataFiles)
-            % Load file
-            DataMat = in_bst_data(DataFiles{i});
-            % Check the time vector and channels list (all must be of the same length)
-            if (length(DataMat.Time) ~= length(Time))
-                error('All files must have the same number of time samples.');
-            elseif (size(DataMat.F,1) ~= length(GlobalData.DataSet(iDS).Channel))
-                error('All files must have the same number of channels.');
-            end
-            % Get data matrix
-            F = DataMat.F(iChanDisplay,:);
-            % Set bad channels to zero
-            if ~isequal(TsInfo.MontageName, 'Bad channels')
-                F(DataMat.ChannelFlag(iChanDisplay) == -1,:) = 0;
-            end
-            % Apply montage to the data
-            if ~isempty(TsInfo.MontageName) && ~isempty(sMontage)
-                F = panel_montage('ApplyMontage', sMontage, F, GlobalData.DataSet(iDS).DataFile, iMatrixDisp, iMatrixChan);
-            end
+            switch (FileType)
+                % ===== RECORDINGS =====
+                case {'data','pdata'} 
+                    % Load file
+                    DataMat = in_bst_data(DataFiles{i});
+                    Comment = DataMat.Comment;
+                    % Check the time vector and channels list (all must be of the same length)
+                    if (length(DataMat.Time) ~= length(Time))
+                        error('All files must have the same number of time samples.');
+                    elseif (size(DataMat.F,1) ~= length(GlobalData.DataSet(iDS).Channel))
+                        error('All files must have the same number of channels.');
+                    end
+                    % Get data matrix
+                    F = DataMat.F(iChanDisplay,:);
+                    % Set bad channels to zero
+                    if ~isequal(TsInfo.MontageName, 'Bad channels')
+                        F(DataMat.ChannelFlag(iChanDisplay) == -1,:) = 0;
+                    end
+                    % Apply montage to the data
+                    if ~isempty(TsInfo.MontageName) && ~isempty(sMontage)
+                        F = panel_montage('ApplyMontage', sMontage, F, GlobalData.DataSet(iDS).DataFile, iMatrixDisp, iMatrixChan);
+                    end
+                    
+                % ===== MATRIX =====
+                case 'matrix'
+                    % Read matrix file
+                    sMat = in_bst_matrix(DataFiles{i});     
+                    % Get Value
+                    F = sMat.Value;
+                    Comment = sMat.Comment;
+                    % Check the time vector and row names (all must be of the same length)
+                    if (length(sMat.Time) ~= length(Time))
+                        error('All files must have the same number of time samples.');
+                    elseif (size(sMat.Value,1) ~= length(RowNames))
+                        error('All files must have the same number of rows.');
+                    end
+            end                   
             % Copy recordings
             ERP(i,1,:,:) = F';
-            FileComments{i} = DataMat.Comment;
+            FileComments{i} = Comment;
             % Increment progress bar
             bst_progress('inc', 1);
         end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -2306,6 +2306,8 @@ switch (lower(action))
                         jMenuCluster = gui_component('Menu', jPopup, [], 'Significant clusters', IconLoader.ICON_ATLAS, [], []);
                         gui_component('MenuItem', jMenuCluster, [], 'Cluster indices', IconLoader.ICON_TIMEFREQ, [], @(h,ev)view_statcluster(filenameRelative, 'clustindex_time', []));
                     end
+                else
+                    gui_component('MenuItem', jPopup, [], 'Display as image', IconLoader.ICON_NOISECOV, [], @(h,ev)view_erpimage(GetAllFilenames(bstNodes), 'erpimage', 'none'));
                 end
                 % Export to file
                 if strcmpi(nodeType, 'matrix')
@@ -2314,7 +2316,7 @@ switch (lower(action))
                 
 %% ===== POPUP: MATRIX LIST =====
             case 'matrixlist'
-                % Nothing for now
+                gui_component('MenuItem', jPopup, [], 'Display as image', IconLoader.ICON_NOISECOV, [], @(h,ev)view_erpimage(GetAllFilenames(bstNodes, 'matrix'), 'erpimage', 'none'));
         end
         
 %% ===== POPUP: COMMON MENUS =====


### PR DESCRIPTION
Add the option "Display as image" when two matrix nodes (or a matrixlist node) are selected. 
This display can be useful to visualize data extracted from multiple trials. E.g, scout time series.