### PR TITLE
Time series figure: Use DisplayUnits from the files (fix NIRS)

### DIFF
--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -1452,16 +1452,9 @@ function ConfigureColorbar(hFig, ColormapType, DataType, DisplayUnits) %#ok<DEFN
                     fFactor = 1e6;                  
                 elseif strcmp(DisplayUnits,'mV')
                     fFactor = 1e3;                                      
-                elseif ~isempty(strfind(DisplayUnits,'mol'))
+                elseif ~isempty(strfind(DisplayUnits,'mol')) || ~isempty(strfind(DisplayUnits,'OD'))
                      fmax = max(abs(dataBounds));
-                     if round(log10(fmax)) < -3
-                         fFactor = 1e6;
-                     else    
-                        fFactor = 1;  
-                     end   
-                elseif ~isempty(strfind(DisplayUnits,'OD'))
-                    fFactor = 1e3;
-                    DisplayUnits='OD(*10^-3)';
+                    [valScaled, fFactor, DisplayUnits] = bst_getunits( fmax, DataType, 'nirs', DisplayUnits);
                 elseif strcmp(DisplayUnits,'U.A.')
                     fmax = max(abs(dataBounds));
                     if fmax < 1e3

--- a/toolbox/math/bst_getunits.m
+++ b/toolbox/math/bst_getunits.m
@@ -63,7 +63,7 @@ end
 
 % If the display unit is already defined
 if ~isempty(DisplayUnits)
-    if ismember(lower(DataType), {'nirs', '$nirs'})
+    if ismember(lower(DataType), {'nirs', '$nirs','nirs-src'})
         if ~isempty(strfind(DisplayUnits, 'mol'))
             [valFactor, valUnits] = GetSIFactor(val, DisplayUnits);
         elseif ~isempty(DisplayUnits) && ~isempty(strfind(DisplayUnits, 'cm'))
@@ -118,8 +118,8 @@ else
                 valUnits = 'No units';
             end
         case  'nirs-src'
-            if ~isempty(strfind(lower(FileName), 'hb')) 
-                 [valFactor, valUnits] = GetSIFactor(val, '\mumol.l-1');
+            if ~isempty(DisplayUnits)
+                 [valFactor, valUnits] = GetSIFactor(val,  DisplayUnits);
             else
                  [valFactor, valUnits] = GetExponent(val);
             end     
@@ -218,7 +218,7 @@ function [valFactor, valUnits] = GetSIFactor(val, originalUnit)
     
     
     [unit, modifier] = getUnit(originalUnit);
-    if abs(val) < eps
+    if abs(val) > 10^-2
         valFactor = 1;
         valUnits = originalUnit;
         return
@@ -239,7 +239,7 @@ function [valFactor, valUnits] = GetSIFactor(val, originalUnit)
     idp = find(adj(idx)==vpw);
     
     valFactor = 10^(- vpw(idp));
-    valUnits  = sprintf('%s%s',pfs{idp + modifier}, unit);
+    valUnits  = sprintf('%s%s',pfs{idp-1}, unit);
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%num2sip
 function adj = n2pAdjust(pwr,dPw)

--- a/toolbox/math/bst_getunits.m
+++ b/toolbox/math/bst_getunits.m
@@ -66,10 +66,10 @@ if ~isempty(DisplayUnits)
     if ismember(lower(DataType), {'nirs', '$nirs','nirs-src'})
         if ~isempty(strfind(DisplayUnits, 'mol'))
             [valFactor, valUnits] = GetSIFactor(val, DisplayUnits);
-        elseif ~isempty(DisplayUnits) && ~isempty(strfind(DisplayUnits, 'cm'))
+        elseif ~isempty(strfind(DisplayUnits, 'cm'))
             valFactor = 1;
             valUnits  = 'cm';
-        elseif ~isempty(DisplayUnits)
+        else
             [valFactor, valUnits] = GetExponent(val);
             valUnits = sprintf('%s(%s)',DisplayUnits,valUnits);
         end
@@ -117,13 +117,7 @@ else
                 valFactor = 1;
                 valUnits = 'No units';
             end
-        case  'nirs-src'
-            if ~isempty(DisplayUnits)
-                 [valFactor, valUnits] = GetSIFactor(val,  DisplayUnits);
-            else
-                 [valFactor, valUnits] = GetExponent(val);
-            end     
-        case {'nirs', '$nirs'}
+        case {'nirs', '$nirs','nirs-src'}
              [valFactor, valUnits] = GetExponent(val);
         case {'results', 'sources', 'source'}
             % Results in Amper.meter (display in picoAmper.meter)

--- a/toolbox/math/bst_getunits.m
+++ b/toolbox/math/bst_getunits.m
@@ -36,7 +36,7 @@ function [valScaled, valFactor, valUnits] = bst_getunits( val, DataType, FileNam
 %          Edouard Delaire, 2021
 
 % Parse inputs
-if (nargin <= 4) || isempty(DisplayUnits)
+if (nargin < 4) || isempty(DisplayUnits)
     DisplayUnits = [];
 end
 
@@ -63,7 +63,7 @@ end
 
 % If the display unit is already defined
 if ~isempty(DisplayUnits)
-    if ismember(DataType, {'nirs', '$nirs'})
+    if ismember(lower(DataType), {'nirs', '$nirs'})
         if ~isempty(strfind(DisplayUnits, 'mol'))
             [valFactor, valUnits] = GetSIFactor(val, DisplayUnits);
         elseif ~isempty(DisplayUnits) && ~isempty(strfind(DisplayUnits, 'cm'))


### PR DESCRIPTION
Continuation of https://github.com/brainstorm-tools/brainstorm3/commit/0c6e8e863ed01edc79a0dfe53e99736afad4f13c and https://github.com/brainstorm-tools/brainstorm3/commit/9f46ab386756430119e18ff735dda979e42f7fe2 

I think ConfigureColorbar in bst_colormap could be simplified by calling bst_getunit; no?
