### PR TITLE
Time series figure: Use DisplayUnits from the files (fix NIRS)

### DIFF
--- a/toolbox/math/bst_getunits.m
+++ b/toolbox/math/bst_getunits.m
@@ -69,8 +69,15 @@ if ~isempty(DisplayUnits)
         elseif ~isempty(strfind(DisplayUnits, 'cm'))
             valFactor = 1;
             valUnits  = 'cm';
+        elseif ~isempty(strfind(DisplayUnits, 'delta'))
+            [valFactor, valUnits] = GetExponent(val);
+            valUnits = sprintf('%s(%s)',strrep(DisplayUnits,'delta ','\Delta'),valUnits);
         else
             [valFactor, valUnits] = GetExponent(val);
+            startIndex = regexp(DisplayUnits,'\(10\^{-?\d+}\)');
+            if ~isempty(startIndex) 
+                DisplayUnits = DisplayUnits(1:startIndex-1);
+            end
             valUnits = sprintf('%s(%s)',DisplayUnits,valUnits);
         end
     else


### PR DESCRIPTION
This small PR is here to display delta OD a bit more nicely and fix a bug where: when displaying a time course the unit would be delta OD (10^-3) but becomes delta OD (10^-3)(10^-3)  if displaying a particular timecourse 

 