### PR TITLE
Bugfix: Handle `badSeg` when out-of or half-in the user-specified `TimeWindow`

### DIFF
--- a/toolbox/process/functions/process_evt_detect.m
+++ b/toolbox/process/functions/process_evt_detect.m
@@ -197,34 +197,20 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         end
         
         % ===== BAD SEGMENTS =====
-        % If ignore bad segments
         Fmask = [];
         if isIgnoreBad
-            % Get list of bad segments in file
-            badSeg = panel_record('GetBadSegments', sFile);
-            % Adjust with beginning of file
-            badSeg = badSeg - round(sFile.prop.times(1) .* sFile.prop.sfreq) + 1;
-            if ~isempty(TimeWindow)
-                badSeg = badSeg - (bst_closest(TimeWindow(1), DataMat.Time) - 1);
-                % badSeg outside of TimeVector: 0=in, 1=half-in 2=out
-                badSeg_status = sum(badSeg < 1) + sum(badSeg > length(TimeVector), 1);
-                % Ignore badSeg out of TimeVector
-                badSeg(:,badSeg_status == 2) = [];
-                % Handle badSeg half-in TimeVector
-                badSeg(1, badSeg(1, :) < 0) = 1;
-                badSeg(2, badSeg(2, :) > length(TimeVector)) = length(TimeVector);
-                badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
-            end
+            badSeg = GetBadSegments(sFile, TimeWindow, DataMat.Time, length(TimeVector));
             if ~isempty(badSeg)
                 % Create file mask
                 Fmask = true(size(F));
                 % Loop on each segment: mark as bad
                 for iSeg = 1:size(badSeg, 2)
-                    Fmask(badSeg(1,iSeg):badSeg(2,iSeg)) = false;
+                    Fmask(:, badSeg(1,iSeg):badSeg(2,iSeg)) = false;
                 end
             end
         end
         
+
         % ===== DETECT PEAKS =====
         % Progress bar
         bst_progress('text', 'Detecting peaks...');
@@ -529,4 +515,24 @@ function [iChannels, iChanWeights] = ParseChannelMontage(strMontage, ChannelName
 end
             
 
+
+%% ===== GET VALID BAD SEGMENTS =====
+function badSeg = GetBadSegments(sFile, TimeWindow, DataMatTime, nReadTimes)
+    % Get list of bad segments in file
+    badSeg = panel_record('GetBadSegments', sFile);
+    % Adjust with beginning of file
+    badSeg = badSeg - round(sFile.prop.times(1) .* sFile.prop.sfreq) + 1;
+    % Keep bad segments in TimeWindow
+    if ~isempty(TimeWindow)
+        badSeg = badSeg - (bst_closest(TimeWindow(1), DataMatTime) - 1);
+        % badSeg outside of ReadTime: 0=in, 1=half-in 2=out
+        badSeg_status = sum(badSeg < 1, 1) + sum(badSeg > nReadTimes, 1);
+        % Ignore badSeg out of ReadTime
+        badSeg(:,badSeg_status == 2) = [];
+        % Handle badSeg half-in ReadTime
+        badSeg(1, badSeg(1, :) < 1) = 1;
+        badSeg(2, badSeg(2, :) > nReadTimes) = nReadTimes;
+        badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
+    end
+end
 

--- a/toolbox/process/functions/process_evt_detect.m
+++ b/toolbox/process/functions/process_evt_detect.m
@@ -206,6 +206,14 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             badSeg = badSeg - round(sFile.prop.times(1) .* sFile.prop.sfreq) + 1;
             if ~isempty(TimeWindow)
                 badSeg = badSeg - (bst_closest(TimeWindow(1), DataMat.Time) - 1);
+                % badSeg outside of TimeVector: 0=in, 1=half-in 2=out
+                badSeg_status = sum(badSeg < 1) + sum(badSeg > length(TimeVector), 1);
+                % Ignore badSeg out of TimeVector
+                badSeg(:,badSeg_status == 2) = [];
+                % Handle badSeg half-in TimeVector
+                badSeg(1, badSeg(1, :) < 0) = 1;
+                badSeg(2, badSeg(2, :) > length(TimeVector)) = length(TimeVector);
+                badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
             end
             if ~isempty(badSeg)
                 % Create file mask

--- a/toolbox/process/functions/process_evt_detect_analog.m
+++ b/toolbox/process/functions/process_evt_detect_analog.m
@@ -230,30 +230,15 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         end
         
         % ===== BAD SEGMENTS =====
-        % If ignore bad segments
         Fmask = [];
         if isIgnoreBad
-            % Get list of bad segments in file
-            badSeg = panel_record('GetBadSegments', sFile);
-            % Adjust with beginning of file
-            badSeg = badSeg - round(sFile.prop.times(1) .* sFile.prop.sfreq) + 1;
-            if ~isempty(TimeWindow)
-                badSeg = badSeg - (bst_closest(TimeWindow(1), DataMat.Time) - 1);
-                % badSeg outside of TimeVector: 0=in, 1=half-in 2=out
-                badSeg_status = sum(badSeg < 1) + sum(badSeg > length(TimeVector), 1);
-                % Ignore badSeg out of TimeVector
-                badSeg(:,badSeg_status == 2) = [];
-                % Handle badSeg half-in TimeVector
-                badSeg(1, badSeg(1, :) < 0) = 1;
-                badSeg(2, badSeg(2, :) > length(TimeVector)) = length(TimeVector);
-                badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
-            end
+            badSeg = process_evt_detect('GetBadSegments', sFile, TimeWindow, DataMat.Time, length(TimeVector));
             if ~isempty(badSeg)
                 % Create file mask
                 Fmask = true(size(F));
                 % Loop on each segment: mark as bad
                 for iSeg = 1:size(badSeg, 2)
-                    Fmask(badSeg(1,iSeg):badSeg(2,iSeg)) = false;
+                    Fmask(:, badSeg(1,iSeg):badSeg(2,iSeg)) = false;
                 end
             end
         end

--- a/toolbox/process/functions/process_evt_detect_analog.m
+++ b/toolbox/process/functions/process_evt_detect_analog.m
@@ -239,6 +239,14 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             badSeg = badSeg - round(sFile.prop.times(1) .* sFile.prop.sfreq) + 1;
             if ~isempty(TimeWindow)
                 badSeg = badSeg - (bst_closest(TimeWindow(1), DataMat.Time) - 1);
+                % badSeg outside of TimeVector: 0=in, 1=half-in 2=out
+                badSeg_status = sum(badSeg < 1) + sum(badSeg > length(TimeVector), 1);
+                % Ignore badSeg out of TimeVector
+                badSeg(:,badSeg_status == 2) = [];
+                % Handle badSeg half-in TimeVector
+                badSeg(1, badSeg(1, :) < 0) = 1;
+                badSeg(2, badSeg(2, :) > length(TimeVector)) = length(TimeVector);
+                badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
             end
             if ~isempty(badSeg)
                 % Create file mask

--- a/toolbox/process/functions/process_evt_detect_badsegment.m
+++ b/toolbox/process/functions/process_evt_detect_badsegment.m
@@ -206,6 +206,14 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 badSeg = badSeg - fileSamples(1) + 1;
                 if ~isempty(TimeWindow)
                     badSeg = badSeg - (bst_closest(TimeWindow(1), DataMat.Time) - 1);
+                    % badSeg outside of TimeVector: 0=in, 1=half-in 2=out
+                    badSeg_status = sum(badSeg < 1) + sum(badSeg > length(TimeVector), 1);
+                    % Ignore badSeg out of TimeVector
+                    badSeg(:,badSeg_status == 2) = [];
+                    % Handle badSeg half-in TimeVector
+                    badSeg(1, badSeg(1, :) < 0) = 1;
+                    badSeg(2, badSeg(2, :) > length(TimeVector)) = length(TimeVector);
+                    badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
                 end
                 % Create file mask
                 Fmask = false(1, fileSamples(2) - fileSamples(1) + 1);

--- a/toolbox/process/functions/process_evt_detect_badsegment.m
+++ b/toolbox/process/functions/process_evt_detect_badsegment.m
@@ -92,6 +92,9 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % Time window to process
     RefTimeWindow = 1; %seconds
    
+    % Ignore bad segments? (not in the options: always enforced)
+    isIgnoreBad = 1;
+
     % Option structure for function in_fread()
     ImportOptions = db_template('ImportOptions');
     ImportOptions.ImportMode = 'Time';
@@ -197,34 +200,16 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             cleanRMS = min(refRMS);
 
             % ===== BAD SEGMENTS =====
-            % If ignore bad segments
-            isIgnoreBad = 1;
+            % Create file mask
+            Fmask = false(1, fileSamples(2) - fileSamples(1) + 1);
             if isIgnoreBad
-                % Get list of bad segments in file
-                badSeg = panel_record('GetBadSegments', sFile);
-                % Adjust with beginning of file
-                badSeg = badSeg - fileSamples(1) + 1;
-                if ~isempty(TimeWindow)
-                    badSeg = badSeg - (bst_closest(TimeWindow(1), DataMat.Time) - 1);
-                    % badSeg outside of TimeVector: 0=in, 1=half-in 2=out
-                    badSeg_status = sum(badSeg < 1) + sum(badSeg > length(TimeVector), 1);
-                    % Ignore badSeg out of TimeVector
-                    badSeg(:,badSeg_status == 2) = [];
-                    % Handle badSeg half-in TimeVector
-                    badSeg(1, badSeg(1, :) < 0) = 1;
-                    badSeg(2, badSeg(2, :) > length(TimeVector)) = length(TimeVector);
-                    badSeg(:, badSeg(1, :) == badSeg(2, :)) = [];
-                end
-                % Create file mask
-                Fmask = false(1, fileSamples(2) - fileSamples(1) + 1);
+                badSeg = process_evt_detect('GetBadSegments', sFile, TimeWindow, DataMat.Time, diff(TimeSamples) + 1);
                 if ~isempty(badSeg) 
                     % Loop on each segment: mark as bad
                     for iSeg = 1:size(badSeg, 2)
                         Fmask(badSeg(1,iSeg):badSeg(2,iSeg)) = true;
                     end
                 end
-            else
-                Fmask = [];
             end
         
             % ===== DETECT ARTIFACTS =====


### PR DESCRIPTION
Extend the bugfix added in #498, because if the user specified a `TimeWindow` it could lead to negative indices. 

In this PR: 
 * Bad segments out of the user-specified `TimeWindow` are ignored in making `Fmask`
 * Bad segments that are partially in the user-specified `TimeWindow` are constrained and used to make `Fmask`. However, if the resulting bad segment is not a segment but a point, it is ignored in making `Fmask`