### PR TITLE
fixed misreading of the trigger cahnnel in .bdf files

### DIFF
--- a/toolbox/io/in_fread_edf.m
+++ b/toolbox/io/in_fread_edf.m
@@ -201,14 +201,14 @@ function F = edf_read_epoch(sFile, sfid, iEpoch, iTimes, ChannelsRange, isAnnotO
 
     % Processing for BDF status file
     if isBdfStatus
-        % Mask to keep only the first 15 bits (Triggers bits)
+        % Mask to keep only the first 16 bits (Triggers bits)
         % Bit 16    : High when new Epoch is started
         % Bit 17-19 : Speed bits 0 1 2
         % Bit 20 	: High when CMS is within range
         % Bit 21 	: Speed bit 3
         % Bit 22 	: High when battery is low
         % Bit 23    : High if ActiveTwo MK2
-        F = bitand(F, bin2dec('000000000111111111111111'));
+        F = bitand(F, hex2dec('00FFFF'));
     % Processing for real data
     elseif ~isAnnotOnly
         % Convert to double


### PR DESCRIPTION
In `.bdf` files, the status channels' first two bytes are trigger bits, but only 15 were masked in `brainstorm3/toolbox/io/in_fread_edf.m` (note that bits are indexed in 0-based):

Status channel information from [https://www.biosemi.com/faq/trigger_signals.htm](https://www.biosemi.com/faq/trigger_signals.htm):
| Bit Number | Description |
| --- | --- |
| Bit 00 (LSB) | Trigger Input 1 (High = trigger on) |
| Bit 01 | Trigger Input 2 (High = trigger on) |
| Bit 02 | Trigger Input 3 (High = trigger on) |
| Bit 03 | Trigger Input 4 (High = trigger on) |
| Bit 04 | Trigger Input 5 (High = trigger on) |
| Bit 05 | Trigger Input 6 (High = trigger on) |
| Bit 06 | Trigger Input 7 (High = trigger on) |
| Bit 07 | Trigger Input 8 (High = trigger on) |
| Bit 08 | Trigger Input 9 (High = trigger on) |
| Bit 09 | Trigger Input 10 (High = trigger on) |
| Bit 10 | Trigger Input 11 (High = trigger on) |
| Bit 11 | Trigger Input 12 (High = trigger on) |
| Bit 12 | Trigger Input 13 (High = trigger on) |
| Bit 13 | Trigger Input 14 (High = trigger on) |
| Bit 14 | Trigger Input 15 (High = trigger on) |
| Bit 15 | Trigger Input 16 (High = trigger on) |
| Bit 16 | High when new Epoch is started |
| Bit 17 | Speed bit 0 |
| Bit 18 | Speed bit 1 |
| Bit 19 | Speed bit 2 |
| Bit 20 | High when CMS is within range |
| Bit 21 | Speed bit 3 |
| Bit 22 | High when battery is low |
| Bit 23 (MSB) | High if ActiveTwo MK2 |
