### PR TITLE
NWB: Added the examination of channel information before loading data.

### DIFF
--- a/toolbox/io/in_fopen_nwb.m
+++ b/toolbox/io/in_fopen_nwb.m
@@ -8,7 +8,7 @@ function [sFile, ChannelMat] = in_fopen_nwb(DataFile)
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
 % 
-% Copyright (c) University of Southern California & McGill University
+% Copyright (c)2000-2020 University of Southern California & McGill University
 % This software is distributed under the terms of the GNU General Public License
 % as published by the Free Software Foundation. Further details on the GPLv3
 % license can be found at http://www.gnu.org/copyleft/gpl.html.
@@ -131,6 +131,11 @@ sFile = db_template('sfile');
 sFile.header.ChannelsModuleStructure = ChannelsModuleStructure;
 sFile.prop.sfreq = Fs;
 
+% Check the number of channels
+if ChannelsModuleStructure.nChannels > length(ChannelsModuleStructure.amp_channel_IDs)
+    warning('More channels are found in raw data than in DynamicTable. Select channels according to DynamicTable.');
+    ChannelsModuleStructure.nChannels = length(ChannelsModuleStructure.amp_channel_IDs);
+end
 nChannels = sum([ChannelsModuleStructure.nChannels]);
 
 %% Check for epochs/trials
@@ -151,6 +156,20 @@ for iModule = iElectrophysiologyModules
     groups = [groups ChannelsModuleStructure(iModule).groupLabels];
 end
 
+% Get semantic labels. The 'label' key might be specific to the dataset that we tested.
+if isKey(nwb2.general_extracellular_ephys_electrodes.vectordata, 'label')
+    labels = nwb2.general_extracellular_ephys_electrodes.vectordata.get('label').data.load; 
+else
+    labels = arrayfun(@(x) sprintf('amp%d', x), ChannelsModuleStructure.amp_channel_IDs, 'UniformOutput', 0);
+end
+
+% Get information of Good/Bad channels. The 'good' key might be specific to the dataset that we tested.
+if isKey(nwb2.general_extracellular_ephys_electrodes.vectordata, 'good')  % 1 is good, 0 is bad
+    ChannelFlag = nwb2.general_extracellular_ephys_electrodes.vectordata.get('good').data.load;
+    ChannelFlag = ChannelFlag * 2 - 1;  % 1 is good, -1 is bad in BST
+else
+    ChannelFlag = ones(nChannels, 1);
+end
 
 try
     % Get coordinates and set to 0 if they are not available
@@ -176,9 +195,9 @@ for iModule = 1:length(ChannelsModuleStructure)
         ii = ii + 1;
         zz = zz + 1;
         if ChannelsModuleStructure(iModule).isElectrophysiology
-            ChannelMat.Channel(ii).Name    = ['amp' num2str(ii-1)];
+            ChannelMat.Channel(ii).Name    = labels{iChannel};
             ChannelMat.Channel(ii).Loc     = [x(iChannel);y(iChannel);z(iChannel)];
-            ChannelMat.Channel(ii).Group   = groups(iChannel,:);
+            ChannelMat.Channel(ii).Group   = groups{iChannel};  % dtype shoud be char
             ChannelMat.Channel(ii).Type    = 'SEEG';
             ChannelType{ii} = 'EEG';
         else
@@ -203,7 +222,7 @@ sFile.comment      = nwb2.identifier;
 sFile.prop.times   = [time(1), time(end)];
 sFile.prop.nAvg    = 1;
 % No info on bad channels
-sFile.channelflag  = ones(nChannels, 1);
+sFile.channelflag  = ChannelFlag;
 sFile.header.ChannelType = ChannelType;
 
 %% ===== READ EVENTS =====
@@ -239,13 +258,24 @@ function moduleStructure = getDeeperModule(nwb, DataKey)
         amp_channel_IDs = obj.electrodes.data.load + 1; % Python starts from 0
         
         electrodes_path = obj.electrodes.table.path;
-        electrodes_path = strrep(electrodes_path(2:end), '/','_');        
+        electrodes_path = strrep(electrodes_path(2:end), '/', '_');
         
-        not_ordered_groupLabels = nwb.(electrodes_path).vectordata.get('group_name').data.load;
-        groupLabels = not_ordered_groupLabels(amp_channel_IDs,:);
+        % Check if Channel IDs are provided
+        if isprop(nwb.(electrodes_path), 'id')
+            amp_channel_IDs = nwb.(electrodes_path).id.data.load + 1;
+        end
+        
+        % Check if 'group_name' exist. If not, extract group names from other
+        % key. The 'group' key here might be specific to the dataset that we tested.
+        if isKey(nwb.(electrodes_path).vectordata, 'group_name')   
+            not_ordered_groupLabels = nwb.(electrodes_path).vectordata.get('group_name').data.load; 
+        else
+            not_ordered_groupLabels = {nwb.(electrodes_path).vectordata.get('group').data.path};                     
+            [~, not_ordered_groupLabels] = cellfun(@(x) fileparts(x), not_ordered_groupLabels', 'UniformOutput', 0);
+        end
         
         moduleStructure.amp_channel_IDs = amp_channel_IDs;
-        moduleStructure.groupLabels = groupLabels;
+        moduleStructure.groupLabels = not_ordered_groupLabels(amp_channel_IDs,:);
 
     else
         moduleStructure.amp_channel_IDs = [];

--- a/toolbox/io/in_fopen_nwb.m
+++ b/toolbox/io/in_fopen_nwb.m
@@ -8,7 +8,7 @@ function [sFile, ChannelMat] = in_fopen_nwb(DataFile)
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
 % 
-% Copyright (c)2000-2020 University of Southern California & McGill University
+% Copyright (c) University of Southern California & McGill University
 % This software is distributed under the terms of the GNU General Public License
 % as published by the Free Software Foundation. Further details on the GPLv3
 % license can be found at http://www.gnu.org/copyleft/gpl.html.


### PR DESCRIPTION
Hello,

This PR follows [the post](https://neuroimage.usc.edu/forums/t/error-opening-nwb-files/21025/19) on the Brainstorm forum.

Here are the changes:
- Check the number of channels before loading data. (Line 134-138)
- Get semantic labels of channels if possible. (Line 159-164)
- Get Good/Bad channel information if it exists. (Line 166-172)
- Directly extract channel IDs if possible. (Line 263-266)
- Get group names inside the getDeeperModule() function if 'group_name' doesn't exist. (Line 268-275)

Thanks,
Shuai 