### PR TITLE
Feature: sort ICs (from ICA) by variance is not reference channel

### DIFF
--- a/toolbox/process/functions/process_ssp2.m
+++ b/toolbox/process/functions/process_ssp2.m
@@ -772,7 +772,11 @@ function OutputFiles = Run(sProcess, sInputsA, sInputsB)
             [corrs, iSort] = sort(max(abs(C),[],1), 'descend');
         else
             % By explained variance
-            M = inv(W);
+            if diff(size(W)) == 0
+                M = inv(W);
+            else
+                M = pinv(W);
+            end
             var = sum(M.^2, 1) .* sum(Y.^2, 2)';
             [var, iSort] = sort(var, 'descend');
         end

--- a/toolbox/process/functions/process_ssp2.m
+++ b/toolbox/process/functions/process_ssp2.m
@@ -603,6 +603,7 @@ function OutputFiles = Run(sProcess, sInputsA, sInputsB)
     end
             
     % ===== COMPUTE PROJECTORS =====
+    Y = [];
     bst_progress('text', 'Computing projector...');
     switch (Method)
         
@@ -742,7 +743,6 @@ function OutputFiles = Run(sProcess, sInputsA, sInputsB)
             else
                 [M,W] = fastica(F);
             end
-            Y = W * F;
 
         otherwise
             bst_report('Error', sProcess, sInputsA, ['Invalid method: "' Method '".']);
@@ -764,15 +764,17 @@ function OutputFiles = Run(sProcess, sInputsA, sInputsB)
         if ~isempty(SelectComp)
             proj.CompMask(SelectComp) = 1;
         end
+        % Compute IC
+        if isempty(Y)
+            Y = W * F;
+        end
         % Sort ICA components
         if ~isempty(icaSort)
-            Y = W * F;
             % By correlation with reference channel
             C = bst_corrn(Fref, Y);
             [corrs, iSort] = sort(max(abs(C),[],1), 'descend');
             proj.Components = proj.Components(:,iSort);
         elseif ismember(Method, {'ICA_picard', 'ICA_fastica'})
-            Y = W * F;
             % By explained variance
             if diff(size(W)) == 0
                 M = inv(W);
@@ -1073,4 +1075,3 @@ function proj = ConvertOldFormat(OldProj)
         proj = OldProj;
     end
 end
-

--- a/toolbox/process/functions/process_ssp2.m
+++ b/toolbox/process/functions/process_ssp2.m
@@ -708,7 +708,7 @@ function OutputFiles = Run(sProcess, sInputsA, sInputsB)
                 bst_report('Error', sProcess, sInputsA, 'Function "runica" did not return any results.');
                 return;
             end
-            % Reconstruct mixing matrix
+            % Reconstruct unmixing matrix
             W = icaweights * icasphere;
             
         % === ICA: PICARD ===


### PR DESCRIPTION
Sort ICs (from ICA) by variance is not reference channel.
Previous behaviour: If reference channel string is empty, ICs are not sorted.

IC selection in tutorials: tutorial_epilepsy and tutorial_yokogawa is not affected