### PR TITLE
Add Modality validation

### DIFF
--- a/toolbox/gui/view_mri.m
+++ b/toolbox/gui/view_mri.m
@@ -92,7 +92,15 @@ switch lower(FileType)
         % Get modality
         iResChan = GlobalData.DataSet(iDS).Results(iDSResult).GoodChannel;
         if ~isempty(iResChan)
-            Modality = GlobalData.DataSet(iDS).Channel().Type;
+            AllModalities = unique({GlobalData.DataSet(iDS).Channel(iResChan).Type});
+            % Replace MEG GRAD+MEG MAG with "MEG"
+            if all(ismember({'MEG GRAD', 'MEG MAG'}, AllModalities))
+                AllModalities{end+1} = 'MEG';
+                AllModalities = setdiff(AllModalities, {'MEG GRAD', 'MEG MAG'});
+            end
+            if ~isempty(AllModalities)
+                Modality = AllModalities{1};
+            end
         end
         % Get subject file
         SubjectFile = GlobalData.DataSet(iDS).SubjectFile;


### PR DESCRIPTION
Add validation for Modality in `view_mri`.
The replaced code on Modality was introduced in 2d451cbd74f7efa13f5b542e10167de6ed24050a, and produced this warning in the Command Window:

![image](https://user-images.githubusercontent.com/8238803/211397354-4344ed45-b895-420e-a1cb-0fd82990bb16.png)

