### PR TITLE
Bugfix: Keep tolerance value for auto-align when multiple raw files a…

### DIFF
--- a/toolbox/db/db_set_channel.m
+++ b/toolbox/db/db_set_channel.m
@@ -1,4 +1,4 @@
-function [OutputFile, ChannelMat, ChannelReplace, ChannelAlign, Modality] = db_set_channel( iStudy, ChannelMat, ChannelReplace, ChannelAlign )
+function [OutputFile, ChannelMat, ChannelReplace, ChannelAlign, Modality, Tolerance] = db_set_channel( iStudy, ChannelMat, ChannelReplace, ChannelAlign, Tolerance)
 % DB_SET_CHANNEL: Define a channel file for a given study.
 %
 % USAGE:  db_set_channel( iStudy, ChannelMat,  ChannelReplace=1, ChannelAlign=1 )
@@ -16,6 +16,8 @@ function [OutputFile, ChannelMat, ChannelReplace, ChannelAlign, Modality] = db_s
 %    - ChannelAlign   : 0, do not perform automatic headpoints-based alignment
 %                       1, perform automatic alignment after user confirmation
 %                       2, perform automatic alignment without user confirmation
+%    - Tolerance      : Percentage of outliers head points, ignored in the final fit
+%
 % OUTPUT:
 %    - OutputFile: Newly created channel file (empty is no file created)
 
@@ -41,6 +43,9 @@ function [OutputFile, ChannelMat, ChannelReplace, ChannelAlign, Modality] = db_s
 
 %% ===== PARSE INPUTS =====
 % Check inputs
+if (nargin < 5) || isempty(Tolerance)
+    Tolerance = 0;
+end
 if (nargin < 4) || isempty(ChannelAlign)
     ChannelAlign = 1;
 end
@@ -175,7 +180,7 @@ if (ChannelAlign >= 1)
     end
     
     % Call automatic registration for MEG
-    [ChannelMat, R, T, isSkip, isUserCancel] = channel_align_auto(OutputFile, [], 0, isConfirm);
+    [ChannelMat, R, T, isSkip, isUserCancel, strReport, Tolerance] = channel_align_auto(OutputFile, [], 0, isConfirm, Tolerance);
     % User validated: keep this answer for the next round (force alignment for next call)
     if ~isSkip
         if isUserCancel

--- a/toolbox/io/import_raw.m
+++ b/toolbox/io/import_raw.m
@@ -118,6 +118,7 @@ end
 %% ===== IMPORT =====
 iOutputStudy = [];
 isSSP = 0;
+Tolerance = [];
 % Loop on the files to import
 for iFile = 1:length(RawFiles)
     % ===== OPENING FILE =====
@@ -282,7 +283,7 @@ for iFile = 1:length(RawFiles)
         % Channel structure loaded from file
         else
             % Add channel file to database
-            [ChannelFile, ChannelMat, ImportOptions.ChannelReplace, ImportOptions.ChannelAlign, Modality] = db_set_channel(iChannelStudy, ChannelMat, ImportOptions.ChannelReplace, ImportOptions.ChannelAlign);
+            [ChannelFile, ChannelMat, ImportOptions.ChannelReplace, ImportOptions.ChannelAlign, Modality, Tolerance] = db_set_channel(iChannelStudy, ChannelMat, ImportOptions.ChannelReplace, ImportOptions.ChannelAlign, Tolerance);
             % If loading SEEG or ECOG data: change the sensor type
             if ismember(FileFormat, {'SEEG-ALL', 'ECOG-ALL'})
                 Mod = strrep(FileFormat, '-ALL', '');

--- a/toolbox/sensors/channel_align_auto.m
+++ b/toolbox/sensors/channel_align_auto.m
@@ -1,4 +1,4 @@
-function [ChannelMat, R, T, isSkip, isUserCancel, strReport] = channel_align_auto(ChannelFile, ChannelMat, isWarning, isConfirm, tolerance)
+function [ChannelMat, R, T, isSkip, isUserCancel, strReport, tolerance] = channel_align_auto(ChannelFile, ChannelMat, isWarning, isConfirm, tolerance)
 % CHANNEL_ALIGN_AUTO: Aligns the channels to the scalp using Polhemus points.
 %
 % USAGE:  [ChannelMat, R, T, isSkip, isUserCancel, strReport] = channel_align_auto(ChannelFile, ChannelMat=[], isWarning=1, isConfirm=1, tolerance=0)
@@ -27,6 +27,8 @@ function [ChannelMat, R, T, isSkip, isUserCancel, strReport] = channel_align_aut
 %     - isSkip       : If 1, processing was skipped because there was not enough information in the file
 %     - isUserCancel : If 1, user cancelled the alignment
 %     - strReport    : Text description of the quality of the alignment (distance between headpoint and scalp surface)
+%     - tolerance    : The same tolerance input if alignment was performed, otherwise empty
+
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -132,6 +134,7 @@ if (isConfirm || isWarning)
                                 'Refine registration', [], num2str(round(tolerance*100)));
     if isempty(res) || isnan(str2double(res))
         isUserCancel = 1;
+        tolerance = [];
         bst_progress('stop');
         return
     end
@@ -150,6 +153,7 @@ if ~isempty(tolerance)
         end
         % Cancel processing as a user error
         isUserCancel = 1;
+        tolerance = [];
         bst_progress('stop');
         return
     end
@@ -175,6 +179,7 @@ end
 if isempty(R)
     bst_progress('stop');
     isSkip = 1;
+    tolerance = [];
     return;
 end
 % Distance between fitted points and reference surface


### PR DESCRIPTION
**Issue**: When the user links a directory with many raw files, selects [Yes] in the "Refine registration" window and sets the tolerance value. This tolerance value is used only for the first raw file, for the 2nd (and the next) raw files the value is reset to 0. 
Issue discovered by @ZaidaEMtzMo 

**Expected behaviour**: Use the same answer ([Yes]) and same tolerance for all the raw files imported in the same call. 