### PR TITLE
Head points & manual registration figure

### DIFF
--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -376,23 +376,18 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
                     case {'3DViz', 'MriViewer'}
                         % Get surfaces defined in this figure
                         TessInfo = getappdata(sFigure.hFigure, 'Surface');
-                        % Find surfaces that match this ColormapType
-                        iSurfaces = find(strcmpi({TessInfo.ColormapType}, ColormapType));
+                        % Find 1st surface that match this ColormapType
+                        iTess = find(strcmpi({TessInfo.ColormapType}, ColormapType), 1);
                         DataFig = [];
-                        for i = 1:length(iSurfaces)
-                            iTess = iSurfaces(i);
-                            if ~isempty(TessInfo(iTess).DataSource.Type)
-                                DataFig = [min([DataFig(:); TessInfo(iTess).DataMinMax(:)]), ...
-                                    max([DataFig(:); TessInfo(iTess).DataMinMax(:)])];
-                                % We'll keep the last non-empty DataType
-                                DataType = TessInfo(iTess).DataSource.Type;
-                                % For Data: use the modality instead
-                                if strcmpi(DataType, 'Data') && ~isempty(ColormapInfo.Type) && ismember(ColormapInfo.Type, {'eeg', 'meg', 'nirs'})
-                                    DataType = upper(ColormapInfo.Type);
-                                % sLORETA: Do not use regular source scaling (pAm)
-                                elseif strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo(iTess).DataSource.FileName), 'sloreta'))
-                                    DataType = 'sLORETA';
-                                end
+                        if ~isempty(iTess) && ~isempty(TessInfo(iTess).DataSource.Type)
+                            DataFig = TessInfo(iTess).DataMinMax;
+                            DataType = TessInfo(iTess).DataSource.Type;
+                            % For Data: use the modality instead
+                            if strcmpi(DataType, 'Data') && ~isempty(ColormapInfo.Type) && ismember(ColormapInfo.Type, {'eeg', 'meg', 'nirs'})
+                                DataType = upper(ColormapInfo.Type);
+                            % sLORETA: Do not use regular source scaling (pAm)
+                            elseif strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo(iTess).DataSource.FileName), 'sloreta'))
+                                DataType = 'sLORETA';
                             end
                         end
                         if isempty(DataFig)

--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -376,18 +376,20 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
                     case {'3DViz', 'MriViewer'}
                         % Get surfaces defined in this figure
                         TessInfo = getappdata(sFigure.hFigure, 'Surface');
-                        DataFig = TessInfo.DataMinMax;
-                        if ~isempty(TessInfo.DataSource.Type)
-                            DataType = TessInfo.DataSource.Type;
-                            isSLORETA = strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo.DataSource.FileName), 'sloreta'));
-                            if isSLORETA 
-                                DataType = 'sLORETA';
-                            end
-                        elseif isempty(DataFig)
-                            % If displaying color-coded head points (see channel_align_manual)
-                            HeadpointsDistMax = getappdata(sFigure.hFigure, 'HeadpointsDistMax');
-                            if ~isempty(HeadpointsDistMax)
-                                DataFig = [0, HeadpointsDistMax * 1000];
+                        % Find surface(s) that matches this ColormapType
+                        iSurfaces = find(strcmpi({TessInfo.ColormapType}, ColormapType));
+                        DataFig = [];
+                        for i = 1:length(iSurfaces)
+                            iTess = iSurfaces(i);
+                            DataFig = [min([DataFig(:); TessInfo(iTess).DataMinMax(:)]), ...
+                                max([DataFig(:); TessInfo(iTess).DataMinMax(:)])];
+                            if ~isempty(TessInfo(iTess).DataSource.Type)
+                                % We'll keep the last non-empty DataType
+                                DataType = TessInfo(iTess).DataSource.Type;
+                                isSLORETA = strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo(iTess).DataSource.FileName), 'sloreta'));
+                                if isSLORETA
+                                    DataType = 'sLORETA';
+                                end
                             end
                         end
                         
@@ -452,7 +454,7 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
         elseif isequal(DisplayUnits, '%') || isequal(DisplayUnits, 'mm')
             fFactor = 1;
             fUnits = DisplayUnits;
-        else
+        else 
             % Guess the display units
             [tmp, fFactor, fUnits ] = bst_getunits(amplitudeMax, DataType);
             % For readability: replace '\sigma' with 'no units'

--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -376,7 +376,7 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
                     case {'3DViz', 'MriViewer'}
                         % Get surfaces defined in this figure
                         TessInfo = getappdata(sFigure.hFigure, 'Surface');
-                        % Find surface(s) that matches this ColormapType
+                        % Find surfaces that match this ColormapType
                         iSurfaces = find(strcmpi({TessInfo.ColormapType}, ColormapType));
                         DataFig = [];
                         for i = 1:length(iSurfaces)
@@ -393,6 +393,13 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
                                 elseif strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo(iTess).DataSource.FileName), 'sloreta'))
                                     DataType = 'sLORETA';
                                 end
+                            end
+                        end
+                        if isempty(DataFig)
+                            % If displaying color-coded head points (see channel_align_manual)
+                            HeadpointsDistMax = getappdata(sFigure.hFigure, 'HeadpointsDistMax');
+                            if ~isempty(HeadpointsDistMax)
+                                DataFig = [0, HeadpointsDistMax * 1000];
                             end
                         end
                         

--- a/toolbox/core/bst_colormaps.m
+++ b/toolbox/core/bst_colormaps.m
@@ -381,13 +381,16 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
                         DataFig = [];
                         for i = 1:length(iSurfaces)
                             iTess = iSurfaces(i);
-                            DataFig = [min([DataFig(:); TessInfo(iTess).DataMinMax(:)]), ...
-                                max([DataFig(:); TessInfo(iTess).DataMinMax(:)])];
                             if ~isempty(TessInfo(iTess).DataSource.Type)
+                                DataFig = [min([DataFig(:); TessInfo(iTess).DataMinMax(:)]), ...
+                                    max([DataFig(:); TessInfo(iTess).DataMinMax(:)])];
                                 % We'll keep the last non-empty DataType
                                 DataType = TessInfo(iTess).DataSource.Type;
-                                isSLORETA = strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo(iTess).DataSource.FileName), 'sloreta'));
-                                if isSLORETA
+                                % For Data: use the modality instead
+                                if strcmpi(DataType, 'Data') && ~isempty(ColormapInfo.Type) && ismember(ColormapInfo.Type, {'eeg', 'meg', 'nirs'})
+                                    DataType = upper(ColormapInfo.Type);
+                                % sLORETA: Do not use regular source scaling (pAm)
+                                elseif strcmpi(DataType, 'Source') && ~isempty(strfind(lower(TessInfo(iTess).DataSource.FileName), 'sloreta'))
                                     DataType = 'sLORETA';
                                 end
                             end
@@ -454,7 +457,7 @@ function SetMaxCustom(ColormapType, DisplayUnits, newMin, newMax)
         elseif isequal(DisplayUnits, '%') || isequal(DisplayUnits, 'mm')
             fFactor = 1;
             fUnits = DisplayUnits;
-        else 
+        else
             % Guess the display units
             [tmp, fFactor, fUnits ] = bst_getunits(amplitudeMax, DataType);
             % For readability: replace '\sigma' with 'no units'

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -169,11 +169,6 @@ function ColormapChangedCallback(iDS, iFig) %#ok<DEFNU>
     if ~isempty(getappdata(hFig, 'Dipoles')) && gui_brainstorm('isTabVisible', 'Dipoles')
         panel_dipoles('PlotSelectedDipoles', hFig);
     end
-    % If displaying color-coded head points (see channel_align_manual)
-    HeadpointsDistMax = getappdata(hFig, 'HeadpointsDistMax');
-    if ~isempty(HeadpointsDistMax)
-        UpdateHeadPointsColormap(hFig);
-    end
 end
 
 
@@ -3772,7 +3767,7 @@ function ViewHeadPoints(hFig, isVisible, isColorDist)
         [HeadPoints.Loc(1,iDupli), HeadPoints.Loc(2,iDupli), HeadPoints.Loc(3,iDupli)] = sph2cart(th, phi, r - 0.0001);
     end
     
-    % Else, get previous head points
+    % Look for previous head points
     hHeadPointsMarkers = findobj(hAxes, 'Tag', 'HeadPointsMarkers');
     hHeadPointsLabels  = findobj(hAxes, 'Tag', 'HeadPointsLabels');
     % If head points graphic objects already exist: set the "Visible" property
@@ -3787,22 +3782,19 @@ function ViewHeadPoints(hFig, isVisible, isColorDist)
         ColormapType = 'stat1';
         if isColorDist && ~strcmpi(get(hHeadPointsMarkers, 'MarkerFaceColor'), 'flat')
             % Color points according to distance to surface
-            % Get selected surface
-            [iTess, TessInfo, hFig, sSurf] = panel_surface('GetSelectedSurface', hFig);
+            % Get scalp surface
+            [~, ~, hFig, sSurf] = panel_surface('GetSurface', hFig, '', 'Scalp');
             if ~isempty(sSurf) && isfield(sSurf, 'Vertices') && ~isempty(sSurf.Vertices)
-                if ~ismember(ColormapType, ColormapInfo.AllTypes)
-                    % Add missing colormap (color was toggled after points were displayed)
-                    bst_colormaps('AddColormapToFigure', hFig, ColormapType, 'mm');
-                    ColormapInfo = getappdata(hFig, 'Colormap');
-                end
                 % Compute the distance
                 Dist = bst_surfdist(get(hHeadPointsMarkers, 'Vertices'), sSurf.Vertices, sSurf.Faces);
                 set(hHeadPointsMarkers, 'CData', Dist * 1000, ...
                     'MarkerFaceColor', 'flat', 'MarkerEdgeColor', 'flat');
-                setappdata(hFig, 'HeadpointsDistMax', max(Dist));
-                if strcmpi(ColormapInfo.Type, ColormapType)
-                    ColormapChangedCallback(iDS, iFig);
-                    bst_colormaps('SetColorbarVisible', hFig, 1);
+                if ~ismember(ColormapType, ColormapInfo.AllTypes)
+                    iTess = panel_surface('GetSurface', hFig, '', 'HeadPoints');
+                    if isempty(iTess)
+                        error('HeadPoints surface not found.');
+                    end
+                    panel_surface('SetSurfaceData', hFig, iTess, 'HeadPointsDistance', '', 1); % isStat=1
                 end
             end
         elseif ~isColorDist && strcmpi(get(hHeadPointsMarkers, 'MarkerFaceColor'), 'flat')
@@ -3890,15 +3882,13 @@ function ViewHeadPoints(hFig, isVisible, isColorDist)
         if ~isempty(iExtra)
             % Color code points by distance
             if isColorDist
-                % Get selected surface
-                [iTess, TessInfo, hFig, sSurf] = panel_surface('GetSelectedSurface', hFig);
+                % Get scalp surface
+                [~, ~, hFig, sSurf] = panel_surface('GetSurface', hFig, '', 'Scalp');
                 % Compute the distance
                 Dist = bst_surfdist(digLoc(iExtra, :), sSurf.Vertices, sSurf.Faces);
                 CData = Dist * 1000; % mm
-                setappdata(hFig, 'HeadpointsDistMax', max(Dist));
                 MarkerFaceColor = 'flat';
                 MarkerEdgeColor = 'flat';
-                bst_colormaps('AddColormapToFigure', hFig, 'stat1', 'mm');
             else
                 CData = 'w'; % any color, not displayed
                 MarkerFaceColor = [.3 1 .3];
@@ -3915,33 +3905,13 @@ function ViewHeadPoints(hFig, isVisible, isColorDist)
                 'Marker',          'o', ...
                 'UserData',        iExtra, ...
                 'Tag',             'HeadPointsMarkers');
+            % Add points patch to figure surfaces so all color bar functionality work.
+            iTess = panel_surface('AddSurface', hFig, '', 'HeadPoints');
             if isColorDist
-                ColormapChangedCallback(iDS, iFig);
+                panel_surface('SetSurfaceData', hFig, iTess, 'HeadPointsDistance', '', 1); % isStat=1
             end
         end
     end
-end
-
-
-%% ===== UPDATE HEADPOINTS COLORMAP =====
-function UpdateHeadPointsColormap(hFig)
-    % If not using color-coded display
-    hHeadPointsMarkers = findobj(hFig, 'Tag', 'HeadPointsMarkers');
-    if ~strcmpi(get(hHeadPointsMarkers, 'MarkerFaceColor'), 'flat')
-        return;
-    end
-    % Get colormap configuration
-    sColormap = bst_colormaps('GetColormap', 'stat1');
-    % Update axes color limits, which will update de colorbar
-    hAxes = get(hHeadPointsMarkers, 'Parent');
-    if strcmpi(sColormap.MaxMode, 'custom')
-        set(hAxes, 'CLim', [sColormap.MinValue, sColormap.MaxValue]);
-    else
-        HeadpointsDistMax = getappdata(hFig, 'HeadpointsDistMax');
-        set(hAxes, 'CLim', [0, HeadpointsDistMax * 1000]);
-    end
-    % Update colorbar
-    bst_colormaps('ConfigureColorbar', hFig, 'stat1', 'stat', 'mm');
 end
 
 

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -1130,20 +1130,15 @@ end
 %% ===== ADD A SURFACE =====
 % Add a surface to a given 3DViz figure
 % USAGE : [iTess, TessInfo] = panel_surface('AddSurface', hFig, surfaceFile)
-%         [iTess, TessInfo] = panel_surface('AddSurface', hFig, [], surfaceType)
 % OUTPUT: Indice of the surface in the figure's surface array
-function [iTess, TessInfo] = AddSurface(hFig, surfaceFile, surfaceType)
+function [iTess, TessInfo] = AddSurface(hFig, surfaceFile)
     % ===== CHECK EXISTENCE =====
+    % Check whether filename is an absolute or relative path
+    surfaceFile = file_short(surfaceFile);
     % Get figure appdata (surfaces configuration)
     TessInfo = getappdata(hFig, 'Surface');
     % Check that this surface is not already displayed in 3DViz figure
-    if isempty(surfaceFile) && nargin > 2
-        iTess = find(file_compare({TessInfo.Name}, surfaceType));
-    else
-        % Check whether filename is an absolute or relative path
-        surfaceFile = file_short(surfaceFile);
-        iTess = find(file_compare({TessInfo.SurfaceFile}, surfaceFile));
-    end
+    iTess = find(file_compare({TessInfo.SurfaceFile}, surfaceFile));
     if ~isempty(iTess)
         disp('BST> This surface is already displayed. Ignoring...');
         return
@@ -1166,9 +1161,6 @@ function [iTess, TessInfo] = AddSurface(hFig, surfaceFile, surfaceType)
     % ===== PLOT OBJECT =====
     % Get file type (tessalation or MRI)
     fileType = file_gettype(surfaceFile);
-    if strcmpi(fileType, 'unknown') && nargin > 2
-        fileType = surfaceType;
-    end
     % === TESSELATION ===
     if any(strcmpi(fileType, {'cortex','scalp','innerskull','outerskull','tess'}))
         % === LOAD SURFACE ===
@@ -1298,16 +1290,6 @@ function [iTess, TessInfo] = AddSurface(hFig, surfaceFile, surfaceType)
             % Update figure's surfaces list and current surface pointer
             setappdata(hFig, 'Surface',  TessInfo);
         end
-        
-    % === NO FILE: HeadPoints ===
-    elseif strcmpi(fileType, 'HeadPoints')
-        % Points were already displayed; just add the patch to the figure surfaces.
-        %TessInfo(iTess).DataSource.Type = 'HeadPointsDistance';
-        TessInfo(iTess).Name = 'HeadPoints';
-        TessInfo(iTess).ColormapType = 'stat1';
-        TessInfo(iTess).hPatch = findobj(hFig, 'Tag', 'HeadPointsMarkers');
-        % Update figure's surfaces list and current surface pointer
-        setappdata(hFig, 'Surface',  TessInfo);
         
     % === FEM ===
     else % TODO: Check for FEM fileType explicitly
@@ -1515,11 +1497,6 @@ function [isOk, TessInfo] = SetSurfaceData(hFig, iTess, dataType, dataFile, isSt
             TessInfo(iTess).Data = [];
             TessInfo(iTess).DataWmat = [];
 
-        case 'HeadPointsDistance'
-            ColormapType = 'stat1';
-            DisplayUnits = 'mm';
-            % Data is actually added in UpdateSurfaceData below.
-            
         otherwise
             ColormapType = '';
             DisplayUnits = [];
@@ -1901,15 +1878,6 @@ function [isOk, TessInfo] = UpdateSurfaceData(hFig, iSurfaces)
                 figure_callback(hFig, 'UpdateSurfaceColor', hFig, iTess);
                 % Get updated surface definition
                 TessInfo = getappdata(hFig, 'Surface');
-
-            case 'HeadPointsDistance'
-                TessInfo(iTess).Data = get(TessInfo(iTess).hPatch, 'CData');
-                if isempty(TessInfo(iTess).Data) || ~isnumeric(TessInfo(iTess).Data)
-                    isOk = 0;
-                    return;
-                end
-                TessInfo(iTess).DataMinMax = [min(TessInfo(iTess).Data(:)), max(TessInfo(iTess).Data(:))];
-
             otherwise
                 % Nothing to do
         end
@@ -2033,7 +2001,7 @@ function UpdateSurfaceColormap(hFig, iSurfaces)
             TessInfo(iTess).Data = abs(TessInfo(iTess).Data);
         end
         % If current colormap is the default colormap for this figure (for colorbar)
-        if strcmpi(ColormapInfo.Type, TessInfo(iTess).ColormapType) && ~isempty(TessInfo(iTess).DataSource.Type)
+        if strcmpi(ColormapInfo.Type, TessInfo(iTess).ColormapType) && ~isempty(TessInfo(iTess).DataSource.FileName)
             if all(~isnan(TessInfo(iTess).DataLimitValue)) && (TessInfo(iTess).DataLimitValue(1) < TessInfo(iTess).DataLimitValue(2))
                 set(hAxes, 'CLim', TessInfo(iTess).DataLimitValue);
             else
@@ -2049,8 +2017,7 @@ function UpdateSurfaceColormap(hFig, iSurfaces)
             end
         end     
         % === DISPLAY ON MRI ===
-        if strcmpi(TessInfo(iTess).Name, 'Anatomy') && ~isempty(TessInfo(iTess).DataSource.Type) && ...
-                ~strcmpi(TessInfo(iTess).DataSource.Type, 'MriTime') && isempty(TessInfo(iTess).OverlayCube)
+        if strcmpi(TessInfo(iTess).Name, 'Anatomy') && ~isempty(TessInfo(iTess).DataSource.Type) && ~strcmpi(TessInfo(iTess).DataSource.Type, 'MriTime') && isempty(TessInfo(iTess).OverlayCube)
             % Progress bar
             isProgressBar = bst_progress('isVisible');
             bst_progress('start', 'Display MRI', 'Updating values...');
@@ -2062,10 +2029,6 @@ function UpdateSurfaceColormap(hFig, iSurfaces)
             if ~isProgressBar
                 bst_progress('stop');
             end
-        elseif strcmpi(TessInfo(iTess).Name, 'HeadPoints')
-            % No need to update surface color here, data already updated.
-            % Update figure's appdata (surface list)
-            setappdata(hFig, 'Surface', TessInfo);            
         else
             % Update figure's appdata (surface list)
             setappdata(hFig, 'Surface', TessInfo);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -1302,7 +1302,7 @@ function [iTess, TessInfo] = AddSurface(hFig, surfaceFile, surfaceType)
     % === NO FILE: HeadPoints ===
     elseif strcmpi(fileType, 'HeadPoints')
         % Points were already displayed; just add the patch to the figure surfaces.
-        TessInfo(iTess).DataSource.Type = 'HeadPointsDistance';
+        %TessInfo(iTess).DataSource.Type = 'HeadPointsDistance';
         TessInfo(iTess).Name = 'HeadPoints';
         TessInfo(iTess).ColormapType = 'stat1';
         TessInfo(iTess).hPatch = findobj(hFig, 'Tag', 'HeadPointsMarkers');

--- a/toolbox/process/functions/process_adjust_coordinates.m
+++ b/toolbox/process/functions/process_adjust_coordinates.m
@@ -1,9 +1,8 @@
 function varargout = process_adjust_coordinates(varargin)
 % PROCESS_ADJUST_COORDINATES: Adjust, recompute, or remove various coordinate transformations.
 % 
-% Native coordinates are based on system fiducials (e.g. MEG head coils),
-% whereas Brainstorm's SCS coordinates are based on the anatomical fiducial
-% points from the .pos file.
+% Native coordinates are based on system fiducials (e.g. MEG head coils), whereas Brainstorm's SCS
+% coordinates are based on the anatomical fiducial points from the .pos file.
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -30,7 +29,7 @@ end
 
 
 
-function sProcess = GetDescription() %#ok<DEFNU>
+function sProcess = GetDescription()
     % Description of the process
     sProcess.Comment     = 'Adjust coordinate system';
     sProcess.Description = 'https://neuroimage.usc.edu/brainstorm/Tutorials/HeadMotion#Adjust_the_reference_head_position';
@@ -42,7 +41,7 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.OutputTypes = {'raw', 'data'};
     sProcess.nInputs     = 1;
     sProcess.nMinFiles   = 1;
-    % Option [to do: ignore bad segments]
+    % Option
     sProcess.options.reset.Type    = 'checkbox';
     sProcess.options.reset.Comment = 'Reset coordinates using original channel file (removes all adjustments: head, points, manual).';
     sProcess.options.reset.Value   = 0;
@@ -60,7 +59,7 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.bad.Type    = 'checkbox';
     sProcess.options.bad.Comment = 'For adjust option, exclude bad segments.';
     sProcess.options.bad.Value   = 1;
-    sProcess.options.bad.Class = 'Adjust';
+    sProcess.options.bad.Class   = 'Adjust';
     sProcess.options.points.Type    = 'checkbox';
     sProcess.options.points.Comment = 'Refine MRI coregistration using digitized head points.';
     sProcess.options.points.Value   = 0;
@@ -103,9 +102,8 @@ function OutputFiles = Run(sProcess, sInputs)
     end
     bst_progress('start', 'Adjust coordinate system', ...
         ' ', 0, nFiles);
-    % If resetting, in case the original data moved, and because the same
-    % channel file may appear in many places for processed data, keep track
-    % of user file selections.
+    % If resetting, in case the original data moved, and because the same channel file may appear in
+    % many places for processed data, keep track of user file selections.
     NewChannelFiles = cell(0, 2);
     for iFile = iUniqFiles(:)' % no need to repeat on same channel file.
         
@@ -132,13 +130,11 @@ function OutputFiles = Run(sProcess, sInputs)
         
         % ----------------------------------------------------------------
         if sProcess.options.reset.Value
-            % The main goal of this option is to fix a bug in a previous
-            % version: when importing a channel file, when going to SCS
-            % coordinates based on digitized coils and anatomical
-            % fiducials, the channel orientation was wrong.  We wish to fix
-            % this but keep as much pre-processing that was previously
-            % done.  Thus we will re-import the channel file, and copy the
-            % projectors (and history) from the old one.
+            % The main goal of this option is to fix a bug in a previous version: when importing a
+            % channel file, when going to SCS coordinates based on digitized coils and anatomical
+            % fiducials, the channel orientation was wrong.  We wish to fix this but keep as much
+            % pre-processing that was previously done.  Thus we will re-import the channel file, and
+            % copy the projectors (and history) from the old one.
             
             [ChannelMat, NewChannelFiles, Failed] = ...
                 ResetChannelFile(ChannelMat, NewChannelFiles, sInputs(iFile), sProcess);
@@ -148,25 +144,23 @@ function OutputFiles = Run(sProcess, sInputs)
             
             % ----------------------------------------------------------------
         elseif sProcess.options.remove.Value
-            % Because channel_align_manual does not consistently apply the
-            % manual transformation to all sensors or save it in both
-            % TransfMeg and TransfEeg, it could lead to confusion and
-            % errors when playing with transforms.  Therefore, if we detect
-            % a difference between the MEG and EEG transforms when trying
-            % to remove one that applies to both (currently only refine
-            % with head points), we don't proceed and recommend resetting
-            % with the original channel file instead.
+            % Because channel_align_manual does not consistently apply the manual transformation to
+            % all sensors or save it in both TransfMeg and TransfEeg, it could lead to confusion and
+            % errors when playing with transforms.  Therefore, if we detect a difference between the
+            % MEG and EEG transforms when trying to remove one that applies to both (currently only
+            % refine with head points), we don't proceed and recommend resetting with the original
+            % channel file instead.
             
             Which = {};
             if sProcess.options.head.Value
-                Which{end+1} = 'AdjustedNative';
+                Which{end+1} = 'AdjustedNative'; %#ok<AGROW> 
             end
             if sProcess.options.points.Value
-                Which{end+1} = 'refine registration: head points';
+                Which{end+1} = 'refine registration: head points'; %#ok<AGROW> 
             end
             
             for TransfLabel = Which
-                TransfLabel = TransfLabel{1};
+                TransfLabel = TransfLabel{1}; %#ok<FXSET> 
                 ChannelMat = RemoveTransformation(ChannelMat, TransfLabel, sInputs(iFile), sProcess);
             end % TransfLabel loop
             
@@ -189,8 +183,8 @@ function OutputFiles = Run(sProcess, sInputs)
             bst_progress('text', 'Fitting head surface to points...');
             [ChannelMat, R, T, isSkip] = ...
                 channel_align_auto(sInputs(iFile).ChannelFile, ChannelMat, 0, 0); % No warning or confirmation
-            % ChannelFile needed to find subject and scalp surface, but not
-            % used otherwise when ChannelMat is provided.
+            % ChannelFile needed to find subject and scalp surface, but not used otherwise when
+            % ChannelMat is provided.
             if isSkip
                 bst_report('Error', sProcess, sInputs(iFile), ...
                     'Error trying to refine registration using head points.');
@@ -212,10 +206,9 @@ function OutputFiles = Run(sProcess, sInputs)
     end % file loop
     bst_progress('stop');
     
-    % Return the input files that were processed properly.  Include those
-    % that were removed due to sharing a channel file, where appropriate.
-    % The complicated indexing picks the first input of those with the same
-    % channel file, i.e. the one that was marked ok.
+    % Return the input files that were processed properly.  Include those that were removed due to
+    % sharing a channel file, where appropriate. The complicated indexing picks the first input of
+    % those with the same channel file, i.e. the one that was marked ok.
     OutputFiles = {sInputs(isFileOk(iUniqInputs(iUniqFiles))).FileName};
 end
 
@@ -266,8 +259,7 @@ end
 %                 end
 
 
-function [ChannelMat, NewChannelFiles, Failed] = ...
-        ResetChannelFile(ChannelMat, NewChannelFiles, sInput, sProcess)
+function [ChannelMat, NewChannelFiles, Failed] = ResetChannelFile(ChannelMat, NewChannelFiles, sInput, sProcess)
     if nargin < 4
         sProcess = [];
     end
@@ -307,10 +299,9 @@ function [ChannelMat, NewChannelFiles, Failed] = ...
     if NotFound
         bst_report('Info', sProcess, sInput, ...
             sprintf('Could not find original channel file: %s.', ChannelFile));
-        % import_channel will prompt the user, but they will not
-        % know which file to pick!  And prompt is modal for Matlab,
-        % so likely can't look at command window (e.g. if
-        % Brainstorm is in front).
+        % import_channel will prompt the user, but they will not know which file to pick!  And
+        % prompt is modal for Matlab, so likely can't look at command window (e.g. if Brainstorm is
+        % in front).
         [ChanPath, ChanName, ChanExt] = fileparts(ChannelFile);
         MsgFig = msgbox(sprintf('Select the new location of channel file %s %s to reset %s.', ...
             ChanPath, [ChanName, ChanExt], sInput.ChannelFile), ...
@@ -380,9 +371,8 @@ function ChannelMat = RemoveTransformation(ChannelMat, TransfLabel, sInput, sPro
         % Need to check for empty, otherwise applies to all channels!
     else
         iChan = []; % All channels.
-        % Note: NIRS doesn't have a separate set of
-        % transformations, but "refine" and "SCS" are applied
-        % to NIRS as well.
+        % Note: NIRS doesn't have a separate set of transformations, but "refine" and "SCS" are
+        % applied to NIRS as well.
     end
     while ~isempty(iUndoMeg)
         if isMegOnly && isempty(iChan)
@@ -457,9 +447,8 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
         return;
     end
     
-    % The data could be changed such that the head position could be
-    % readjusted (e.g. by deleting segments).  This is allowed and the
-    % previous adjustment will be replaced.
+    % The data could be changed such that the head position could be readjusted (e.g. by deleting
+    % segments).  This is allowed and the previous adjustment will be replaced.
     if isfield(ChannelMat, 'TransfMegLabels') && iscell(ChannelMat.TransfMegLabels) && ...
             ismember('AdjustedNative', ChannelMat.TransfMegLabels)
         bst_report('Info', sProcess, sInputs, ...
@@ -513,7 +502,7 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
                 Locs(:, ismember(iHeadSamples, iBad)) = [];
             end
         end
-        Locations = [Locations, Locs];
+        Locations = [Locations, Locs]; %#ok<AGROW> 
     end
     
     % If a collection was aborted, the channels will be filled with zeros. Remove these.
@@ -523,8 +512,7 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
     MedianLoc = MedianLocation(Locations);
     %         disp(MedianLoc);
     
-    % Also get the initial reference position.  We only use it to see
-    % how much the adjustment moves.
+    % Also get the initial reference position.  We only use it to estimate how much the adjustment moves.
     InitRefLoc = ReferenceHeadLocation(ChannelMat, sInputs);
     if isempty(InitRefLoc)
         % There was an error, already reported. Skip this file.
@@ -532,9 +520,8 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
         return;
     end
     
-    % Extract transformations that are applied before and after the
-    % head position adjustment.  Any previous adjustment will be
-    % ignored here and replaced later.
+    % Extract transformations that are applied before and after the head position adjustment.  Any
+    % previous adjustment will be ignored here and replaced later.
     [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = ...
         GetTransforms(ChannelMat, sInputs);
     if isempty(TransfBefore)
@@ -545,33 +532,26 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
     % Compute transformation corresponding to coil position.
     [TransfMat, TransfAdjust] = LocationTransform(MedianLoc, ...
         TransfBefore, TransfAdjust, TransfAfter);
-    % This TransfMat would automatically give an identity
-    % transformation if the process is run multiple times, and
-    % TransfAdjust would not change.
+    % This TransfMat would automatically give an identity transformation if the process is run
+    % multiple times, and TransfAdjust would not change.
     
-    % Apply this transformation to the current head position.
-    % This is a correction to the 'Dewar=>Native'
-    % transformation so it applies to MEG channels only and not
-    % to EEG or head points, which start in Native.
+    % Apply this transformation to the current head position. This is a correction to the
+    % 'Dewar=>Native' transformation so it applies to MEG channels only and not to EEG or head
+    % points, which start in Native.
     iMeg  = sort([good_channel(ChannelMat.Channel, [], 'MEG'), ...
         good_channel(ChannelMat.Channel, [], 'MEG REF')]);
     ChannelMat = channel_apply_transf(ChannelMat, TransfMat, iMeg, false); % Don't apply to head points.
     ChannelMat = ChannelMat{1};
     
-    % After much thought, it was decided to save this
-    % adjustment transformation separately and at its logical
-    % place: between 'Dewar=>Native' and
-    % 'Native=>Brainstorm/CTF'.  In particular, this allows us
-    % to use it directly when displaying head motion distance.
-    % This however means we must correctly move the
-    % transformation from the end where it was just applied to
-    % its logical place. This "moved" transformation is also
-    % computed in LocationTransform above.
+    % After much thought, it was decided to save this adjustment transformation separately and at
+    % its logical place: between 'Dewar=>Native' and 'Native=>Brainstorm/CTF'.  In particular, this
+    % allows us to use it directly when displaying head motion distance. This however means we must
+    % correctly move the transformation from the end where it was just applied to its logical place.
+    % This "moved" transformation is also computed in LocationTransform above.
     if isempty(iAdjust)
         iAdjust = iDewToNat + 1;
-        % Shift transformations to make room for the new
-        % adjustment, and reject the last one, that we just
-        % applied.
+        % Shift transformations to make room for the new adjustment, and reject the last one, that
+        % we just applied.
         ChannelMat.TransfMegLabels(iDewToNat+2:end) = ...
             ChannelMat.TransfMegLabels(iDewToNat+1:end-1); % reject last one
         ChannelMat.TransfMeg(iDewToNat+2:end) = ChannelMat.TransfMeg(iDewToNat+1:end-1);
@@ -601,14 +581,12 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
 end % AdjustHeadPosition
 
 
-
 function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
     % Compute initial head location in Dewar coordinates.
     
-    % Here we want to recreate the correct triangle shape from the relative
-    % head coil locations and in the position saved as the reference
-    % (initial) head position according to Brainstorm coordinate
-    % transformation matrices.
+    % Here we want to recreate the correct triangle shape from the relative head coil locations and
+    % in the position saved as the reference (initial) head position according to Brainstorm
+    % coordinate transformation matrices.
     
     if nargin < 2
         sInput = [];
@@ -616,23 +594,24 @@ function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
         sInput = sInput(1);
     end
     Message = '';
-    
-    % These aren't exactly the coil positions in the .hc file, which are not saved
-    % anywhere in Brainstorm, but was verified to give the same transformation.
-    % The SCS coil coordinates are from the digitized coil positions.
-    if isfield(ChannelMat, 'SCS') && all(isfield(ChannelMat.SCS, {'NAS','LPA','RPA'})) && ...
-            (length(ChannelMat.SCS.NAS) == 3) && (length(ChannelMat.SCS.LPA) == 3) && (length(ChannelMat.SCS.RPA) == 3)
-        %         % Use the SCS distances from origin, with left and right PA points symmetrical.
-        %         LeftRightDist = sqrt(sum((ChannelMat.SCS.LPA - ChannelMat.SCS.RPA).^2));
-        %         NasDist = ChannelMat.SCS.NAS(1);
-        InitLoc = [ChannelMat.SCS.NAS(:), ChannelMat.SCS.LPA(:), ChannelMat.SCS.RPA(:); ones(1, 3)];
-    elseif ~isempty(sInput) && isfield(sInput, 'header') && isfield(sInput.header, 'hc') && isfield(sInput.header.hc, 'SCS') && ...
+
+    % From recent investigations, digitized locations are probably not as robust/accurate as those
+    % measured by the MEG. So use the .hc positions if available.
+    if ~isempty(sInput) && isfield(sInput, 'header') && isfield(sInput.header, 'hc') && isfield(sInput.header.hc, 'SCS') && ...
             all(isfield(sInput.header.hc.SCS, {'NAS','LPA','RPA'})) && length(sInput.header.hc.SCS.NAS) == 3
         % Initial head coil locations from the CTF .hc file, but in dewar coordinates, NOT in SCS coordinates!
         InitLoc = [sInput.header.hc.SCS.NAS(:), sInput.header.hc.SCS.LPA(:), sInput.header.hc.SCS.RPA(:)]; % 3x3 by columns
         InitLoc = InitLoc(:);
         return;
-        %InitLoc = TransfAdjust * TransfBefore * [InitLoc; ones(1, 3)];
+        % ChannelMat.SCS are not the coil positions in the .hc file, which are not saved in Brainstorm,
+        % but the digitized coil positions, if present. However, both are saved in "Native" coordinates
+        % and thus give the same transformation.
+    elseif isfield(ChannelMat, 'SCS') && all(isfield(ChannelMat.SCS, {'NAS','LPA','RPA'})) && ...
+            (length(ChannelMat.SCS.NAS) == 3) && (length(ChannelMat.SCS.LPA) == 3) && (length(ChannelMat.SCS.RPA) == 3)
+        %         % Use the SCS distances from origin, with left and right PA points symmetrical.
+        %         LeftRightDist = sqrt(sum((ChannelMat.SCS.LPA - ChannelMat.SCS.RPA).^2));
+        %         NasDist = ChannelMat.SCS.NAS(1);
+        InitLoc = [ChannelMat.SCS.NAS(:), ChannelMat.SCS.LPA(:), ChannelMat.SCS.RPA(:); ones(1, 3)];
     else
         % Just use some reasonable distances, with a warning.
         Message = 'Exact reference head coil locations not available. Using reasonable (adult) locations according to head position.';
@@ -643,11 +622,9 @@ function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
     % InitLoc above is in Native coordiates (if pre head loc didn't fail).
     % Bring it back to Dewar coordinates to compare with HLU channels.
     %
-    % Take into account if the initial/reference head position was
-    % "adjusted", i.e. replaced by the median position throughout the
-    % recording.  If so, use all transformations from 'Dewar=>Native' to
-    % this adjustment transformation.  (In practice there shouldn't be any
-    % between them.)
+    % Take into account if the initial/reference head position was "adjusted", i.e. replaced by the
+    % median position throughout the recording.  If so, use all transformations from 'Dewar=>Native'
+    % to this adjustment transformation.  (In practice there shouldn't be any between them.)
     [TransfBefore, TransfAdjust] = GetTransforms(ChannelMat, sInput);
     InitLoc = TransfBefore \ (TransfAdjust \ InitLoc);
     InitLoc(4, :) = [];
@@ -655,25 +632,22 @@ function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
 end % ReferenceHeadLocation
 
 
-function [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = ...
-        GetTransforms(ChannelMat, sInputs)
-    % Extract transformations that are applied before and after the head
-    % position adjustment we are creating now.  We keep the 'Dewar=>Native'
-    % transformation intact and separate from the adjustment for no deep
-    % reason, but it is the only remaining trace of the initial head coil
+function [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = GetTransforms(ChannelMat, sInputs)
+    % Extract transformations that are applied before and after the head position adjustment we are
+    % creating now.  We keep the 'Dewar=>Native' transformation intact and separate from the
+    % adjustment for no deep reason, but it is the only remaining trace of the initial head coil
     % positions in Brainstorm.
     
-    % The reason this function was split from LocationTransform is that it
-    % can be called only once outside the head sample loop in process_sss,
-    % whereas LocationTransform is called many times within the loop.
+    % The reason this function was split from LocationTransform is that it can be called only once
+    % outside the head sample loop in process_sss, whereas LocationTransform is called many times
+    % within the loop.
     
-    % When this is called from process_sss, we are possibly working on a
-    % second head adjustment, this time based on the instantaneous head
-    % position, so we need to keep the global adjustment based on the entire
-    % recording if it is there.
+    % When this is called from process_sss, we are possibly working on a second head adjustment,
+    % this time based on the instantaneous head position, so we need to keep the global adjustment
+    % based on the entire recording if it is there.
     
-    % Check order of transformations.  These situations should not happen
-    % unless there was some manual editing.
+    % Check order of transformations.  These situations should not happen unless there was some
+    % manual editing.
     iDewToNat = find(strcmpi(ChannelMat.TransfMegLabels, 'Dewar=>Native'));
     iAdjust = find(strcmpi(ChannelMat.TransfMegLabels, 'AdjustedNative'));
     TransfBefore = [];
@@ -724,11 +698,9 @@ function [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = ...
 end % GetTransforms
 
 
-function [TransfMat, TransfAdjust] = LocationTransform(Loc, ...
-        TransfBefore, TransfAdjust, TransfAfter)
-    % Compute transformation corresponding to head coil positions.
-    % We want this to be as efficient as possible, since used many times by
-    % process_sss.
+function [TransfMat, TransfAdjust] = LocationTransform(Loc, TransfBefore, TransfAdjust, TransfAfter)
+    % Compute transformation corresponding to head coil positions. We want this to be as efficient
+    % as possible, since used many times by process_sss.
     
     % Check for previous version.
     if nargin < 4
@@ -736,10 +708,10 @@ function [TransfMat, TransfAdjust] = LocationTransform(Loc, ...
     end
     
     % Transformation matrices are in m, as are HLU channels.
-    % The HLU channels (here Loc) are in dewar coordinates.  Bring them to
-    % the current system by applying all saved transformations, starting with
-    % 'Dewar=>Native'.  This will save us from having to use inverse
-    % transformations later.
+    %
+    % The HLU channels (here Loc) are in dewar coordinates.  Bring them to the current system by
+    % applying all saved transformations, starting with 'Dewar=>Native'.  This will save us from
+    % having to use inverse transformations later.
     Loc = TransfAfter(1:3, :) * TransfAdjust * TransfBefore * [reshape(Loc, 3, 3); 1, 1, 1];
     %   [[Loc(1:3), Loc(4:6), Loc(5:9)]; 1, 1, 1]; % test if efficiency difference.
     
@@ -759,14 +731,12 @@ function [TransfMat, TransfAdjust] = LocationTransform(Loc, ...
     TransfMat(1:3,1:3) = [X, Y, Z]';
     TransfMat(1:3,4) = - [X, Y, Z]' * Origin;
     
-    % TransfMat at this stage is a transformation from the current system
-    % back to the now adjusted Native system.  We thus need to reapply the
-    % following tranformations.
+    % TransfMat at this stage is a transformation from the current system back to the now adjusted
+    % Native system.  We thus need to reapply the following tranformations.
     
     if nargout > 1
-        % Transform from non-adjusted native coordinates to newly adjusted native
-        % coordinates.  To be saved in channel file between "Dewar=>Native" and
-        % "Native=>Brainstorm/CTF".
+        % Transform from non-adjusted native coordinates to newly adjusted native coordinates.  To
+        % be saved in channel file between "Dewar=>Native" and "Native=>Brainstorm/CTF".
         TransfAdjust = TransfMat * TransfAfter * TransfAdjust;
     end
     
@@ -796,34 +766,19 @@ function M = GeoMedian(X, Precision)
     %
     % M = GeoMedian(X, Precision)
     %
-    % Calculate the geometric median: the point that minimizes sum of
-    % Euclidean distances to all points.  size(X) = [n, d, ...], where n is
-    % the number of data points, d is the number of components for each point
-    % and any additional array dimension is treated as independent sets of
-    % data and a median is calculated for each element along those dimensions
-    % sequentially; size(M) = [1, d, ...].  This is an approximate iterative
-    % procedure that stops once the desired precision is achieved.  If
-    % Precision is not provided, 1e-4 of the max distance from the centroid
-    % is used.
+    % Calculate the geometric median: the point that minimizes sum of Euclidean distances to all
+    % points.  size(X) = [n, d, ...], where n is the number of data points, d is the number of
+    % components for each point and any additional array dimension is treated as independent sets of
+    % data and a median is calculated for each element along those dimensions sequentially; size(M)
+    % = [1, d, ...].  This is an approximate iterative procedure that stops once the desired
+    % precision is achieved.  If Precision is not provided, 1e-4 of the max distance from the
+    % centroid is used.
     %
-    % Weiszfeld's algorithm is used, which is a subgradient algorithm; with
-    % (Verdi & Zhang 2001)'s modification to avoid non-optimal fixed points
-    % (if at any iteration the approximation of M equals a data point).
+    % Weiszfeld's algorithm is used, which is a subgradient algorithm; with (Verdi & Zhang 2001)'s
+    % modification to avoid non-optimal fixed points (if at any iteration the approximation of M
+    % equals a data point).
     %
-    %
-    % (c) Copyright 2018 Marc Lalancette
-    % The Hospital for Sick Children, Toronto, Canada
-    %
-    % This file is part of a free repository of Matlab tools for MEG
-    % data processing and analysis <https://gitlab.com/moo.marc/MMM>.
-    % You can redistribute it and/or modify it under the terms of the GNU
-    % General Public License as published by the Free Software Foundation,
-    % either version 3 of the License, or (at your option) a later version.
-    %
-    % This program is distributed WITHOUT ANY WARRANTY.
-    % See the LICENSE file, or <http://www.gnu.org/licenses/> for details.
-    %
-    % 2012-05
+    % Marc Lalancette 2012-05
     
     nDims = ndims(X);
     XSize = size(X);
@@ -850,17 +805,15 @@ function M = GeoMedian(X, Precision)
         Precision = bsxfun(@rdivide, Precision, Scale); % Precision ./ Scale; % [1, 1, nSets]
     end
     
-    % Initial estimate: median in each dimension separately.  Though this
-    % gives a chance of picking one of the data points, which requires
-    % special treatment.
+    % Initial estimate: median in each dimension separately.  Though this gives a chance of picking
+    % one of the data points, which requires special treatment.
     M2 = median(X, 1);
     
-    % It might be better to calculate separately each independent set,
-    % otherwise, they are all iterated until the worst case converges.
+    % It might be better to calculate separately each independent set, otherwise, they are all
+    % iterated until the worst case converges.
     for s = 1:nSets
         
-        % For convenience, pick another point far enough so the loop will always
-        % start.
+        % For convenience, pick another point far enough so the loop will always start.
         M = bsxfun(@plus, M2(:, :, s), Precision(:, :, s));
         % Iterate.
         while  sum((M - M2(:, :, s)).^2 , 2) > Precision(s)^2  % any()scalar
@@ -868,8 +821,7 @@ function M = GeoMedian(X, Precision)
             % Distances from M.
             %       R = sqrt(sum( (M(ones(n, 1), :) - X(:, :, s)).^2 , 2 )); % [n, 1]
             R = sqrt(sum( bsxfun(@minus, M, X(:, :, s)).^2 , 2 )); % [n, 1]
-            % Find data points not equal to M, that we use in the computation
-            % below.
+            % Find data points not equal to M, that we use in the computation below.
             Good = logical(R);
             nG = sum(Good);
             if nG % > 0
@@ -883,10 +835,10 @@ function M = GeoMedian(X, Precision)
             end
             
             % New estimate.
-            % Note the possibility of D = 0 and (n - nG) = 0, in which case 0/0
-            % should be 0, but here gives NaN, which the max function ignores,
-            % returning 0 instead of 1. This is fine however since this
-            % multiplies D (=0 in that case).
+            %
+            % Note the possibility of D = 0 and (n - nG) = 0, in which case 0/0 should be 0, but
+            % here gives NaN, which the max function ignores, returning 0 instead of 1. This is fine
+            % however since this multiplies D (=0 in that case).
             M2(:, :, s) = M - max(0, 1 - (n - nG)/sqrt(sum( D.^2 , 2 ))) * ...
                 D / sum(1 ./ R, 1);
         end
@@ -901,5 +853,81 @@ function M = GeoMedian(X, Precision)
     end
     
 end % GeoMedian
+
+
+function CheckPrevAdjustments(ChannelMat, sMri)
+    % Flag if auto or manual registration performed, and if MRI fids updated. Print to command
+    % window for now.
+    if any(~isfield(ChannelMat, {'History', 'HeadPoints'}))
+        % Nothing to check.
+        return;
+    end
+    if nargin < 2 || isempty(sMri) || ~isfield(sMri, 'History')
+        iMriHist = [];
+    else
+        iMriHist = find(strcmpi(sMri.History(:,3), 'Applied digitized anatomical fiducials'), 1, 'last');
+    end
+    % Can also be reset, so check for 'import' action and ignore previous alignments.
+    iImport = find(strcmpi(ChannelMat.History(:,2), 'import'), 1, 'last');
+    iAlign = find(strcmpi(ChannelMat.History(:,2), 'align'));
+    iAlign(iAlign < iImport) = [];
+    AlignType = 'none';
+    while ~isempty(iAlign)
+        % Check which adjustment was done last.
+        switch lower(ChannelMat.History{iAlign(end),3}(1:5))
+            case 'remov'
+                % Removed a previous step. Ignore corresponding adjustment and look again.
+                iAlign(end) = [];
+                if contains(ChannelMat.History{iAlign(end),3}, 'AdjustedNative')
+                    iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
+                elseif contains(ChannelMat.History{iAlign(end),3}, 'refine registration: head points')
+                    iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
+                elseif contains(ChannelMat.History{iAlign(end),3}, 'manual correction')
+                    iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
+                else
+                    bst_error('Unrecognized removed transformation in history.');
+                end
+                if isempty(iAlignRemoved)
+                    bst_error('Missing removed transformation in history.');
+                else
+                    iAlign(iAlignRemoved) = [];
+                end
+            case 'added'
+                % This alignment is between points and functional dataset, ignore here.
+                iAlign(end) = [];
+            case 'refin'
+                % Automatic MRI-points alignment
+                AlignType = 'auto';
+                break;
+            case 'align'
+                % Manual MRI-points alignment
+                AlignType = 'manual';
+                break;
+        end
+    end
+    disp(['BST> Previous registration adjustment: ' AlignType]);
+    if ~isempty(iMriHist)
+        % Compare digitized fids to MRI fids (in MRI coordinates, mm). ChannelMat.SCS fids are NOT
+        % kept up to date when adjusting registration (manual or auto), so get them from head points
+        % again.
+        % Get the three fiducials in the head points
+        iNas = find(strcmpi(ChannelMat.HeadPoints.Label, 'Nasion') | strcmpi(ChannelMat.HeadPoints.Label, 'NAS'));
+        iLpa = find(strcmpi(ChannelMat.HeadPoints.Label, 'Left')   | strcmpi(ChannelMat.HeadPoints.Label, 'LPA'));
+        iRpa = find(strcmpi(ChannelMat.HeadPoints.Label, 'Right')  | strcmpi(ChannelMat.HeadPoints.Label, 'RPA'));
+        if ~isempty(iNas) && ~isempty(iLpa) && ~isempty(iRpa)
+            ChannelMat.SCS.NAS = mean(ChannelMat.HeadPoints.Loc(:,iNas)', 1);
+            ChannelMat.SCS.LPA = mean(ChannelMat.HeadPoints.Loc(:,iLpa)', 1);
+            ChannelMat.SCS.RPA = mean(ChannelMat.HeadPoints.Loc(:,iRpa)', 1);
+        end
+        if any(abs(sMri.SCS.NAS - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.NAS) .* 1000) > 1e-3) || ...
+                any(abs(sMri.SCS.LPA - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.LPA) .* 1000) > 1e-3) || ...
+                any(abs(sMri.SCS.RPA - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.RPA) .* 1000) > 1e-3)
+            disp('BST> MRI fiducials previously updated, but different than current digitized fiducials.');
+        else
+            disp('BST> MRI fiducials previously updated, and match current digitized fiducials.');
+        end
+    end
+
+end
 
 

--- a/toolbox/process/functions/process_adjust_coordinates.m
+++ b/toolbox/process/functions/process_adjust_coordinates.m
@@ -1,8 +1,9 @@
 function varargout = process_adjust_coordinates(varargin)
 % PROCESS_ADJUST_COORDINATES: Adjust, recompute, or remove various coordinate transformations.
 % 
-% Native coordinates are based on system fiducials (e.g. MEG head coils), whereas Brainstorm's SCS
-% coordinates are based on the anatomical fiducial points from the .pos file.
+% Native coordinates are based on system fiducials (e.g. MEG head coils),
+% whereas Brainstorm's SCS coordinates are based on the anatomical fiducial
+% points from the .pos file.
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -29,7 +30,7 @@ end
 
 
 
-function sProcess = GetDescription()
+function sProcess = GetDescription() %#ok<DEFNU>
     % Description of the process
     sProcess.Comment     = 'Adjust coordinate system';
     sProcess.Description = 'https://neuroimage.usc.edu/brainstorm/Tutorials/HeadMotion#Adjust_the_reference_head_position';
@@ -41,7 +42,7 @@ function sProcess = GetDescription()
     sProcess.OutputTypes = {'raw', 'data'};
     sProcess.nInputs     = 1;
     sProcess.nMinFiles   = 1;
-    % Option
+    % Option [to do: ignore bad segments]
     sProcess.options.reset.Type    = 'checkbox';
     sProcess.options.reset.Comment = 'Reset coordinates using original channel file (removes all adjustments: head, points, manual).';
     sProcess.options.reset.Value   = 0;
@@ -59,7 +60,7 @@ function sProcess = GetDescription()
     sProcess.options.bad.Type    = 'checkbox';
     sProcess.options.bad.Comment = 'For adjust option, exclude bad segments.';
     sProcess.options.bad.Value   = 1;
-    sProcess.options.bad.Class   = 'Adjust';
+    sProcess.options.bad.Class = 'Adjust';
     sProcess.options.points.Type    = 'checkbox';
     sProcess.options.points.Comment = 'Refine MRI coregistration using digitized head points.';
     sProcess.options.points.Value   = 0;
@@ -102,8 +103,9 @@ function OutputFiles = Run(sProcess, sInputs)
     end
     bst_progress('start', 'Adjust coordinate system', ...
         ' ', 0, nFiles);
-    % If resetting, in case the original data moved, and because the same channel file may appear in
-    % many places for processed data, keep track of user file selections.
+    % If resetting, in case the original data moved, and because the same
+    % channel file may appear in many places for processed data, keep track
+    % of user file selections.
     NewChannelFiles = cell(0, 2);
     for iFile = iUniqFiles(:)' % no need to repeat on same channel file.
         
@@ -130,11 +132,13 @@ function OutputFiles = Run(sProcess, sInputs)
         
         % ----------------------------------------------------------------
         if sProcess.options.reset.Value
-            % The main goal of this option is to fix a bug in a previous version: when importing a
-            % channel file, when going to SCS coordinates based on digitized coils and anatomical
-            % fiducials, the channel orientation was wrong.  We wish to fix this but keep as much
-            % pre-processing that was previously done.  Thus we will re-import the channel file, and
-            % copy the projectors (and history) from the old one.
+            % The main goal of this option is to fix a bug in a previous
+            % version: when importing a channel file, when going to SCS
+            % coordinates based on digitized coils and anatomical
+            % fiducials, the channel orientation was wrong.  We wish to fix
+            % this but keep as much pre-processing that was previously
+            % done.  Thus we will re-import the channel file, and copy the
+            % projectors (and history) from the old one.
             
             [ChannelMat, NewChannelFiles, Failed] = ...
                 ResetChannelFile(ChannelMat, NewChannelFiles, sInputs(iFile), sProcess);
@@ -144,23 +148,25 @@ function OutputFiles = Run(sProcess, sInputs)
             
             % ----------------------------------------------------------------
         elseif sProcess.options.remove.Value
-            % Because channel_align_manual does not consistently apply the manual transformation to
-            % all sensors or save it in both TransfMeg and TransfEeg, it could lead to confusion and
-            % errors when playing with transforms.  Therefore, if we detect a difference between the
-            % MEG and EEG transforms when trying to remove one that applies to both (currently only
-            % refine with head points), we don't proceed and recommend resetting with the original
-            % channel file instead.
+            % Because channel_align_manual does not consistently apply the
+            % manual transformation to all sensors or save it in both
+            % TransfMeg and TransfEeg, it could lead to confusion and
+            % errors when playing with transforms.  Therefore, if we detect
+            % a difference between the MEG and EEG transforms when trying
+            % to remove one that applies to both (currently only refine
+            % with head points), we don't proceed and recommend resetting
+            % with the original channel file instead.
             
             Which = {};
             if sProcess.options.head.Value
-                Which{end+1} = 'AdjustedNative'; %#ok<AGROW> 
+                Which{end+1} = 'AdjustedNative';
             end
             if sProcess.options.points.Value
-                Which{end+1} = 'refine registration: head points'; %#ok<AGROW> 
+                Which{end+1} = 'refine registration: head points';
             end
             
             for TransfLabel = Which
-                TransfLabel = TransfLabel{1}; %#ok<FXSET> 
+                TransfLabel = TransfLabel{1};
                 ChannelMat = RemoveTransformation(ChannelMat, TransfLabel, sInputs(iFile), sProcess);
             end % TransfLabel loop
             
@@ -183,8 +189,8 @@ function OutputFiles = Run(sProcess, sInputs)
             bst_progress('text', 'Fitting head surface to points...');
             [ChannelMat, R, T, isSkip] = ...
                 channel_align_auto(sInputs(iFile).ChannelFile, ChannelMat, 0, 0); % No warning or confirmation
-            % ChannelFile needed to find subject and scalp surface, but not used otherwise when
-            % ChannelMat is provided.
+            % ChannelFile needed to find subject and scalp surface, but not
+            % used otherwise when ChannelMat is provided.
             if isSkip
                 bst_report('Error', sProcess, sInputs(iFile), ...
                     'Error trying to refine registration using head points.');
@@ -206,9 +212,10 @@ function OutputFiles = Run(sProcess, sInputs)
     end % file loop
     bst_progress('stop');
     
-    % Return the input files that were processed properly.  Include those that were removed due to
-    % sharing a channel file, where appropriate. The complicated indexing picks the first input of
-    % those with the same channel file, i.e. the one that was marked ok.
+    % Return the input files that were processed properly.  Include those
+    % that were removed due to sharing a channel file, where appropriate.
+    % The complicated indexing picks the first input of those with the same
+    % channel file, i.e. the one that was marked ok.
     OutputFiles = {sInputs(isFileOk(iUniqInputs(iUniqFiles))).FileName};
 end
 
@@ -259,7 +266,8 @@ end
 %                 end
 
 
-function [ChannelMat, NewChannelFiles, Failed] = ResetChannelFile(ChannelMat, NewChannelFiles, sInput, sProcess)
+function [ChannelMat, NewChannelFiles, Failed] = ...
+        ResetChannelFile(ChannelMat, NewChannelFiles, sInput, sProcess)
     if nargin < 4
         sProcess = [];
     end
@@ -299,9 +307,10 @@ function [ChannelMat, NewChannelFiles, Failed] = ResetChannelFile(ChannelMat, Ne
     if NotFound
         bst_report('Info', sProcess, sInput, ...
             sprintf('Could not find original channel file: %s.', ChannelFile));
-        % import_channel will prompt the user, but they will not know which file to pick!  And
-        % prompt is modal for Matlab, so likely can't look at command window (e.g. if Brainstorm is
-        % in front).
+        % import_channel will prompt the user, but they will not
+        % know which file to pick!  And prompt is modal for Matlab,
+        % so likely can't look at command window (e.g. if
+        % Brainstorm is in front).
         [ChanPath, ChanName, ChanExt] = fileparts(ChannelFile);
         MsgFig = msgbox(sprintf('Select the new location of channel file %s %s to reset %s.', ...
             ChanPath, [ChanName, ChanExt], sInput.ChannelFile), ...
@@ -371,8 +380,9 @@ function ChannelMat = RemoveTransformation(ChannelMat, TransfLabel, sInput, sPro
         % Need to check for empty, otherwise applies to all channels!
     else
         iChan = []; % All channels.
-        % Note: NIRS doesn't have a separate set of transformations, but "refine" and "SCS" are
-        % applied to NIRS as well.
+        % Note: NIRS doesn't have a separate set of
+        % transformations, but "refine" and "SCS" are applied
+        % to NIRS as well.
     end
     while ~isempty(iUndoMeg)
         if isMegOnly && isempty(iChan)
@@ -447,8 +457,9 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
         return;
     end
     
-    % The data could be changed such that the head position could be readjusted (e.g. by deleting
-    % segments).  This is allowed and the previous adjustment will be replaced.
+    % The data could be changed such that the head position could be
+    % readjusted (e.g. by deleting segments).  This is allowed and the
+    % previous adjustment will be replaced.
     if isfield(ChannelMat, 'TransfMegLabels') && iscell(ChannelMat.TransfMegLabels) && ...
             ismember('AdjustedNative', ChannelMat.TransfMegLabels)
         bst_report('Info', sProcess, sInputs, ...
@@ -502,7 +513,7 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
                 Locs(:, ismember(iHeadSamples, iBad)) = [];
             end
         end
-        Locations = [Locations, Locs]; %#ok<AGROW> 
+        Locations = [Locations, Locs];
     end
     
     % If a collection was aborted, the channels will be filled with zeros. Remove these.
@@ -512,7 +523,8 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
     MedianLoc = MedianLocation(Locations);
     %         disp(MedianLoc);
     
-    % Also get the initial reference position.  We only use it to estimate how much the adjustment moves.
+    % Also get the initial reference position.  We only use it to see
+    % how much the adjustment moves.
     InitRefLoc = ReferenceHeadLocation(ChannelMat, sInputs);
     if isempty(InitRefLoc)
         % There was an error, already reported. Skip this file.
@@ -520,8 +532,9 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
         return;
     end
     
-    % Extract transformations that are applied before and after the head position adjustment.  Any
-    % previous adjustment will be ignored here and replaced later.
+    % Extract transformations that are applied before and after the
+    % head position adjustment.  Any previous adjustment will be
+    % ignored here and replaced later.
     [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = ...
         GetTransforms(ChannelMat, sInputs);
     if isempty(TransfBefore)
@@ -532,26 +545,33 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
     % Compute transformation corresponding to coil position.
     [TransfMat, TransfAdjust] = LocationTransform(MedianLoc, ...
         TransfBefore, TransfAdjust, TransfAfter);
-    % This TransfMat would automatically give an identity transformation if the process is run
-    % multiple times, and TransfAdjust would not change.
+    % This TransfMat would automatically give an identity
+    % transformation if the process is run multiple times, and
+    % TransfAdjust would not change.
     
-    % Apply this transformation to the current head position. This is a correction to the
-    % 'Dewar=>Native' transformation so it applies to MEG channels only and not to EEG or head
-    % points, which start in Native.
+    % Apply this transformation to the current head position.
+    % This is a correction to the 'Dewar=>Native'
+    % transformation so it applies to MEG channels only and not
+    % to EEG or head points, which start in Native.
     iMeg  = sort([good_channel(ChannelMat.Channel, [], 'MEG'), ...
         good_channel(ChannelMat.Channel, [], 'MEG REF')]);
     ChannelMat = channel_apply_transf(ChannelMat, TransfMat, iMeg, false); % Don't apply to head points.
     ChannelMat = ChannelMat{1};
     
-    % After much thought, it was decided to save this adjustment transformation separately and at
-    % its logical place: between 'Dewar=>Native' and 'Native=>Brainstorm/CTF'.  In particular, this
-    % allows us to use it directly when displaying head motion distance. This however means we must
-    % correctly move the transformation from the end where it was just applied to its logical place.
-    % This "moved" transformation is also computed in LocationTransform above.
+    % After much thought, it was decided to save this
+    % adjustment transformation separately and at its logical
+    % place: between 'Dewar=>Native' and
+    % 'Native=>Brainstorm/CTF'.  In particular, this allows us
+    % to use it directly when displaying head motion distance.
+    % This however means we must correctly move the
+    % transformation from the end where it was just applied to
+    % its logical place. This "moved" transformation is also
+    % computed in LocationTransform above.
     if isempty(iAdjust)
         iAdjust = iDewToNat + 1;
-        % Shift transformations to make room for the new adjustment, and reject the last one, that
-        % we just applied.
+        % Shift transformations to make room for the new
+        % adjustment, and reject the last one, that we just
+        % applied.
         ChannelMat.TransfMegLabels(iDewToNat+2:end) = ...
             ChannelMat.TransfMegLabels(iDewToNat+1:end-1); % reject last one
         ChannelMat.TransfMeg(iDewToNat+2:end) = ChannelMat.TransfMeg(iDewToNat+1:end-1);
@@ -581,12 +601,14 @@ function [ChannelMat, Failed] = AdjustHeadPosition(ChannelMat, sInputs, sProcess
 end % AdjustHeadPosition
 
 
+
 function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
     % Compute initial head location in Dewar coordinates.
     
-    % Here we want to recreate the correct triangle shape from the relative head coil locations and
-    % in the position saved as the reference (initial) head position according to Brainstorm
-    % coordinate transformation matrices.
+    % Here we want to recreate the correct triangle shape from the relative
+    % head coil locations and in the position saved as the reference
+    % (initial) head position according to Brainstorm coordinate
+    % transformation matrices.
     
     if nargin < 2
         sInput = [];
@@ -594,24 +616,23 @@ function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
         sInput = sInput(1);
     end
     Message = '';
-
-    % From recent investigations, digitized locations are probably not as robust/accurate as those
-    % measured by the MEG. So use the .hc positions if available.
-    if ~isempty(sInput) && isfield(sInput, 'header') && isfield(sInput.header, 'hc') && isfield(sInput.header.hc, 'SCS') && ...
-            all(isfield(sInput.header.hc.SCS, {'NAS','LPA','RPA'})) && length(sInput.header.hc.SCS.NAS) == 3
-        % Initial head coil locations from the CTF .hc file, but in dewar coordinates, NOT in SCS coordinates!
-        InitLoc = [sInput.header.hc.SCS.NAS(:), sInput.header.hc.SCS.LPA(:), sInput.header.hc.SCS.RPA(:)]; % 3x3 by columns
-        InitLoc = InitLoc(:);
-        return;
-        % ChannelMat.SCS are not the coil positions in the .hc file, which are not saved in Brainstorm,
-        % but the digitized coil positions, if present. However, both are saved in "Native" coordinates
-        % and thus give the same transformation.
-    elseif isfield(ChannelMat, 'SCS') && all(isfield(ChannelMat.SCS, {'NAS','LPA','RPA'})) && ...
+    
+    % These aren't exactly the coil positions in the .hc file, which are not saved
+    % anywhere in Brainstorm, but was verified to give the same transformation.
+    % The SCS coil coordinates are from the digitized coil positions.
+    if isfield(ChannelMat, 'SCS') && all(isfield(ChannelMat.SCS, {'NAS','LPA','RPA'})) && ...
             (length(ChannelMat.SCS.NAS) == 3) && (length(ChannelMat.SCS.LPA) == 3) && (length(ChannelMat.SCS.RPA) == 3)
         %         % Use the SCS distances from origin, with left and right PA points symmetrical.
         %         LeftRightDist = sqrt(sum((ChannelMat.SCS.LPA - ChannelMat.SCS.RPA).^2));
         %         NasDist = ChannelMat.SCS.NAS(1);
         InitLoc = [ChannelMat.SCS.NAS(:), ChannelMat.SCS.LPA(:), ChannelMat.SCS.RPA(:); ones(1, 3)];
+    elseif ~isempty(sInput) && isfield(sInput, 'header') && isfield(sInput.header, 'hc') && isfield(sInput.header.hc, 'SCS') && ...
+            all(isfield(sInput.header.hc.SCS, {'NAS','LPA','RPA'})) && length(sInput.header.hc.SCS.NAS) == 3
+        % Initial head coil locations from the CTF .hc file, but in dewar coordinates, NOT in SCS coordinates!
+        InitLoc = [sInput.header.hc.SCS.NAS(:), sInput.header.hc.SCS.LPA(:), sInput.header.hc.SCS.RPA(:)]; % 3x3 by columns
+        InitLoc = InitLoc(:);
+        return;
+        %InitLoc = TransfAdjust * TransfBefore * [InitLoc; ones(1, 3)];
     else
         % Just use some reasonable distances, with a warning.
         Message = 'Exact reference head coil locations not available. Using reasonable (adult) locations according to head position.';
@@ -622,9 +643,11 @@ function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
     % InitLoc above is in Native coordiates (if pre head loc didn't fail).
     % Bring it back to Dewar coordinates to compare with HLU channels.
     %
-    % Take into account if the initial/reference head position was "adjusted", i.e. replaced by the
-    % median position throughout the recording.  If so, use all transformations from 'Dewar=>Native'
-    % to this adjustment transformation.  (In practice there shouldn't be any between them.)
+    % Take into account if the initial/reference head position was
+    % "adjusted", i.e. replaced by the median position throughout the
+    % recording.  If so, use all transformations from 'Dewar=>Native' to
+    % this adjustment transformation.  (In practice there shouldn't be any
+    % between them.)
     [TransfBefore, TransfAdjust] = GetTransforms(ChannelMat, sInput);
     InitLoc = TransfBefore \ (TransfAdjust \ InitLoc);
     InitLoc(4, :) = [];
@@ -632,22 +655,25 @@ function [InitLoc, Message] = ReferenceHeadLocation(ChannelMat, sInput)
 end % ReferenceHeadLocation
 
 
-function [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = GetTransforms(ChannelMat, sInputs)
-    % Extract transformations that are applied before and after the head position adjustment we are
-    % creating now.  We keep the 'Dewar=>Native' transformation intact and separate from the
-    % adjustment for no deep reason, but it is the only remaining trace of the initial head coil
+function [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = ...
+        GetTransforms(ChannelMat, sInputs)
+    % Extract transformations that are applied before and after the head
+    % position adjustment we are creating now.  We keep the 'Dewar=>Native'
+    % transformation intact and separate from the adjustment for no deep
+    % reason, but it is the only remaining trace of the initial head coil
     % positions in Brainstorm.
     
-    % The reason this function was split from LocationTransform is that it can be called only once
-    % outside the head sample loop in process_sss, whereas LocationTransform is called many times
-    % within the loop.
+    % The reason this function was split from LocationTransform is that it
+    % can be called only once outside the head sample loop in process_sss,
+    % whereas LocationTransform is called many times within the loop.
     
-    % When this is called from process_sss, we are possibly working on a second head adjustment,
-    % this time based on the instantaneous head position, so we need to keep the global adjustment
-    % based on the entire recording if it is there.
+    % When this is called from process_sss, we are possibly working on a
+    % second head adjustment, this time based on the instantaneous head
+    % position, so we need to keep the global adjustment based on the entire
+    % recording if it is there.
     
-    % Check order of transformations.  These situations should not happen unless there was some
-    % manual editing.
+    % Check order of transformations.  These situations should not happen
+    % unless there was some manual editing.
     iDewToNat = find(strcmpi(ChannelMat.TransfMegLabels, 'Dewar=>Native'));
     iAdjust = find(strcmpi(ChannelMat.TransfMegLabels, 'AdjustedNative'));
     TransfBefore = [];
@@ -698,9 +724,11 @@ function [TransfBefore, TransfAdjust, TransfAfter, iAdjust, iDewToNat] = GetTran
 end % GetTransforms
 
 
-function [TransfMat, TransfAdjust] = LocationTransform(Loc, TransfBefore, TransfAdjust, TransfAfter)
-    % Compute transformation corresponding to head coil positions. We want this to be as efficient
-    % as possible, since used many times by process_sss.
+function [TransfMat, TransfAdjust] = LocationTransform(Loc, ...
+        TransfBefore, TransfAdjust, TransfAfter)
+    % Compute transformation corresponding to head coil positions.
+    % We want this to be as efficient as possible, since used many times by
+    % process_sss.
     
     % Check for previous version.
     if nargin < 4
@@ -708,10 +736,10 @@ function [TransfMat, TransfAdjust] = LocationTransform(Loc, TransfBefore, Transf
     end
     
     % Transformation matrices are in m, as are HLU channels.
-    %
-    % The HLU channels (here Loc) are in dewar coordinates.  Bring them to the current system by
-    % applying all saved transformations, starting with 'Dewar=>Native'.  This will save us from
-    % having to use inverse transformations later.
+    % The HLU channels (here Loc) are in dewar coordinates.  Bring them to
+    % the current system by applying all saved transformations, starting with
+    % 'Dewar=>Native'.  This will save us from having to use inverse
+    % transformations later.
     Loc = TransfAfter(1:3, :) * TransfAdjust * TransfBefore * [reshape(Loc, 3, 3); 1, 1, 1];
     %   [[Loc(1:3), Loc(4:6), Loc(5:9)]; 1, 1, 1]; % test if efficiency difference.
     
@@ -731,12 +759,14 @@ function [TransfMat, TransfAdjust] = LocationTransform(Loc, TransfBefore, Transf
     TransfMat(1:3,1:3) = [X, Y, Z]';
     TransfMat(1:3,4) = - [X, Y, Z]' * Origin;
     
-    % TransfMat at this stage is a transformation from the current system back to the now adjusted
-    % Native system.  We thus need to reapply the following tranformations.
+    % TransfMat at this stage is a transformation from the current system
+    % back to the now adjusted Native system.  We thus need to reapply the
+    % following tranformations.
     
     if nargout > 1
-        % Transform from non-adjusted native coordinates to newly adjusted native coordinates.  To
-        % be saved in channel file between "Dewar=>Native" and "Native=>Brainstorm/CTF".
+        % Transform from non-adjusted native coordinates to newly adjusted native
+        % coordinates.  To be saved in channel file between "Dewar=>Native" and
+        % "Native=>Brainstorm/CTF".
         TransfAdjust = TransfMat * TransfAfter * TransfAdjust;
     end
     
@@ -766,19 +796,34 @@ function M = GeoMedian(X, Precision)
     %
     % M = GeoMedian(X, Precision)
     %
-    % Calculate the geometric median: the point that minimizes sum of Euclidean distances to all
-    % points.  size(X) = [n, d, ...], where n is the number of data points, d is the number of
-    % components for each point and any additional array dimension is treated as independent sets of
-    % data and a median is calculated for each element along those dimensions sequentially; size(M)
-    % = [1, d, ...].  This is an approximate iterative procedure that stops once the desired
-    % precision is achieved.  If Precision is not provided, 1e-4 of the max distance from the
-    % centroid is used.
+    % Calculate the geometric median: the point that minimizes sum of
+    % Euclidean distances to all points.  size(X) = [n, d, ...], where n is
+    % the number of data points, d is the number of components for each point
+    % and any additional array dimension is treated as independent sets of
+    % data and a median is calculated for each element along those dimensions
+    % sequentially; size(M) = [1, d, ...].  This is an approximate iterative
+    % procedure that stops once the desired precision is achieved.  If
+    % Precision is not provided, 1e-4 of the max distance from the centroid
+    % is used.
     %
-    % Weiszfeld's algorithm is used, which is a subgradient algorithm; with (Verdi & Zhang 2001)'s
-    % modification to avoid non-optimal fixed points (if at any iteration the approximation of M
-    % equals a data point).
+    % Weiszfeld's algorithm is used, which is a subgradient algorithm; with
+    % (Verdi & Zhang 2001)'s modification to avoid non-optimal fixed points
+    % (if at any iteration the approximation of M equals a data point).
     %
-    % Marc Lalancette 2012-05
+    %
+    % (c) Copyright 2018 Marc Lalancette
+    % The Hospital for Sick Children, Toronto, Canada
+    %
+    % This file is part of a free repository of Matlab tools for MEG
+    % data processing and analysis <https://gitlab.com/moo.marc/MMM>.
+    % You can redistribute it and/or modify it under the terms of the GNU
+    % General Public License as published by the Free Software Foundation,
+    % either version 3 of the License, or (at your option) a later version.
+    %
+    % This program is distributed WITHOUT ANY WARRANTY.
+    % See the LICENSE file, or <http://www.gnu.org/licenses/> for details.
+    %
+    % 2012-05
     
     nDims = ndims(X);
     XSize = size(X);
@@ -805,15 +850,17 @@ function M = GeoMedian(X, Precision)
         Precision = bsxfun(@rdivide, Precision, Scale); % Precision ./ Scale; % [1, 1, nSets]
     end
     
-    % Initial estimate: median in each dimension separately.  Though this gives a chance of picking
-    % one of the data points, which requires special treatment.
+    % Initial estimate: median in each dimension separately.  Though this
+    % gives a chance of picking one of the data points, which requires
+    % special treatment.
     M2 = median(X, 1);
     
-    % It might be better to calculate separately each independent set, otherwise, they are all
-    % iterated until the worst case converges.
+    % It might be better to calculate separately each independent set,
+    % otherwise, they are all iterated until the worst case converges.
     for s = 1:nSets
         
-        % For convenience, pick another point far enough so the loop will always start.
+        % For convenience, pick another point far enough so the loop will always
+        % start.
         M = bsxfun(@plus, M2(:, :, s), Precision(:, :, s));
         % Iterate.
         while  sum((M - M2(:, :, s)).^2 , 2) > Precision(s)^2  % any()scalar
@@ -821,7 +868,8 @@ function M = GeoMedian(X, Precision)
             % Distances from M.
             %       R = sqrt(sum( (M(ones(n, 1), :) - X(:, :, s)).^2 , 2 )); % [n, 1]
             R = sqrt(sum( bsxfun(@minus, M, X(:, :, s)).^2 , 2 )); % [n, 1]
-            % Find data points not equal to M, that we use in the computation below.
+            % Find data points not equal to M, that we use in the computation
+            % below.
             Good = logical(R);
             nG = sum(Good);
             if nG % > 0
@@ -835,10 +883,10 @@ function M = GeoMedian(X, Precision)
             end
             
             % New estimate.
-            %
-            % Note the possibility of D = 0 and (n - nG) = 0, in which case 0/0 should be 0, but
-            % here gives NaN, which the max function ignores, returning 0 instead of 1. This is fine
-            % however since this multiplies D (=0 in that case).
+            % Note the possibility of D = 0 and (n - nG) = 0, in which case 0/0
+            % should be 0, but here gives NaN, which the max function ignores,
+            % returning 0 instead of 1. This is fine however since this
+            % multiplies D (=0 in that case).
             M2(:, :, s) = M - max(0, 1 - (n - nG)/sqrt(sum( D.^2 , 2 ))) * ...
                 D / sum(1 ./ R, 1);
         end
@@ -853,81 +901,5 @@ function M = GeoMedian(X, Precision)
     end
     
 end % GeoMedian
-
-
-function CheckPrevAdjustments(ChannelMat, sMri)
-    % Flag if auto or manual registration performed, and if MRI fids updated. Print to command
-    % window for now.
-    if any(~isfield(ChannelMat, {'History', 'HeadPoints'}))
-        % Nothing to check.
-        return;
-    end
-    if nargin < 2 || isempty(sMri) || ~isfield(sMri, 'History')
-        iMriHist = [];
-    else
-        iMriHist = find(strcmpi(sMri.History(:,3), 'Applied digitized anatomical fiducials'), 1, 'last');
-    end
-    % Can also be reset, so check for 'import' action and ignore previous alignments.
-    iImport = find(strcmpi(ChannelMat.History(:,2), 'import'), 1, 'last');
-    iAlign = find(strcmpi(ChannelMat.History(:,2), 'align'));
-    iAlign(iAlign < iImport) = [];
-    AlignType = 'none';
-    while ~isempty(iAlign)
-        % Check which adjustment was done last.
-        switch lower(ChannelMat.History{iAlign(end),3}(1:5))
-            case 'remov'
-                % Removed a previous step. Ignore corresponding adjustment and look again.
-                iAlign(end) = [];
-                if contains(ChannelMat.History{iAlign(end),3}, 'AdjustedNative')
-                    iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
-                elseif contains(ChannelMat.History{iAlign(end),3}, 'refine registration: head points')
-                    iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
-                elseif contains(ChannelMat.History{iAlign(end),3}, 'manual correction')
-                    iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
-                else
-                    bst_error('Unrecognized removed transformation in history.');
-                end
-                if isempty(iAlignRemoved)
-                    bst_error('Missing removed transformation in history.');
-                else
-                    iAlign(iAlignRemoved) = [];
-                end
-            case 'added'
-                % This alignment is between points and functional dataset, ignore here.
-                iAlign(end) = [];
-            case 'refin'
-                % Automatic MRI-points alignment
-                AlignType = 'auto';
-                break;
-            case 'align'
-                % Manual MRI-points alignment
-                AlignType = 'manual';
-                break;
-        end
-    end
-    disp(['BST> Previous registration adjustment: ' AlignType]);
-    if ~isempty(iMriHist)
-        % Compare digitized fids to MRI fids (in MRI coordinates, mm). ChannelMat.SCS fids are NOT
-        % kept up to date when adjusting registration (manual or auto), so get them from head points
-        % again.
-        % Get the three fiducials in the head points
-        iNas = find(strcmpi(ChannelMat.HeadPoints.Label, 'Nasion') | strcmpi(ChannelMat.HeadPoints.Label, 'NAS'));
-        iLpa = find(strcmpi(ChannelMat.HeadPoints.Label, 'Left')   | strcmpi(ChannelMat.HeadPoints.Label, 'LPA'));
-        iRpa = find(strcmpi(ChannelMat.HeadPoints.Label, 'Right')  | strcmpi(ChannelMat.HeadPoints.Label, 'RPA'));
-        if ~isempty(iNas) && ~isempty(iLpa) && ~isempty(iRpa)
-            ChannelMat.SCS.NAS = mean(ChannelMat.HeadPoints.Loc(:,iNas)', 1);
-            ChannelMat.SCS.LPA = mean(ChannelMat.HeadPoints.Loc(:,iLpa)', 1);
-            ChannelMat.SCS.RPA = mean(ChannelMat.HeadPoints.Loc(:,iRpa)', 1);
-        end
-        if any(abs(sMri.SCS.NAS - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.NAS) .* 1000) > 1e-3) || ...
-                any(abs(sMri.SCS.LPA - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.LPA) .* 1000) > 1e-3) || ...
-                any(abs(sMri.SCS.RPA - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.RPA) .* 1000) > 1e-3)
-            disp('BST> MRI fiducials previously updated, but different than current digitized fiducials.');
-        else
-            disp('BST> MRI fiducials previously updated, and match current digitized fiducials.');
-        end
-    end
-
-end
 
 

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -405,8 +405,6 @@ if isProgress
     bst_progress('stop');
 end
 
-% Check and print to command window if previously auto/manual registration, and if MRI fids updated.
-process_adjust_coordinates('CheckPrevAdjustments', in_bst_channel(ChannelFile), sMri);
 end
 
 %% ===== MOUSE CALLBACKS =====  

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -231,7 +231,7 @@ end
     
 % ===== DISPLAY MRI FIDUCIALS =====
 % Get the fiducials positions defined in the MRI volume
-sMri = load(file_fullpath(sSubject.Anatomy(sSubject.iAnatomy).FileName), 'SCS', 'History');
+sMri = load(file_fullpath(sSubject.Anatomy(sSubject.iAnatomy).FileName), 'SCS');
 if ~isempty(sMri.SCS.NAS) && ~isempty(sMri.SCS.LPA) && ~isempty(sMri.SCS.RPA)
     % Convert coordinates MRI => SCS
     MriFidLoc = [cs_convert(sMri, 'mri', 'scs', sMri.SCS.NAS ./ 1000); ...

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -28,7 +28,8 @@ function hFig = channel_align_manual( ChannelFile, Modality, isEdit, SurfaceType
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Francois Tadel, 2008-2020
+% Authors: Francois Tadel, 2008-2022
+%          Marc Lalancette, 2022
 
 global GlobalData;
 

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -914,7 +914,6 @@ function AlignClose_Callback(varargin)
         else
             SaveChanged = java_dialog('confirm', ['The sensors locations changed.' 10 10 ...
                     'Would you like to save changes? ' 10 10], 'Align sensors');
-            end
         end
         % Don't close figure if cancelled.
         if isCancel

--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -231,7 +231,7 @@ end
     
 % ===== DISPLAY MRI FIDUCIALS =====
 % Get the fiducials positions defined in the MRI volume
-sMri = load(file_fullpath(sSubject.Anatomy(sSubject.iAnatomy).FileName), 'SCS');
+sMri = load(file_fullpath(sSubject.Anatomy(sSubject.iAnatomy).FileName), 'SCS', 'History');
 if ~isempty(sMri.SCS.NAS) && ~isempty(sMri.SCS.LPA) && ~isempty(sMri.SCS.RPA)
     % Convert coordinates MRI => SCS
     MriFidLoc = [cs_convert(sMri, 'mri', 'scs', sMri.SCS.NAS ./ 1000); ...
@@ -364,7 +364,7 @@ elseif gChanAlign.isNirs
     gChanAlign.hButtonRefine   = uipushtool(hToolbar, 'CData', java_geticon('ICON_ALIGN_CHANNELS'), 'TooltipString', 'Refine registration using head points', 'ClickedCallback', @RefineWithHeadPoints, 'separator', 'on');
     gChanAlign.hButtonMoveChan = [];
     gChanAlign.hButtonProject = [];
-else
+else % isEeg
     gChanAlign.hButtonResizeX  = uitoggletool(hToolbar, 'CData', java_geticon('ICON_RESIZE_X'),      'TooltipString', 'Resize/X: Press right button and move mouse up/down',      'ClickedCallback', @SelectOperation, 'separator', 'on');
     gChanAlign.hButtonResizeY  = uitoggletool(hToolbar, 'CData', java_geticon('ICON_RESIZE_Y'),      'TooltipString', 'Resize/Y: Press right button and move mouse up/down',      'ClickedCallback', @SelectOperation);
     gChanAlign.hButtonResizeZ  = uitoggletool(hToolbar, 'CData', java_geticon('ICON_RESIZE_Z'),      'TooltipString', 'Resize/Z: Press right button and move mouse up/down',      'ClickedCallback', @SelectOperation);
@@ -392,7 +392,8 @@ end
 % else
     gChanAlign.hButtonAlign = [];
 % end
-gChanAlign.hButtonOk = uipushtool(  hToolbar, 'CData', java_geticon( 'ICON_OK'), 'separator', 'on', 'ClickedCallback', @buttonOk_Callback);% Update figure localization
+gChanAlign.hButtonReset = uipushtool( hToolbar, 'CData', java_geticon('ICON_RELOAD'), 'separator', 'on', 'TooltipString', 'Reset: discard all changes', 'ClickedCallback', @buttonReset_Callback);
+gChanAlign.hButtonOk = uipushtool( hToolbar, 'CData', java_geticon('ICON_OK'), 'TooltipString', 'Save & close', 'ClickedCallback', @buttonOk_Callback);% Update figure localization
 gui_layout('Update');
 % Move a bit the figure to refresh it on all systems
 pos = get(gChanAlign.hFig, 'Position');
@@ -404,6 +405,60 @@ if isProgress
     bst_progress('stop');
 end
     
+% Flag if auto or manual registration performed, and if MRI fids updated. Print to command
+% window for now.
+ChannelMat = in_bst_channel(ChannelFile);
+iMriHist = find(strcmpi(sMri.History(:,3), 'Applied digitized anatomical fiducials'), 1, 'last');
+% Can also be reset, so check for 'import' action and ignore previous alignments.
+iImport = find(strcmpi(ChannelMat.History(:,2), 'import'), 1, 'last');
+iAlign = find(strcmpi(ChannelMat.History(:,2), 'align'));
+iAlign(iAlign < iImport) = [];
+AlignType = 'none';
+while ~isempty(iAlign)
+    % Check which adjustment was done last.
+    switch lower(ChannelMat.History{iAlign(end),3}(1:5))
+        case 'remov'
+            % Removed a previous step. Ignore corresponding adjustment and look again.
+            iAlign(end) = [];
+            if contains(ChannelMat.History{iAlign(end),3}, 'AdjustedNative')
+                iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
+            elseif contains(ChannelMat.History{iAlign(end),3}, 'refine registration: head points')
+                iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
+            elseif contains(ChannelMat.History{iAlign(end),3}, 'manual correction')
+                iAlignRemoved = find(contains(ChannelMat.History(iAlign,3), 'AdjustedNative'), 1, 'last');
+            else
+                bst_error('Unrecognized removed transformation in history.');
+            end
+            if isempty(iAlignRemoved)
+                bst_error('Missing removed transformation in history.');
+            else
+                iAlign(iAlignRemoved) = [];
+            end
+        case 'added'
+            % This alignment is between points and functional dataset, ignore here.
+            iAlign(end) = [];
+        case 'refin'
+            % Automatic MRI-points alignment
+            AlignType = 'auto';
+            break;
+        case 'align'
+            % Manual MRI-points alignment
+            AlignType = 'manual';
+            break;
+    end
+end
+disp(['BST> Previous registration adjustment: ' AlignType]);
+if ~isempty(iMriHist)
+    % Compare digitized fids to MRI fids (in MRI coordinates, mm).
+    if any(abs(sMri.SCS.NAS - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.NAS) .* 1000) > 1e-3) || ...
+            any(abs(sMri.SCS.LPA - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.LPA) .* 1000) > 1e-3) || ...
+            any(abs(sMri.SCS.RPA - cs_convert(sMri, 'scs', 'mri', ChannelMat.SCS.RPA) .* 1000) > 1e-3)
+        disp('BST> MRI fiducials updated, but different than digitized fiducials.');
+    else
+        disp('BST> MRI fiducials updated, and match digitized fiducials.');
+    end
+end
+
 end
 
 
@@ -646,15 +701,10 @@ function UpdatePoints(iSelChan)
             Dist = bst_surfdist(gChanAlign.HeadPointsMarkersLoc, ...
                 get(gChanAlign.hSurfacePatch, 'Vertices'), get(gChanAlign.hSurfacePatch, 'Faces'));
             set(gChanAlign.hHeadPointsMarkers, 'CData', Dist * 1000);
-            % Update axes maximum
-            setappdata(gChanAlign.hFig, 'HeadpointsDistMax', max(Dist));
-            figure_3d('UpdateHeadPointsColormap', gChanAlign.hFig);
-            % Update colorbar scale
-            ColormapInfo = getappdata(gChanAlign.hFig, 'Colormap');
-            ColormapType = 'stat1';
-            if strcmpi(ColormapInfo.Type, ColormapType)
-                bst_colormaps('ConfigureColorbar', gChanAlign.hFig, ColormapType, 'stat', 'mm');
-            end
+            % Update surface data and colorbar
+            TessInfo = getappdata(gChanAlign.hFig, 'Surface');
+            iTessPoints = find(strcmpi({TessInfo.Name}, 'HeadPoints'));
+            panel_surface('UpdateSurfaceData', gChanAlign.hFig, iTessPoints); 
         end
         % Fiducials
         if ~isempty(gChanAlign.hHeadPointsFid)
@@ -857,17 +907,23 @@ end
 function AlignClose_Callback(varargin)
     global gChanAlign;
     if gChanAlign.isChanged
+        isCancel = false;
         % Ask user to save changes (only if called as a callback)
         if (nargin == 3)
             SaveChanged = 1;
         else
             SaveChanged = java_dialog('confirm', ['The sensors locations changed.' 10 10 ...
-                                           'Would you like to save changes? ' 10 10], 'Align sensors');
+                    'Would you like to save changes? ' 10 10], 'Align sensors');
+            end
         end
-        % Progress bar
-        bst_progress('start', 'Align sensors', 'Updating channel file...');
-        % Save changes and close figure
+        % Don't close figure if cancelled.
+        if isCancel
+            return;
+        end
+        % Save changes to channel file and close figure
         if SaveChanged
+            % Progress bar
+            bst_progress('start', 'Align sensors', 'Updating channel file...');
             % Restore standard close callback for 3DViz figures
             set(gChanAlign.hFig, 'CloseRequestFcn', gChanAlign.Figure3DCloseRequest_Bak);
             drawnow;
@@ -881,14 +937,14 @@ function AlignClose_Callback(varargin)
             [sStudy, iStudy] = bst_get('ChannelFile', gChanAlign.ChannelFile);
             % Reload study file
             db_reload_studies(iStudy);
+            bst_progress('stop');
         end
-        bst_progress('stop');
     else
         SaveChanged = 0;
     end
     % Only close figure
     gChanAlign.Figure3DCloseRequest_Bak(varargin{1:2});
-    % Apply to other recordings in the same subject
+    % Apply to other recordings with same sensor locations in the same subject
     if SaveChanged
         CopyToOtherFolders(ChannelMatOrig, iStudy, Transf, iChannels);
     end
@@ -933,7 +989,7 @@ function CopyToOtherFolders(ChannelMatSrc, iStudySrc, Transf, iChannels)
         end
         % Check if the positions of the sensors are similar
         distLoc = sqrt((locDest(1,:) - locSrc(1,:)).^2 + (locDest(2,:) - locSrc(2,:)).^2 + (locDest(3,:) - locSrc(3,:)).^2);
-        % If the sensors are more than 5mm apart in average: skip
+        % If any sensors are more than 5mm apart: skip
         if any(distLoc > 0.005) 
             continue;
         end
@@ -1156,13 +1212,21 @@ function RefineWithHeadPoints(varargin)
 end
 
 
-%% ===== VALIDATION BUTTONS =====
+%% ===== VALIDATION BUTTON =====
 function buttonOk_Callback(varargin)
     global gChanAlign;
     % Close 3DViz figure
     close(gChanAlign.hFig);
 end
 
+%% ===== RESET BUTTON =====
+function buttonReset_Callback(varargin)
+    global gChanAlign;
+    % Close figure
+    gChanAlign.Figure3DCloseRequest_Bak(gChanAlign.hFig, []);
+    % Call function again, which resets gChanAlign.
+    channel_align_manual(gChanAlign.ChannelFile, gChanAlign.Modality, 1);
+end
 
 %% ===== REMOVE ELECTRODES =====
 function RemoveElectrodes(varargin)

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -225,7 +225,7 @@ switch (lower(action))
                     elseif strcmpi(DisplayMod{1}, 'ECOG')
                         DisplayChannels(bstNodes, DisplayMod{1}, 'cortex', 1);
                     elseif ismember(DisplayMod{1}, {'MEG','MEG GRAD','MEG MAG'})
-                        channel_align_manual(filenameRelative, DisplayMod{1}, 0)
+                        channel_align_manual(filenameRelative, DisplayMod{1}, 0);
                     elseif strcmpi(DisplayMod{1}, 'NIRS')
                         DisplayChannels(bstNodes, 'NIRS-BRS', 'scalp', [], 1);
                     else


### PR DESCRIPTION
Edit: this was removed from this PR: {_As discussed in https://github.com/brainstorm-tools/brainstorm3/pull/567, this is an alternate fix to https://github.com/brainstorm-tools/brainstorm3/commit/422078ae45b6a2bf08352797218a812d55fc5f0b for head point coloring / colorbar behavior, where points are now registered as a figure surface._}

Remaining changes:

1. Minor fix to colormaps/SetMaxCustom: would crash if more than one surface. Fix copied from elsewhere in the code.
2. A "reset" button is added to the figure, to reset the registration.
3. Some checks are made on previous registration steps (manual/auto) and printed to the command window. This was added as a "passive" function (nothing saved, no output) in process_adjust_coordinates.

(Please ignore other changes in process_adjust_coordinates, mainly comment reformatting.)
