### PR TITLE
Github Action to automate check for changes on coil_def file

### DIFF
--- a/.github/workflows/coil_def_check.yml
+++ b/.github/workflows/coil_def_check.yml
@@ -1,0 +1,49 @@
+name: 'coil_def.dat Update Checker' 
+on: 
+  schedule:
+    # runs at 9:00h UTC, any day of the month, any month, on Monday.
+    - cron: '0 9 * * 1'
+
+permissions:
+  issues: write
+
+jobs:
+  Compare-coil_def-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone brainstorm repo
+        uses: actions/checkout@v3
+        
+      - name: Download coil_def.dat from mne-python repo
+        run: |
+          coilDefUrl=https://raw.githubusercontent.com/mne-tools/mne-python/main/mne/data/coil_def.dat
+          curl $coilDefUrl -o toolbox/io/private/coil_def.dat
+          if [[ $(git diff) ]]; then
+            echo 'detected diferences between coil_def.dat versions'
+            echo 'COILDEF_FILES_DIFERENT=TRUE' >> $GITHUB_ENV
+          else
+            echo 'no diferences between coil_def.dat versions'
+            echo 'COILDEF_FILES_DIFERENT=FALSE' >> $GITHUB_ENV
+          fi
+          
+      - name: Create Issue if different
+        if: ${{ env.COILDEF_FILES_DIFERENT == 'TRUE' }}
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          title: coil_def.dat needs update
+          body: |
+            ### Context
+            This issue is automatically created because ```coil_def.dat``` between Brainstorm and MNE-Python have diverged.
+            ### Review Differences
+            - MNE-Python version: [mne-python/mne/data/coil_def.dat](https://github.com/mne-tools/mne-python/blob/main/mne/data/coil_def.dat).
+            - Brainstorm version: [brainstorm3/toolbox/io/private/coil_def.dat](https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/io/private/coil_def.dat).
+            ### Update changes
+            - Manually verify the changes and if needed, update ```coil_def.dat``` and create a pull request.
+
+
+
+            
+
+
+

--- a/.github/workflows/coil_def_check.yml
+++ b/.github/workflows/coil_def_check.yml
@@ -1,8 +1,8 @@
 name: 'coil_def.dat Update Checker' 
 on: 
   schedule:
-    # runs at 9:00h UTC, any day of the month, any month, on Monday.
-    - cron: '0 9 * * 1'
+    # runs at 9:00h UTC, every day of the month, every month, on Mondays to Fridays.
+    - cron: '0 9 * * 1-5'
 
 permissions:
   issues: write


### PR DESCRIPTION
A long term solution to automatically check for updates for MNE-Python's version of coil_def.dat seems interesting. This option takes advantage of the free cloud service provided by Github to check for changes in the file and generate an issue.

See discussion in #551. 

The scripts runs in about 10 seconds or so.
In the future, other parallel jobs can be created completely independent of this one.
If differences are detected between ```coil_def.dat``` stored in MNE-Python and the one stored in this repo, an issue is created similar to this one: https://github.com/juangpc/brainstorm3/issues/7

The job is right now configured to run every day of the week, at 9am UTC. This can be easily changed. See lines [3-4 of the yml file)](https://github.com/juangpc/brainstorm3/blob/44dce088a2e66c1295429d5f9797399eb90d481f/.github/workflows/coil_def_check.yml#L4)

If no differences are detected, nothing happens. 

If an error occurs during the execution of the Github Action, an email is received. This option can be optionally turned off in the settings menu.

This solution is stable and extensively used in many other repositories. Externally the only change is the appearance of a ```.github``` folder in the repository.

If this turns out to be not the best option, feel free to drop this pr. Hope it helps.