### PR TITLE
Improve calls to terminal and file explorer in Linux

### DIFF
--- a/toolbox/misc/bst_which.m
+++ b/toolbox/misc/bst_which.m
@@ -71,24 +71,28 @@ else
     % === TERMINAL ===
     if isTerminal
         xdg_deskptop = getenv('XDG_CURRENT_DESKTOP');
-        switch xdg_deskptop
-            % GNOME & Cinnamom
-            case {'GNOME', 'GNOME-Classic:GNOME', 'GNOME-Flashback:GNOME', 'Cinnamon', 'X-Cinnamon'}
-                [status, cmdout] = system(['gnome-terminal --working-directory="' filepath '" &']);
-            % KDE
-            case 'KDE'
-                [status, cmdout] = system(['export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu && konsole --workdir "' filepath '" &']);
-            % MATE
-            case 'MATE'
-                [status, cmdout] = system(['mate-terminal --working-directory="' filepath '" &']);
-            otherwise
-                status = 1;
+        % KDE default terminal
+        if strcmp('KDE', xdg_deskptop) && (system('which konsole > /dev/null') == 0)
+            [status, cmdout] = system(['export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu && konsole --workdir "' filepath '" &']);
+            if status == 0, return; end
         end
-        if status ~= 0
-            [status, cmdout] = system(['xterm -e ''cd "' filepath '" && /bin/bash'' &']);
+        % MATE default terminal
+        if strcmp('MATE', xdg_deskptop) && (system('which mate-terminal > /dev/null') == 0)
+            [status, cmdout] = system(['mate-terminal --working-directory="' filepath '" &']);
+            if status == 0, return; end
         end
-        return
-
+        % GNOME terminal
+        if system('which gnome-terminal > /dev/null') == 0
+            [status, cmdout] = system(['gnome-terminal --working-directory="' filepath '" &']);
+            if status == 0, return; end
+        end
+        % XTERM
+        if system('which xterm > /dev/null')
+            system(['xterm -e ''cd "' filepath '" && /bin/bash'' &']);
+            if status == 0, return; end
+        end
+        % Error
+        error('No terminal emulator found for your operating system.');
         
     % === FILE EXPLORERS ===
     else

--- a/toolbox/misc/bst_which.m
+++ b/toolbox/misc/bst_which.m
@@ -93,24 +93,22 @@ else
     % === FILE EXPLORERS ===
     else
         % Any X Desktop Group (XDG) compliant
-        [ixXdg, cmdout] = system('which xdg-open');
+        ixXdg = system('which xdg-open > /dev/null');
         if (ixXdg == 0)          
             [status, cmdout] = system(['xdg-open "' filepath '"']);
-            if status == 0
-                return
-            end
+            if status == 0, return; end
         end
         % DOLPHIN (KDE)
-        [isKde, cmdout] = system('which dolphin');
+        isKde = system('which dolphin > /dev/null');
         if (isKde == 0)
-            system(['export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu && dolphin "' filepath '" &']);
-            return
+            [status, cmdout] = system(['export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu && dolphin "' filepath '" &']);
+            if status == 0, return; end
         end
         % NAUTILUS (GNOME)
-        [isGnome, cmdout] = system('which nautilus');
+        isGnome = system('which nautilus > /dev/null');
         if (isGnome == 0)
-            system(['nautilus "' filepath '" &']);
-            return
+            [status, cmdout] = system(['nautilus "' filepath '" &']);
+            if status == 0, return; end
         end
         % Error
         error('No file manager found for your operating system.');

--- a/toolbox/misc/bst_which.m
+++ b/toolbox/misc/bst_which.m
@@ -70,44 +70,46 @@ elseif strncmp(computer,'MAC',3)
 else
     % === TERMINAL ===
     if isTerminal
-        % GNOME
-        isGnome = system('which gnome-terminal');
-        if (isGnome == 0)
-            system(['gnome-terminal --working-directory="' filepath '" &']);
-            return
+        xdg_deskptop = getenv('XDG_CURRENT_DESKTOP');
+        switch xdg_deskptop
+            % GNOME & Cinnamom
+            case {'GNOME', 'GNOME-Classic:GNOME', 'GNOME-Flashback:GNOME'}
+                [status, cmdout] = system(['gnome-terminal --working-directory="' filepath '" &']);
+            % KDE
+            case 'KDE'
+                [status, cmdout] = system(['export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu && konsole --workdir "' filepath '" &']);
+            % MATE
+            case 'MATE'
+                [status, cmdout] = system(['mate-terminal --working-directory="' filepath '" &']);
+            otherwise
+                status = 1;
         end
-        % KDE
-        isKde = system('which konsole');
-        if (isKde == 0)
-            system(['konsole --workdir "' filepath '" &']);
-            return
+        if status ~= 0
+            [status, cmdout] = system(['xterm -e ''cd "' filepath '" && /bin/bash'' &']);
         end
-        % ELSE: XTERM
-        isXterm = system('which xterm');
-        if (isXterm == 0)
-            system(['xterm -e ''cd "' filepath '" && /bin/bash'' &']);
-            return
-        end
+        return
+
         
     % === FILE EXPLORERS ===
     else
         % Any X Desktop Group (XDG) compliant
-        ixXdg = system('which xdg-open');
+        [ixXdg, cmdout] = system('which xdg-open');
         if (ixXdg == 0)          
-            system(['xdg-open "' filepath '"']);
+            [status, cmdout] = system(['xdg-open "' filepath '"']);
+            if status == 0
+                return
+            end
+        end
+        % DOLPHIN (KDE)
+        [isKde, cmdout] = system('which dolphin');
+        if (isKde == 0)
+            system(['export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu && dolphin "' filepath '" &']);
             return
         end
         % NAUTILUS (GNOME)
-        isGnome = system('which nautilus');
+        [isGnome, cmdout] = system('which nautilus');
         if (isGnome == 0)
-            %unix(['xterm -e "nautilus \"' filepath '\""']);
             system(['nautilus "' filepath '" &']);
-            return
-        end
-        % KONQUEROR (KDE)
-        isKde = system('which konqueror');
-        if (isKde == 0)
-            system(['xterm -e "konqueror \"' filepath '\"" &']);
             return
         end
         % Error

--- a/toolbox/misc/bst_which.m
+++ b/toolbox/misc/bst_which.m
@@ -88,10 +88,11 @@ else
         end
         % XTERM
         if system('which xterm > /dev/null')
-            system(['xterm -e ''cd "' filepath '" && /bin/bash'' &']);
+            [status, cmdout] = system(['xterm -e ''cd "' filepath '" && /bin/bash'' &']);
             if status == 0, return; end
         end
         % Error
+        disp(cmdout);
         error('No terminal emulator found for your operating system.');
         
     % === FILE EXPLORERS ===
@@ -115,6 +116,7 @@ else
             if status == 0, return; end
         end
         % Error
+        disp(cmdout);
         error('No file manager found for your operating system.');
     end
 end

--- a/toolbox/misc/bst_which.m
+++ b/toolbox/misc/bst_which.m
@@ -73,7 +73,7 @@ else
         xdg_deskptop = getenv('XDG_CURRENT_DESKTOP');
         switch xdg_deskptop
             % GNOME & Cinnamom
-            case {'GNOME', 'GNOME-Classic:GNOME', 'GNOME-Flashback:GNOME'}
+            case {'GNOME', 'GNOME-Classic:GNOME', 'GNOME-Flashback:GNOME', 'Cinnamon', 'X-Cinnamon'}
                 [status, cmdout] = system(['gnome-terminal --working-directory="' filepath '" &']);
             % KDE
             case 'KDE'


### PR DESCRIPTION
- Support for default terminal and default-explorer according DE.
- Bugfix: In KDE (Plasma 5), an error occur when `File > Show in file explorer`. Caused due to old Qt libraries distributed with Matlab (18b, 19b, 20b and 21b). Solution: LD_LIBRARY_PATH is set when calling the KDE default terminal and default file explorer with `system()`.
- KDE now calls Dolphin, which is the default file explorer, instead of Konqueror (webbrowser).
- The command output is omitted when there is not error.
