### PR TITLE
Bugfix: Get number of children after removing Intra (Bug reported in Forum)

### DIFF
--- a/toolbox/tree/node_create_db_studies.m
+++ b/toolbox/tree/node_create_db_studies.m
@@ -567,9 +567,9 @@ if ~isempty(nodeListIntra_cond)
     else
         % Get parent node
         nodeParent = nodeListIntra_cond.getParent();
-        nbChild = nodeParent.getChildCount();
         % Remove temporary analysis node
         nodeListIntra_cond.removeFromParent();
+        nbChild = nodeParent.getChildCount();
         % If there are other special nodes (Analysis-Inter, GlobalCommonfiles), put it after them
         if (nbChild >= 2) && (length(nodeParent.getChildAt(1).toString) > 1) && (nodeParent.getChildAt(1).toString.charAt(0) == '(')
             iInsert = 2;


### PR DESCRIPTION
Fix bug reported in: https://neuroimage.usc.edu/forums/t/36049
`nbChild` should be counted after removing `@intra`

Replicate bug:
1. Protocol with 1 Subject with only the `@intra` node
2. In condition view, root node will have only global `@default_study` and `@intra`
