### PR TITLE
Bugfix: Correct sfreq when reading EDF files

### DIFF
--- a/toolbox/io/in_fread_edf.m
+++ b/toolbox/io/in_fread_edf.m
@@ -35,11 +35,6 @@ iChanSkip      = union(iChanAnnot, iChanWrongRate);
 if (nargin < 4) || isempty(ChannelsRange)
     ChannelsRange = [1, nChannels];
 end
-if (nargin < 3) || isempty(SamplesBounds)
-    SamplesBounds = [0, sFile.header.nrec * sFile.header.signal(ChannelsRange(1)).nsamples - 1];
-end
-nTimes = round(sFile.header.reclen * sFile.header.signal(ChannelsRange(1)).sfreq);
-iTimes = SamplesBounds(1):SamplesBounds(2);
 % Block of times/channels to extract
 nReadChannels = double(ChannelsRange(2) - ChannelsRange(1) + 1);
 % Read annotations instead of real data ?
@@ -73,6 +68,18 @@ if (ChannelsRange(1) ~= ChannelsRange(2))
     end
 end
 
+if (nargin < 3) || isempty(SamplesBounds)
+    SamplesBounds = [0, sFile.header.nrec * sFile.header.signal(ChannelsRange(1)).nsamples - 1];
+end
+% Convert SamplesBounds to the correct sampling frequency
+if sFile.header.signal(ChannelsRange(1)).sfreq ~= sFile.prop.sfreq
+    SamplesBounds(2) = SamplesBounds(2) + 1;
+    TimesBounds = SamplesBounds ./ sFile.prop.sfreq;
+    SamplesBounds = round(TimesBounds * sFile.header.signal(ChannelsRange(1)).sfreq);
+    SamplesBounds(2) = SamplesBounds(2) - 1;
+end
+nTimes = round(sFile.header.reclen * sFile.header.signal(ChannelsRange(1)).sfreq);
+iTimes = SamplesBounds(1):SamplesBounds(2);
 
 %% ===== READ ALL NEEDED EPOCHS =====
 % Detect which epochs are necessary for the range of data selected


### PR DESCRIPTION
Bugfix for reading EDF files with multiple sampling frequencies.

* Variable `nTimes` is computed with the sampling frequency of the first good channel

* Also, variable `iTimes` is adjusted accordingly to the sampling frequency of the channel to be displayed. This would be useful for the cases when a signal different of EEG needs to be displayed.

See further discussion and example in: 
https://neuroimage.usc.edu/forums/t/37956