### PR TITLE
Feature: Bit behaviour for process_evt_read.m

### DIFF
--- a/toolbox/process/functions/process_evt_read.m
+++ b/toolbox/process/functions/process_evt_read.m
@@ -295,7 +295,6 @@ function [events, EventsTrackMode, StimChan] = Compute(sFile, ChannelMat, StimCh
                 tracks = double(bitand(uint32(tracks), 2^16-1));
             end
             % Determine the precise timing of the triggers (from FieldTrip's read_ctf_trigger)
-            upflank = [0 (diff(tracks)>0 & tracks(1:(end-1))==0)];
             tracks = upflank(1:(end-trigshift)).*tracks((1+trigshift):end);
         % Other formats
         else

--- a/toolbox/process/functions/process_evt_read.m
+++ b/toolbox/process/functions/process_evt_read.m
@@ -222,7 +222,6 @@ function [events, EventsTrackMode, StimChan] = Compute(sFile, ChannelMat, StimCh
             StimChan = StimChan(1:end-3);
         end
     end
-    trigshift = fix(sFile.prop.sfreq * 9/1200);
 
     % ===== ASK READ MODE =====
     if strcmpi(EventsTrackMode, 'ask')
@@ -294,8 +293,6 @@ function [events, EventsTrackMode, StimChan] = Compute(sFile, ChannelMat, StimCh
             elseif isCtfLow
                 tracks = double(bitand(uint32(tracks), 2^16-1));
             end
-            % Determine the precise timing of the triggers (from FieldTrip's read_ctf_trigger)
-            tracks = upflank(1:(end-trigshift)).*tracks((1+trigshift):end);
         % Other formats
         else
             % Old code: Might be useless and/or detrimental to the reading of the events


### PR DESCRIPTION
This PR addresses the issue pointed by @Moo-Marc in the Forum post: https://neuroimage.usc.edu/forums/t/reading-ctf-digital-stim-events-in-bit-mode/34897

* Removes the trigger-shift corrections. This was introduced in 9329fa0 along side improvements in reading CTF triggers.
* Keep all changes in tracks (x→y, 0→x and x→0), not only from 0→x
* For the "Bit" option and Not "Accept zeros as trigger values". The nBit event group registers the set (0→1) of nBit.
* For the "Bit" option and "Accept zeros as trigger values". The nBit event group registers the set (0→1) and reset (1→0) of the nBit. However these two events will have the same event label. As a former improvement we could create two event groups: nBit-Set and nBit-Reset