### PR TITLE
Bugfix: Accept empty strings in `combobox_label` option type

### DIFF
--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -2270,7 +2270,9 @@ function [OutputFiles, OutputFiles2, sInputs, sInputs2] = CallProcess(sProcess, 
             updateVal{1} = newVal;
         elseif ismember(lower(defType), {'timewindow','baseline','poststim','value','range','freqrange','freqrange_static'}) && isempty(defVal) && ~isempty(newVal) && ~iscell(newVal)
             updateVal = {newVal, 's', []};
-        elseif ismember(lower(defType), {'timewindow','baseline','poststim','value','range','freqrange','freqrange_static','combobox','combobox_label'}) && iscell(defVal) && ~isempty(defVal) && ~iscell(newVal) && ~isempty(newVal)
+        elseif ismember(lower(defType), {'timewindow','baseline','poststim','value','range','freqrange','freqrange_static','combobox'}) && iscell(defVal) && ~isempty(defVal) && ~iscell(newVal) && ~isempty(newVal)
+            updateVal{1} = newVal;
+        elseif ismember(lower(defType), {'combobox_label'}) && iscell(defVal) && ~isempty(defVal) && ismember(newVal, defVal{2})
             updateVal{1} = newVal;
         % Generic call: just copy the value
         else


### PR DESCRIPTION
Fixes a bug when calling a process with an option type `combobox_label` with value `''`.

For example, this Brainstorm generated: https://gist.github.com/rcassani/0a551d4d35850c33ba0f11a375c0b5d9 returns an error for option `eeg` as its value is `''`.

Error message:   
```
Line 143: Brace indexing is not supported for variables of this type.
_______________________________________________ 
Call stack: 
>process_simulate_dipoles.m>Run at 143 
>process_simulate_dipoles.m at 26 
>bst_process.m>Run at 202 
>bst_process.m>CallProcess at 2302 
>bst_process.m at 38 
>pipeline_dipole_sim.m at 20
```