### PR TITLE
add oc_filtfilt

### DIFF
--- a/external/octave/oc_filtfilt.m
+++ b/external/octave/oc_filtfilt.m
@@ -1,0 +1,93 @@
+%% Copyright (C) 1999 Paul Kienzle <pkienzle@users.sf.net>
+%% Copyright (C) 2007 Francesco Potortì <pot@gnu.org>
+%% Copyright (C) 2008 Luca Citi <lciti@essex.ac.uk>
+%%
+%% This program is free software: you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published by
+%% the Free Software Foundation, either version 3 of the License, or
+%% (at your option) any later version.
+%%
+%% This program is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+%% GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with this program; see the file COPYING. If not, see
+%% <https://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @deftypefn {Function File} {@var{y} =} filtfilt (@var{b}, @var{a}, @var{x})
+%%
+%% Forward and reverse filter the signal. This corrects for phase
+%% distortion introduced by a one-pass filter, though it does square the
+%% magnitude response in the process. That's the theory at least.  In
+%% practice the phase correction is not perfect, and magnitude response
+%% is distorted, particularly in the stop band.
+%%
+%% Example
+%% @example
+%% @group
+%% [b, a]=butter(3, 0.1);                  % 5 Hz low-pass filter
+%% t = 0:0.01:1.0;                         % 1 second sample
+%% x=sin(2*pi*t*2.3)+0.25*randn(size(t));  % 2.3 Hz sinusoid+noise
+%% y = filtfilt(b,a,x); z = filter(b,a,x); % apply filter
+%% plot(t,x,';data;',t,y,';filtfilt;',t,z,';filter;')
+%% @end group
+%% @end example
+%% @end deftypefn
+
+%% FIXME: My version seems to have similar quality to matlab,
+%%        but both are pretty bad.  They do remove gross lag errors, though.
+
+function y = oc_filtfilt(b, a, x)
+
+  if (nargin ~= 3)
+    print_usage;
+  end
+  rotate = (size(x,1)==1);
+  if rotate,                    % a row vector
+    x = x(:);                   % make it a column vector
+  end
+
+  lx = size(x,1);
+  a = a(:).';
+  b = b(:).';
+  lb = length(b);
+  la = length(a);
+  n = max(lb, la);
+  lrefl = 3 * (n - 1);
+  if la < n, a(n) = 0; end
+  if lb < n, b(n) = 0; end
+
+  if (size(x,1) <= lrefl)
+    error ("filtfilt: X must be a vector or matrix with length greater than %d", ...
+           lrefl);
+  end
+
+  %% Compute a the initial state taking inspiration from
+  %% Likhterov & Kopeika, 2003. "Hardware-efficient technique for
+  %%     minimizing startup transients in Direct Form II digital filters"
+  kdc = sum(b) / sum(a);
+  if (abs(kdc) < inf) % neither NaN nor +/- Inf
+    si = fliplr(cumsum(fliplr(b - kdc * a)));
+  else
+    si = zeros(size(a)); % fall back to zero initialization
+  end
+  si(1) = [];
+
+  for (c = 1:size(x,2)) % filter all columns, one by one
+    v = [2*x(1,c)-x((lrefl+1):-1:2,c); x(:,c);
+         2*x(end,c)-x((end-1):-1:end-lrefl,c)]; % a column vector
+
+    %% Do forward and reverse filtering
+    v = filter(b,a,v,si*v(1));                   % forward filter
+    v = flipud(filter(b,a,flipud(v),si*v(end))); % reverse filter
+    y(:,c) = v((lrefl+1):(lx+lrefl));
+  end
+
+  if (rotate)                   % x was a row vector
+    y = rot90(y);               % rotate it back
+  end
+
+ end

--- a/external/octave/oc_filtfilt.m
+++ b/external/octave/oc_filtfilt.m
@@ -1,93 +1,91 @@
-%% Copyright (C) 1999 Paul Kienzle <pkienzle@users.sf.net>
-%% Copyright (C) 2007 Francesco Potortì <pot@gnu.org>
-%% Copyright (C) 2008 Luca Citi <lciti@essex.ac.uk>
-%%
-%% This program is free software: you can redistribute it and/or modify
-%% it under the terms of the GNU General Public License as published by
-%% the Free Software Foundation, either version 3 of the License, or
-%% (at your option) any later version.
-%%
-%% This program is distributed in the hope that it will be useful,
-%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-%% GNU General Public License for more details.
-%%
-%% You should have received a copy of the GNU General Public License
-%% along with this program; see the file COPYING. If not, see
-%% <https://www.gnu.org/licenses/>.
+% Copyright (C) 1999 Paul Kienzle <pkienzle@users.sf.net>
+% Copyright (C) 2007 Francesco Potortì <pot@gnu.org>
+% Copyright (C) 2008 Luca Citi <lciti@essex.ac.uk>
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; see the file COPYING. If not, see
+% <https://www.gnu.org/licenses/>.
 
-%% -*- texinfo -*-
-%% @deftypefn {Function File} {@var{y} =} filtfilt (@var{b}, @var{a}, @var{x})
-%%
-%% Forward and reverse filter the signal. This corrects for phase
-%% distortion introduced by a one-pass filter, though it does square the
-%% magnitude response in the process. That's the theory at least.  In
-%% practice the phase correction is not perfect, and magnitude response
-%% is distorted, particularly in the stop band.
-%%
-%% Example
-%% @example
-%% @group
-%% [b, a]=butter(3, 0.1);                  % 5 Hz low-pass filter
-%% t = 0:0.01:1.0;                         % 1 second sample
-%% x=sin(2*pi*t*2.3)+0.25*randn(size(t));  % 2.3 Hz sinusoid+noise
-%% y = filtfilt(b,a,x); z = filter(b,a,x); % apply filter
-%% plot(t,x,';data;',t,y,';filtfilt;',t,z,';filter;')
-%% @end group
-%% @end example
-%% @end deftypefn
+% -*- texinfo -*-
+% @deftypefn {Function File} {@var{y} =} filtfilt (@var{b}, @var{a}, @var{x})
+%
+% Forward and reverse filter the signal. This corrects for phase
+% distortion introduced by a one-pass filter, though it does square the
+% magnitude response in the process. That's the theory at least.  In
+% practice the phase correction is not perfect, and magnitude response
+% is distorted, particularly in the stop band.
+%
+% Example
+% @example
+% @group
+% [b, a]=butter(3, 0.1);                  % 5 Hz low-pass filter
+% t = 0:0.01:1.0;                         % 1 second sample
+% x=sin(2*pi*t*2.3)+0.25*randn(size(t));  % 2.3 Hz sinusoid+noise
+% y = filtfilt(b,a,x); z = filter(b,a,x); % apply filter
+% plot(t,x,';data;',t,y,';filtfilt;',t,z,';filter;')
+% @end group
+% @end example
+% @end deftypefn
 
-%% FIXME: My version seems to have similar quality to matlab,
-%%        but both are pretty bad.  They do remove gross lag errors, though.
+% FIXME: My version seems to have similar quality to matlab,
+%        but both are pretty bad.  They do remove gross lag errors, though.
 
 function y = oc_filtfilt(b, a, x)
 
-  if (nargin ~= 3)
+if (nargin ~= 3)
     print_usage;
-  end
-  rotate = (size(x,1)==1);
-  if rotate,                    % a row vector
+end
+rotate = (size(x,1)==1);
+if rotate                     % a row vector
     x = x(:);                   % make it a column vector
-  end
+end
 
-  lx = size(x,1);
-  a = a(:).';
-  b = b(:).';
-  lb = length(b);
-  la = length(a);
-  n = max(lb, la);
-  lrefl = 3 * (n - 1);
-  if la < n, a(n) = 0; end
-  if lb < n, b(n) = 0; end
+lx = size(x,1);
+a = a(:).';
+b = b(:).';
+lb = length(b);
+la = length(a);
+n = max(lb, la);
+lrefl = 3 * (n - 1);
+if la < n, a(n) = 0; end
+if lb < n, b(n) = 0; end
 
-  if (size(x,1) <= lrefl)
+if (size(x,1) <= lrefl)
     error ("filtfilt: X must be a vector or matrix with length greater than %d", ...
-           lrefl);
-  end
+        lrefl);
+end
 
-  %% Compute a the initial state taking inspiration from
-  %% Likhterov & Kopeika, 2003. "Hardware-efficient technique for
-  %%     minimizing startup transients in Direct Form II digital filters"
-  kdc = sum(b) / sum(a);
-  if (abs(kdc) < inf) % neither NaN nor +/- Inf
+% Compute a the initial state taking inspiration from
+% Likhterov & Kopeika, 2003. "Hardware-efficient technique for
+%     minimizing startup transients in Direct Form II digital filters"
+kdc = sum(b) / sum(a);
+if (abs(kdc) < inf) % neither NaN nor +/- Inf
     si = fliplr(cumsum(fliplr(b - kdc * a)));
-  else
+else
     si = zeros(size(a)); % fall back to zero initialization
-  end
-  si(1) = [];
+end
+si(1) = [];
 
-  for (c = 1:size(x,2)) % filter all columns, one by one
+for c = 1:size(x,2) % filter all columns, one by one
     v = [2*x(1,c)-x((lrefl+1):-1:2,c); x(:,c);
-         2*x(end,c)-x((end-1):-1:end-lrefl,c)]; % a column vector
+        2*x(end,c)-x((end-1):-1:end-lrefl,c)]; % a column vector
 
-    %% Do forward and reverse filtering
+    % Do forward and reverse filtering
     v = filter(b,a,v,si*v(1));                   % forward filter
     v = flipud(filter(b,a,flipud(v),si*v(end))); % reverse filter
     y(:,c) = v((lrefl+1):(lx+lrefl));
-  end
+end
 
-  if (rotate)                   % x was a row vector
+if (rotate)                   % x was a row vector
     y = rot90(y);               % rotate it back
-  end
-
- end
+end

--- a/toolbox/process/functions/process_bandstop.m
+++ b/toolbox/process/functions/process_bandstop.m
@@ -144,6 +144,14 @@ function [x, FiltSpec, Messages] = Compute(x, sfreq, FreqList, FreqWidth, method
         method = 'fieldtrip_butter';
         FreqWidth = 1.5;
     end
+    % Use the signal processing toolbox?
+    if bst_get('UseSigProcToolbox')
+        filtfilt_fcn = @filtfilt;
+        butter_fcn = @butter;
+    else
+        filtfilt_fcn = @oc_filtfilt;
+        butter_fcn = @oc_butter;
+    end
     % Check list of freq to remove
     if isempty(FreqList) || isequal(FreqList, 0)
         return;
@@ -168,16 +176,12 @@ function [x, FiltSpec, Messages] = Compute(x, sfreq, FreqList, FreqWidth, method
                 % Filter order
                 N = 4;
                 % Butterworth filter
-                if bst_get('UseSigProcToolbox')
-                    [B,A] = butter(N, FreqBand ./ Fnyq, 'stop');
-                else
-                    [B,A] = oc_butter(N, FreqBand ./ Fnyq, 'stop');
-                end
+                [B,A] = butter_fcn(N, FreqBand ./ Fnyq, 'stop');
                 FiltSpec.b(ifreq,:) = B;
                 FiltSpec.a(ifreq,:) = A;
                 % Filter signal
                 if ~isempty(x)
-                    x = filtfilt(B, A, x')';
+                    x = filtfilt_fcn(B, A, x')';
                 end
 
             % Source: FieldTrip toolbox

--- a/toolbox/process/functions/process_notch.m
+++ b/toolbox/process/functions/process_notch.m
@@ -143,8 +143,6 @@ end
 %% ===== EXTERNAL CALL =====
 % USAGE: x = process_notch('Compute', x, sfreq, FreqList)
 function [x, FiltSpec, Messages] = Compute(x, sfreq, FreqList, Method, bandWidth)
-    % Use the signal processing toolbox?
-    UseSigProcToolbox = bst_get('UseSigProcToolbox');
     % Check list of freq to remove
     if isempty(FreqList) || isequal(FreqList, 0)
         return;
@@ -154,6 +152,12 @@ function [x, FiltSpec, Messages] = Compute(x, sfreq, FreqList, Method, bandWidth
     end
     if (nargin < 4) || isempty(Method)
         Method = 'hnotch' ;
+    end
+    % Use the signal processing toolbox?
+    if bst_get('UseSigProcToolbox')
+        filtfilt_fcn = @filtfilt;
+    else
+        filtfilt_fcn = @oc_filtfilt;
     end
     % Define a default width
     % Remove the mean of the data before filtering
@@ -194,12 +198,7 @@ function [x, FiltSpec, Messages] = Compute(x, sfreq, FreqList, Method, bandWidth
         
         % Filter signal
         if ~isempty(x)
-            if UseSigProcToolbox
-                x = filtfilt(B,A,x')';
-            else
-                x = filter(B,A,x')';
-                x(:,end:-1:1) = filter(B,A,x(:,end:-1:1)')';
-            end
+            x = filtfilt_fcn(B,A,x')';
         end
     end
     % Restore the mean of the signal


### PR DESCRIPTION
Add oc_filtfilt to replace the use of filtfit when signal toolbox is not available https://octave.sourceforge.io/signal/function/filtfilt.html 


Cf: https://neuroimage.usc.edu/forums/t/fnirs-data-import/36740/12

merge https://github.com/Nirstorm/nirstorm/pull/205

Edit: this might be a usefull replacement here too: https://github.com/brainstorm-tools/brainstorm3/blob/6cc6addc8e084ce5209ed6e67f619953199981d8/toolbox/math/bst_bandpass_filtfilt.m#L165
