### PR TITLE
Display VolAtlas over it self

### DIFF
--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1010,8 +1010,8 @@ switch (lower(action))
                     % MENU : DISPLAY
                     jMenuDisplay = gui_component('Menu', jPopup, [], 'Display', IconLoader.ICON_ANATOMY, [], []);
                         % Display
-                        gui_component('MenuItem', jMenuDisplay, [], 'MRI Viewer',           IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(filenameRelative));
-                        gui_component('MenuItem', jMenuDisplay, [], '3D orthogonal slices', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri_3d(filenameRelative));
+                        gui_component('MenuItem', jMenuDisplay, [], 'MRI Viewer',           IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(filenameRelative, filenameRelative));
+                        gui_component('MenuItem', jMenuDisplay, [], '3D orthogonal slices', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri_3d(filenameRelative, filenameRelative));
                         AddSeparator(jMenuDisplay);
                         % Display as overlay
                         if ~bstNodes(1).isMarked()


### PR DESCRIPTION
This small modification shows the parcellation by colors the volume atlas is show alone (not as overlay on subjetc MRI), i.e., right-click on Volume Atlas and `Display > MRI viewer (or 3D orthogonal slices)`.

It also avoids to start the MRI view of the volume atlas alone with a different atlas selected, even when it is hidden.

**Before (left images) and After (right images)**

![Screenshot from 2022-09-08 18-12-19](https://user-images.githubusercontent.com/8238803/189235218-9716dcba-0ab9-47db-97ba-35d216f3737d.png)


