### PR TITLE
Enforce to display "No units" for SSP and ICA component plots 

### DIFF
--- a/toolbox/gui/panel_ssp_selection.m
+++ b/toolbox/gui/panel_ssp_selection.m
@@ -497,6 +497,9 @@ function PlotComponents(UseSmoothing, isPlotTopo, isPlotTs)
             % Plot single topography
             if (length(iComp) == 1)
                 EditSspPanel.hFigTopo(end+1) = view_topography(DataFile, modPlot, [], Topo, UseSmoothing, 'NewFigure');
+                % Enforce 'no units' for colorbar
+                hColorbar = findobj(EditSspPanel.hFigTopo(end), '-depth', 1, 'Tag', 'Colorbar');
+                xlabel(hColorbar, 'No units');   
             % Plot all the components in a contact sheet
             else
                 % Open figure
@@ -579,10 +582,15 @@ function PlotComponents(UseSmoothing, isPlotTopo, isPlotTs)
                 TsInfo.DisplayMode = 'column';
                 setappdata(EditSspPanel.hFigTs, 'TsInfo', TsInfo);
                 % Re-plot figure
-                bst_figures('ReloadFigures', EditSspPanel.hFigTs);
+                bst_figures('ReloadFigures', EditSspPanel.hFigTs);              
             end
             % Update the montage for this figure
             panel_montage('SetCurrentMontage', EditSspPanel.hFigTs, sMontage.Name);
+            % Enforce 'no units' for scale
+            hColumnScaleText = findobj(EditSspPanel.hFigTs, '-depth', 2, 'Tag', 'ColumnScaleText');
+            txtAmp = get(hColumnScaleText, 'String');
+            txtAmp = regexprep(txtAmp,'\s.*', ' No units');
+            set(hColumnScaleText, 'String', txtAmp);  
         end
     end
 end


### PR DESCRIPTION
The time series and the scalp maps of the components obtained with either ICA or SSP (PCA) are in arbitrary units. It's their product the one that has the same units as the original data. This should be explicit. 

See forum question: https://neuroimage.usc.edu/forums/t/flat-time-series-components/34408

This PR, enforces the display of "No units" in the colorbar (displayed for topography) and the scale in the time series figure. 

* An example of the time series of SSP components taking the units of the data can be seen in the introduction tutorial. 
  ![image](https://user-images.githubusercontent.com/8238803/168688514-96ce0e9c-9102-45d1-b7b9-916df8aa63bf.png)
  Plot of the first 4 SSP components for `blink`

* An example of the scalp maps of ICA components taking the units of the data can be seen in the epilepsy tutorial:
  ![image](https://user-images.githubusercontent.com/8238803/168690157-05dcde3c-01da-4d19-bf92-2e0c7d7fcdd7.png)
  Topoplot for 1st ICA component



  








