### PR TITLE
Allow contralateral projection of volume scouts

### DIFF
--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -1155,8 +1155,9 @@ function iScouts = SetScouts(SurfaceFile, iScouts, sScouts)
     end
     % Save the previous scouts configuration
     sScoutsOld = GlobalData.Surface(iSurf).Atlas(sSurf.iAtlas).Scouts;
-    % Detect region if not defined yet (only for new scouts)
-    if isAdd
+    isVolumeAtlas = ParseVolumeAtlas(GlobalData.Surface(iSurf).Atlas(sSurf.iAtlas).Name);
+    % Detect region if not defined yet (only for new surface scouts)
+    if isAdd && ~isVolumeAtlas
         for i = 1:length(sScouts)
             if ~isempty(sScouts(i).Seed) && (isempty(sScouts(i).Region) || strcmpi(sScouts(i).Region, 'UU'))
                 sScouts(i) = SetRegionAuto(sSurf, sScouts(i));
@@ -4050,6 +4051,19 @@ function ProjectScoutsContralateral(srcSurfFile)
         sMri = panel_surface('GetSurfaceMri', hFig);
         % Get figure GridLoc
         GridLoc = GetFigureGrid(hFig);
+        % Warning when using linear MNI registration
+        if ~isfield(sMri, 'NCS') || ~isfield(sMri.NCS, 'y') || isempty(sMri.NCS.y)
+            % Error when no MNI registration at all
+            if ~isfield(sMri, 'NCS') || ~isfield(sMri.NCS, 'R') || isempty(sMri.NCS.R)
+                bst_error('Compute MNI registration first.', 'Project volume scouts', 0);
+                return;
+            else
+                isConfirm = java_dialog('confirm', ['To project volume scouts, it is advised to compute a nonlinear MNI normalization first.' 10 10 'Proceed with linear MNI registration anyway?' 10 10], 'Project volume scouts');
+                if ~isConfirm
+                    return;
+                end
+            end
+        end
     else
         sMri = [];
         GridLoc = [];

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -4038,6 +4038,22 @@ function ProjectScoutsContralateral(srcSurfFile)
 
     % Get current atlas
     [sAtlas, iAtlas, sSurf] = GetAtlas();
+    isVolumeAtlas = ParseVolumeAtlas(sAtlas.Name);
+    % Volume atlas: Get anatomy surface and grid of points
+    if isVolumeAtlas
+        % Get current figure
+        hFig = bst_figures('GetCurrentFigure', '3D');
+        if isempty(hFig) || ~ishandle(hFig)
+            return
+        end
+        % Get figure Anatomy surface
+        sMri = panel_surface('GetSurfaceMri', hFig);
+        % Get figure GridLoc
+        GridLoc = GetFigureGrid(hFig);
+    else
+        sMri = [];
+        GridLoc = [];
+    end
     % Get selected scouts
     sScouts = GetSelectedScouts();
     if isempty(sAtlas) || isempty(sScouts)
@@ -4049,13 +4065,11 @@ function ProjectScoutsContralateral(srcSurfFile)
     % Progress bar
     bst_progress('start', 'Project scouts', 'Computing interpolation...');
     % Call function to project scouts
-    sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas);
+    sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas, sMri, GridLoc);
     if isempty(sAtlas.Scouts)
         return;
     end
     
-    % Set default seeds
-    sAtlas.Scouts = SetScoutsSeed(sAtlas.Scouts, sSurf.Vertices);
     % Set handles structure
     sTemplate = db_template('scout');
     [sAtlas.Scouts.Handles] = deal(sTemplate.Handles);

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -229,11 +229,13 @@ else
                 % Find the compact boundary that envelops all the projected points
                 faces = boundary(GridLoc(vi,:), 1);
                 % Find grid points inside polyhedron
-                vi = find(inpolyhedron(struct('faces', faces, 'vertices', GridLoc(vi,:)), GridLoc));
-                if isempty(vi)
+                vi_in = find(inpolyhd(GridLoc, GridLoc(vi,:), faces));
+                if isempty(vi_in)
                     % Find the vertex that is closer to the center of the projected points
-                    [tmp, vi] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, mean(GridLoc(vi,:), 1)) .^ 2, 2)));
+                    [tmp, vi_in] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, mean(GridLoc(vi,:), 1)) .^ 2, 2)));
                 end
+                % Include surface points
+                vi = union(vi, vi_in);
             end
             vi = vi(:)'; % Force to be column vector
             % Save in input structure

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -1,9 +1,10 @@
-function sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas)
-% BST_PROJECT_SCOUTS_CONTRA: Project scouts from left to right hemisphere and viceversa
+function sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas, sMri, GridLoc)
+% BST_PROJECT_SCOUTS_CONTRA: Project surface and volume scouts from left to right hemisphere and viceversa
 %
-% USAGE:  sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas)
+% USAGE:  sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas)                 % Surface scouts
+%         sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas, sMri, GridLoc)  % Volume scouts
 %
-% REFERENCE:
+% PROJECT SURFACE SCOUTS REFERENCE:
 %    - Requires the FreeSurfer registered contralateral spheres: Option -contrasurfreg in FreeSurfer 6.X
 %      See tutorial: https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer#Contralateral_registration
 %    - Use the contralateral spheres if available at the subject level: sSurf.Reg.SphereLR.Vertices
@@ -11,7 +12,13 @@ function sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas)
 %      1) project scouts on anatomy template (high-resolution cortex surface)
 %      2) project left-right in the template anatomy
 %      3) project back to the subject surface
-
+%
+% PROJECT VOLUME SCOUTS REFERENCE:
+%    - Contralateral projection is based on MNI-coordinates
+%    - If the original scout has less than 4 vertices, the projected scout consists in the set of projected vertices
+%    - Else, the boundary of the original scout vertices is projected and used find the projected scout
+%
+%
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
@@ -32,157 +39,243 @@ function sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas)
 %
 % Authors: Edouard Delaire, 2022
 %          Francois Tadel, 2022-2023
+%          Raymundo Cassani, 2023
+
+isVolume = 0;
+% Check for volume defined Atlas
+if nargin > 3 && ~isempty(sMri) && ~isempty(GridLoc)
+    isVolume = 1;
+end
 
 % Load surface
 sSurf = in_tess_bst(srcSurfFile);
-% Number of nearest neighbors in interpolation between spheres
-nbNeighbors = 8;
-% Signature string for the current transformation
-Signature_LR = sprintf('%s%d_LR', srcSurfFile, length(sSurf.Vertices));
 
-
-% ===== COMPUTE INTERPOLATION =====
-% Try to get an existing valid interpolation matrix
-if isfield(sSurf, 'tess2tess_interp') && all(isfield(sSurf.tess2tess_interp, {'Signature_LR', 'Wmat_LR', 'Wmat_RL'})) && ...
-        strcmpi(sSurf.tess2tess_interp.Signature_LR, Signature_LR) && ~isempty(sSurf.tess2tess_interp.Wmat_LR)
-    % Identify left and right hemispheres
-    [rH, lH]  = tess_hemisplit(sSurf);
-    % Reuse saved interpolations
-    Wmat_RL = sSurf.tess2tess_interp.Wmat_RL;
-    Wmat_LR = sSurf.tess2tess_interp.Wmat_LR;
-    defSurfFile = [];
-    
-% Identify left and right hemispheres
-[rH, lH]  = tess_hemisplit(sSurf);
-% Check for contralateral surfaces in subject
-elseif isfield(sSurf, 'Reg') && isfield(sSurf.Reg, 'SphereLR') && isfield(sSurf.Reg.SphereLR, 'Vertices') && (size(sSurf.Reg.SphereLR.Vertices, 1) == size(sSurf.Vertices, 1))
-    % Identify left and right hemispheres
-    [rH, lH]  = tess_hemisplit(sSurf);
-    % Pre-compute WMAT directly between left and right
-    Wmat_RL = bst_shepards(sSurf.Reg.Sphere.Vertices(lH, : ), sSurf.Reg.SphereLR.Vertices(rH, : ),  nbNeighbors, 0);
-    Wmat_LR = bst_shepards(sSurf.Reg.Sphere.Vertices(rH, : ), sSurf.Reg.SphereLR.Vertices(lH, : ),  nbNeighbors, 0);
-    % Save interpolation matrices
-    sSurf.tess2tess_interp.Wmat_LR      = Wmat_LR;
-    sSurf.tess2tess_interp.Wmat_RL      = Wmat_RL;
-    sSurf.tess2tess_interp.Signature_LR = Signature_LR;
-    bst_save(file_fullpath(srcSurfFile), sSurf, 'v7');
-    defSurfFile = [];
-
-% Check for contralateral surfaces in template: 
-% If available, 1) project scouts on template, 2) project left-right, 3) project back to subject
-else
-    % Get default anatomy from the protocol
-    sSubjectDef = bst_get('Subject', 0);
-    % If input is the low-resolution cortex
-    if ~isempty(strfind(srcSurfFile, '_low'))
-        defCortexFile = 'tess_cortex_pial_low.mat';
-    else
-        defCortexFile = 'tess_cortex_pial_high.mat';
-    end
-    % Get high-resolution cortex surface
-    iCortexDef = find(~cellfun(@(c)isempty(strfind(c, defCortexFile)), {sSubjectDef.Surface.FileName}));
-    if isempty(iCortexDef)
-        error(['No registered contralateral spheres available for this cortex surface.' 10 ...
-            'No cortex surface available in default anatomy: ' defCortexFile]);
-    end
-    defSurfFile = sSubjectDef.Surface(iCortexDef(1)).FileName;
-
-    % Load cortex surface
-    sSurfDef = in_tess_bst(defSurfFile);
-    % Check for contralateral surfaces in subject
-    if ~isfield(sSurfDef, 'Reg') || ~isfield(sSurfDef.Reg, 'SphereLR') || ~isfield(sSurfDef.Reg.SphereLR, 'Vertices') || (size(sSurfDef.Reg.SphereLR.Vertices, 1) ~= size(sSurfDef.Vertices, 1))
-        error(['No registered contralateral spheres available for this cortex surface.' 10 ...
-            'No registered contralateral spheres available in the default anatomy.' 10 ... 
-            'See FreeSurfer tutorial for computing contralateral registration: ' 10 ...
-            'https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer']);
-    end
-    % Display warning
-    disp([10 'BST> WARNING: Using contralateral registration from the template anatomy.' 10 ...
-          'BST>          For faster and more accurate results, consider computing the' 10 ...
-          'BST>          contralateral registration for each subject using FreeSurfer.' 10 ...
-          'BST>          https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer' 10]);
-
-    % Identify left and right hemispheres
-    [rH, lH]  = tess_hemisplit(sSurfDef);
+% ===== PROJECT SURFACE SCOUTS =====
+if ~isVolume
+    % Number of nearest neighbors in interpolation between spheres
+    nbNeighbors = 8;
     % Signature string for the current transformation
-    SignatureDef_LR = sprintf('%s%d_LR', defSurfFile, length(sSurfDef.Vertices));
+    Signature_LR = sprintf('%s%d_LR', srcSurfFile, length(sSurf.Vertices));
 
-    % Try to get an existing valid left-right interpolation matrix in the template surface
-    if isfield(sSurfDef, 'tess2tess_interp') && all(isfield(sSurfDef.tess2tess_interp, {'Signature_LR', 'Wmat_LR', 'Wmat_RL'})) && ...
-            strcmpi(sSurfDef.tess2tess_interp.Signature_LR, SignatureDef_LR) && ~isempty(sSurfDef.tess2tess_interp.Wmat_LR)
-        Wmat_RL = sSurfDef.tess2tess_interp.Wmat_RL;
-        Wmat_LR = sSurfDef.tess2tess_interp.Wmat_LR;
-    % Otherwise, compute interpolation
+
+    % ===== COMPUTE INTERPOLATION =====
+    % Try to get an existing valid interpolation matrix
+    if isfield(sSurf, 'tess2tess_interp') && all(isfield(sSurf.tess2tess_interp, {'Signature_LR', 'Wmat_LR', 'Wmat_RL'})) && ...
+            strcmpi(sSurf.tess2tess_interp.Signature_LR, Signature_LR) && ~isempty(sSurf.tess2tess_interp.Wmat_LR)
+        % Identify left and right hemispheres
+        [rH, lH]  = tess_hemisplit(sSurf);
+        % Reuse saved interpolations
+        Wmat_RL = sSurf.tess2tess_interp.Wmat_RL;
+        Wmat_LR = sSurf.tess2tess_interp.Wmat_LR;
+        defSurfFile = [];
+
+    % Identify left and right hemispheres
+    [rH, lH]  = tess_hemisplit(sSurf);
+    % Check for contralateral surfaces in subject
+    elseif isfield(sSurf, 'Reg') && isfield(sSurf.Reg, 'SphereLR') && isfield(sSurf.Reg.SphereLR, 'Vertices') && (size(sSurf.Reg.SphereLR.Vertices, 1) == size(sSurf.Vertices, 1))
+        % Identify left and right hemispheres
+        [rH, lH]  = tess_hemisplit(sSurf);
+        % Pre-compute WMAT directly between left and right
+        Wmat_RL = bst_shepards(sSurf.Reg.Sphere.Vertices(lH, : ), sSurf.Reg.SphereLR.Vertices(rH, : ),  nbNeighbors, 0);
+        Wmat_LR = bst_shepards(sSurf.Reg.Sphere.Vertices(rH, : ), sSurf.Reg.SphereLR.Vertices(lH, : ),  nbNeighbors, 0);
+        % Save interpolation matrices
+        sSurf.tess2tess_interp.Wmat_LR      = Wmat_LR;
+        sSurf.tess2tess_interp.Wmat_RL      = Wmat_RL;
+        sSurf.tess2tess_interp.Signature_LR = Signature_LR;
+        bst_save(file_fullpath(srcSurfFile), sSurf, 'v7');
+        defSurfFile = [];
+
+    % Check for contralateral surfaces in template: 
+    % If available, 1) project scouts on template, 2) project left-right, 3) project back to subject
     else
-        % Compute interpolation matrices between left and right hemispheres
-        Wmat_RL = bst_shepards(sSurfDef.Reg.Sphere.Vertices(lH, : ), sSurfDef.Reg.SphereLR.Vertices(rH, : ),  nbNeighbors, 0);
-        Wmat_LR = bst_shepards(sSurfDef.Reg.Sphere.Vertices(rH, : ), sSurfDef.Reg.SphereLR.Vertices(lH, : ),  nbNeighbors, 0);
-        % Save interpolations
-        sSurfDef.tess2tess_interp.Wmat_LR      = Wmat_LR;
-        sSurfDef.tess2tess_interp.Wmat_RL      = Wmat_RL;
-        sSurfDef.tess2tess_interp.Signature_LR = SignatureDef_LR;
-        bst_save(file_fullpath(defSurfFile), sSurfDef, 'v7');
-    end
-end
-
-% ===== PROJECT TO TEMPLATE =====
-if ~isempty(defSurfFile)
-    [nScoutProj, sSurfDef, sAtlas] = bst_project_scouts(srcSurfFile, defSurfFile, sAtlas, 0, 0);
-    if (nScoutProj == 0)
-        error('Cannot project the scouts to the template cortex surface.');
-    end
-end
-
-% ===== PROCESS ATLAS/SCOUTS =====
-for iAtlas = 1:length(sAtlas)
-    for iScout = 1:length(sAtlas(iAtlas).Scouts)
-        % Find scout indices in left OR right hemisphere
-        isLeft = ~isempty(intersect(lH,  sAtlas(iAtlas).Scouts(iScout).Vertices));
-        isRight = ~isempty(intersect(rH, sAtlas(iAtlas).Scouts(iScout).Vertices));
-        if isRight && ~isLeft
-            Wmat =  Wmat_RL;
-            iVertHemi = lH;
-            [~, sScout_Vertices] = intersect(rH, sAtlas(iAtlas).Scouts(iScout).Vertices);
-        elseif isLeft && ~isRight
-            Wmat =  Wmat_LR;
-            iVertHemi = rH;
-            [~, sScout_Vertices] = intersect(lH, sAtlas(iAtlas).Scouts(iScout).Vertices);
+        % Get default anatomy from the protocol
+        sSubjectDef = bst_get('Subject', 0);
+        % If input is the low-resolution cortex
+        if ~isempty(strfind(srcSurfFile, '_low'))
+            defCortexFile = 'tess_cortex_pial_low.mat';
         else
-            bst_error('The scout should contain only left or right vertices.');
-            return;
+            defCortexFile = 'tess_cortex_pial_high.mat';
         end
+        % Get high-resolution cortex surface
+        iCortexDef = find(~cellfun(@(c)isempty(strfind(c, defCortexFile)), {sSubjectDef.Surface.FileName}));
+        if isempty(iCortexDef)
+            error(['No registered contralateral spheres available for this cortex surface.' 10 ...
+                'No cortex surface available in default anatomy: ' defCortexFile]);
+        end
+        defSurfFile = sSubjectDef.Surface(iCortexDef(1)).FileName;
+
+        % Load cortex surface
+        sSurfDef = in_tess_bst(defSurfFile);
+        % Check for contralateral surfaces in subject
+        if ~isfield(sSurfDef, 'Reg') || ~isfield(sSurfDef.Reg, 'SphereLR') || ~isfield(sSurfDef.Reg.SphereLR, 'Vertices') || (size(sSurfDef.Reg.SphereLR.Vertices, 1) ~= size(sSurfDef.Vertices, 1))
+            error(['No registered contralateral spheres available for this cortex surface.' 10 ...
+                'No registered contralateral spheres available in the default anatomy.' 10 ... 
+                'See FreeSurfer tutorial for computing contralateral registration: ' 10 ...
+                'https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer']);
+        end
+        % Display warning
+        disp([10 'BST> WARNING: Using contralateral registration from the template anatomy.' 10 ...
+              'BST>          For faster and more accurate results, consider computing the' 10 ...
+              'BST>          contralateral registration for each subject using FreeSurfer.' 10 ...
+              'BST>          https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer' 10]);
+
+        % Identify left and right hemispheres
+        [rH, lH]  = tess_hemisplit(sSurfDef);
+        % Signature string for the current transformation
+        SignatureDef_LR = sprintf('%s%d_LR', defSurfFile, length(sSurfDef.Vertices));
+
+        % Try to get an existing valid left-right interpolation matrix in the template surface
+        if isfield(sSurfDef, 'tess2tess_interp') && all(isfield(sSurfDef.tess2tess_interp, {'Signature_LR', 'Wmat_LR', 'Wmat_RL'})) && ...
+                strcmpi(sSurfDef.tess2tess_interp.Signature_LR, SignatureDef_LR) && ~isempty(sSurfDef.tess2tess_interp.Wmat_LR)
+            Wmat_RL = sSurfDef.tess2tess_interp.Wmat_RL;
+            Wmat_LR = sSurfDef.tess2tess_interp.Wmat_LR;
+        % Otherwise, compute interpolation
+        else
+            % Compute interpolation matrices between left and right hemispheres
+            Wmat_RL = bst_shepards(sSurfDef.Reg.Sphere.Vertices(lH, : ), sSurfDef.Reg.SphereLR.Vertices(rH, : ),  nbNeighbors, 0);
+            Wmat_LR = bst_shepards(sSurfDef.Reg.Sphere.Vertices(rH, : ), sSurfDef.Reg.SphereLR.Vertices(lH, : ),  nbNeighbors, 0);
+            % Save interpolations
+            sSurfDef.tess2tess_interp.Wmat_LR      = Wmat_LR;
+            sSurfDef.tess2tess_interp.Wmat_RL      = Wmat_RL;
+            sSurfDef.tess2tess_interp.Signature_LR = SignatureDef_LR;
+            bst_save(file_fullpath(defSurfFile), sSurfDef, 'v7');
+        end
+    end
+
+    % ===== PROJECT TO TEMPLATE =====
+    if ~isempty(defSurfFile)
+        [nScoutProj, sSurfDef, sAtlas] = bst_project_scouts(srcSurfFile, defSurfFile, sAtlas, 0, 0);
+        if (nScoutProj == 0)
+            error('Cannot project the scouts to the template cortex surface.');
+        end
+    end
+
+    % ===== PROCESS ATLAS/SCOUTS =====
+    for iAtlas = 1:length(sAtlas)
+        for iScout = 1:length(sAtlas(iAtlas).Scouts)
+            % Find scout indices in left OR right hemisphere
+            isLeft = ~isempty(intersect(lH,  sAtlas(iAtlas).Scouts(iScout).Vertices));
+            isRight = ~isempty(intersect(rH, sAtlas(iAtlas).Scouts(iScout).Vertices));
+            if isRight && ~isLeft
+                Wmat =  Wmat_RL;
+                iVertHemi = lH;
+                [~, sScout_Vertices] = intersect(rH, sAtlas(iAtlas).Scouts(iScout).Vertices);
+            elseif isLeft && ~isRight
+                Wmat =  Wmat_LR;
+                iVertHemi = rH;
+                [~, sScout_Vertices] = intersect(lH, sAtlas(iAtlas).Scouts(iScout).Vertices);
+            else
+                bst_error('The scout should contain only left or right vertices.');
+                return;
+            end
+
+            % Project scouts one by one and keep for each vertex only the maximum probability
+            % Vertex map on the original surface
+            vMap                    = zeros(size(Wmat, 2),1);
+            vMap(sScout_Vertices)   = 1;
+
+            % Project to destination surface
+            vMapProj = full(Wmat * vMap);
+            % Keep the highest values, in order to obtain the same number of vertices as the original scout
+            [~, NewIndex] = bst_maxk(vMapProj, length(sScout_Vertices));
+            newVertices = iVertHemi(sort(NewIndex(:)'));
+            % Save in input structure
+            sAtlas(iAtlas).Scouts(iScout).Vertices = newVertices;
+            sAtlas(iAtlas).Scouts(iScout) = panel_scout('SetScoutsSeed', sAtlas(iAtlas).Scouts(iScout), sSurf.Vertices);
+
+            % Update label and region
+            % Remove hemisphere suffix if present
+            sAtlas(iAtlas).Scouts(iScout).Label = regexprep(sAtlas(iAtlas).Scouts(iScout).Label, ' (L|R)$', '');
+            if isRight
+                sAtlas(iAtlas).Scouts(iScout).Label = [sAtlas(iAtlas).Scouts(iScout).Label ' L'];
+                sAtlas(iAtlas).Scouts(iScout).Region = strrep(sAtlas(iAtlas).Scouts(iScout).Region, 'R', 'L');
+            else
+                sAtlas(iAtlas).Scouts(iScout).Label = [sAtlas(iAtlas).Scouts(iScout).Label ' R'];
+                sAtlas(iAtlas).Scouts(iScout).Region = strrep(sAtlas(iAtlas).Scouts(iScout).Region, 'L', 'R');
+            end
+        end
+    end
+
+    % ===== PROJECT BACK TO SUBJECT =====
+    if ~isempty(defSurfFile)
+        [nScoutProj, ~, sAtlas] = bst_project_scouts(defSurfFile, srcSurfFile, sAtlas, 0, 0);
+        if (nScoutProj == 0)
+            error('Cannot project the scouts to the subject surface.');
+        end
+    end
+
+% ===== PROJECT VOLUME SCOUTS =====
+else
+    % ===== PROCESS ATLAS/SCOUTS =====
+    for iAtlas = 1:length(sAtlas)
+        for iScout = 1:length(sAtlas(iAtlas).Scouts)
+            disp(sAtlas(iAtlas).Scouts(iScout).Label)
+            nOrgVertices = length(sAtlas(iAtlas).Scouts(iScout).Vertices);
+            % SCS coordinates
+            scs_coords = GridLoc(sAtlas(iAtlas).Scouts(iScout).Vertices, :);
+            % Convert to MNI coordinates
+            mni_coords = cs_convert(sMri, 'scs', 'mni', scs_coords);
+            % Scout hemisphere
+            isRight = sum(mni_coords(:,1)) > 0;
+            % Flip MNI coordinates on the X axis
+            mni_coords(:, 1) = -mni_coords(:, 1);
+            % Convert back to SCS
+            scs_coords = cs_convert(sMri, 'mni', 'scs', mni_coords);
+            if  nOrgVertices < 4
+                % Find closets grid point to projected points
+                vi = zeros(1, nOrgVertices);
+                for iVertex = 1 : nOrgVertices
+                    % Compute the distance from each point to the seed
+                    [tmp, I] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, scs_coords(iVertex, :)) .^ 2, 2)));
+                    vi(iVertex) = I;
+                end
+            else
+                % Find boundary for set of projected points
+                faces = boundary(scs_coords, 0);
+                % Find grid points inside polyhedron
+                vi = find(inpolyhedron(struct('faces', faces, 'vertices', scs_coords), GridLoc));
+                if isempty(vi)
+                    % Find the vertex that is closer to the center of the projected points
+                    [tmp, I] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, mean(scs_coords, 1)) .^ 2, 2)));
+                    vi = I;
+                end
+            end
+            vi = vi(:)'; % Force to be column vector
+            % Save in input structure
+            sAtlas(iAtlas).Scouts(iScout).Vertices = vi;
+            % Set seed for new Scout
+            sAtlas(iAtlas).Scouts(iScout) = panel_scout('SetScoutsSeed', sAtlas(iAtlas).Scouts(iScout), GridLoc);
+            % Grow new scout around it seed to march the number of vertices in origin scout
+            nToGrow = nOrgVertices - length(vi);
+            if nToGrow ~= 0
+                seedXYZ = GridLoc(sAtlas(iAtlas).Scouts(iScout).Seed, :);
+                viPossible = 1:size(GridLoc,1);
+                % Remove the points that are already in the new scout
+                viPossible = setdiff(viPossible, vi);
+                % If there are some candidates, find the closest ones
+                if ~isempty(viPossible) && (length(viPossible) <= nToGrow)
+                    vi = union(vi, viPossible);
+                elseif ~isempty(viPossible)
+                    % Compute the distance from each point to the seed
+                    distFromSeed = sqrt(sum(bst_bsxfun(@minus, GridLoc(viPossible,:), seedXYZ) .^ 2, 2))';
+                    % Add the the closest points
+                    [tmp, I] = sort(distFromSeed);
+                    vi = union(vi, viPossible(I(1:nToGrow)));
+                end
+                % Update vertices
+                sAtlas(iAtlas).Scouts(iScout).Vertices = vi;
+            end
+            % Update label and region
+            % Remove hemisphere suffix if present
+            sAtlas(iAtlas).Scouts(iScout).Label = regexprep(sAtlas(iAtlas).Scouts(iScout).Label, ' (L|R)$', '');
+            if isRight
+                sAtlas(iAtlas).Scouts(iScout).Label = [sAtlas(iAtlas).Scouts(iScout).Label ' L'];
+                sAtlas(iAtlas).Scouts(iScout).Region = strrep(sAtlas(iAtlas).Scouts(iScout).Region, 'R', 'L');
+            else
+                sAtlas(iAtlas).Scouts(iScout).Label = [sAtlas(iAtlas).Scouts(iScout).Label ' R'];
+                sAtlas(iAtlas).Scouts(iScout).Region = strrep(sAtlas(iAtlas).Scouts(iScout).Region, 'L', 'R');
+            end
+        end
+    end
+end
         
-        % Project scouts one by one and keep for each vertex only the maximum probability
-        % Vertex map on the original surface
-        vMap                    = zeros(size(Wmat, 2),1);
-        vMap(sScout_Vertices)   = 1;
-
-        % Project to destination surface
-        vMapProj = full(Wmat * vMap);
-        % Keep the highest values, in order to obtain the same number of vertices as the original scout
-        [~, NewIndex] = bst_maxk(vMapProj, length(sScout_Vertices));
-        newVertices = iVertHemi(sort(NewIndex(:)'));
-        % Save in input structure
-        sAtlas(iAtlas).Scouts(iScout).Vertices = newVertices;
-        sAtlas(iAtlas).Scouts(iScout).Seed     = newVertices(1);
-
-        % Update label and region
-        if isRight
-            ScoutVertices = lH(NewIndex);
-            sAtlas(iAtlas).Scouts(iScout).Label = [sAtlas(iAtlas).Scouts(iScout).Label ' L'];
-            sAtlas(iAtlas).Scouts(iScout).Region = strrep(sAtlas(iAtlas).Scouts(iScout).Region, 'R', 'L');
-        else
-            ScoutVertices = rH(NewIndex);
-            sAtlas(iAtlas).Scouts(iScout).Label = [sAtlas(iAtlas).Scouts(iScout).Label ' R'];
-            sAtlas(iAtlas).Scouts(iScout).Region = strrep(sAtlas(iAtlas).Scouts(iScout).Region, 'L', 'R');
-        end
-    end
-end
-
-% ===== PROJECT BACK TO SUBJECT =====
-if ~isempty(defSurfFile)
-    [nScoutProj, ~, sAtlas] = bst_project_scouts(defSurfFile, srcSurfFile, sAtlas, 0, 0);
-    if (nScoutProj == 0)
-        error('Cannot project the scouts to the subject surface.');
-    end
-end

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -69,8 +69,6 @@ if ~isVolume
         Wmat_LR = sSurf.tess2tess_interp.Wmat_LR;
         defSurfFile = [];
 
-    % Identify left and right hemispheres
-    [rH, lH]  = tess_hemisplit(sSurf);
     % Check for contralateral surfaces in subject
     elseif isfield(sSurf, 'Reg') && isfield(sSurf.Reg, 'SphereLR') && isfield(sSurf.Reg.SphereLR, 'Vertices') && (size(sSurf.Reg.SphereLR.Vertices, 1) == size(sSurf.Vertices, 1))
         % Identify left and right hemispheres

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -226,8 +226,8 @@ else
             end
             % If points form a closed surface
             if  nOrgVertices >= 4
-                % Find boundary for set of projected points
-                faces = boundary(GridLoc(vi,:), 0);
+                % Find the compact boundary that envelops all the projected points
+                faces = boundary(GridLoc(vi,:), 1);
                 % Find grid points inside polyhedron
                 vi = find(inpolyhedron(struct('faces', faces, 'vertices', GridLoc(vi,:)), GridLoc));
                 if isempty(vi)

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -224,10 +224,9 @@ else
             for iVertex = 1 : nOrgVertices
                 [tmp, vi(iVertex)] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, scs_coords(iVertex, :)) .^ 2, 2)));
             end
-            % If points form a closed surface
-            if  nOrgVertices >= 4
-                % Find the compact boundary that envelops all the projected points
-                faces = boundary(GridLoc(vi,:), 1);
+            % Find the compact boundary that envelops all the projected points
+            faces = boundary(GridLoc(vi,:), 1);
+            if ~isempty(faces)
                 % Find grid points inside polyhedron
                 vi_in = find(inpolyhd(GridLoc, GridLoc(vi,:), faces));
                 if isempty(vi_in)

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -219,23 +219,20 @@ else
             mni_coords(:, 1) = -mni_coords(:, 1);
             % Convert back to SCS
             scs_coords = cs_convert(sMri, 'mni', 'scs', mni_coords);
-            if  nOrgVertices < 4
-                % Find closets grid point to projected points
-                vi = zeros(1, nOrgVertices);
-                for iVertex = 1 : nOrgVertices
-                    % Compute the distance from each point to the seed
-                    [tmp, I] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, scs_coords(iVertex, :)) .^ 2, 2)));
-                    vi(iVertex) = I;
-                end
-            else
+            % Find points to project in GridLoc
+            vi = zeros(1, nOrgVertices);
+            for iVertex = 1 : nOrgVertices
+                [tmp, vi(iVertex)] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, scs_coords(iVertex, :)) .^ 2, 2)));
+            end
+            % If points form a closed surface
+            if  nOrgVertices >= 4
                 % Find boundary for set of projected points
-                faces = boundary(scs_coords, 0);
+                faces = boundary(GridLoc(vi,:), 0);
                 % Find grid points inside polyhedron
-                vi = find(inpolyhedron(struct('faces', faces, 'vertices', scs_coords), GridLoc));
+                vi = find(inpolyhedron(struct('faces', faces, 'vertices', GridLoc(vi,:)), GridLoc));
                 if isempty(vi)
                     % Find the vertex that is closer to the center of the projected points
-                    [tmp, I] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, mean(scs_coords, 1)) .^ 2, 2)));
-                    vi = I;
+                    [tmp, vi] = min(sqrt(sum(bst_bsxfun(@minus, GridLoc, mean(GridLoc(vi,:), 1)) .^ 2, 2)));
                 end
             end
             vi = vi(:)'; % Force to be column vector

--- a/toolbox/math/bst_project_scouts_contra.m
+++ b/toolbox/math/bst_project_scouts_contra.m
@@ -4,7 +4,8 @@ function sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas, sMri, GridLoc)
 % USAGE:  sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas)                 % Surface scouts
 %         sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas, sMri, GridLoc)  % Volume scouts
 %
-% PROJECT SURFACE SCOUTS REFERENCE:
+% REFERENCE:
+%    Surface scouts:
 %    - Requires the FreeSurfer registered contralateral spheres: Option -contrasurfreg in FreeSurfer 6.X
 %      See tutorial: https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer#Contralateral_registration
 %    - Use the contralateral spheres if available at the subject level: sSurf.Reg.SphereLR.Vertices
@@ -13,7 +14,7 @@ function sAtlas = bst_project_scouts_contra(srcSurfFile, sAtlas, sMri, GridLoc)
 %      2) project left-right in the template anatomy
 %      3) project back to the subject surface
 %
-% PROJECT VOLUME SCOUTS REFERENCE:
+%    Volume scouts:
 %    - Contralateral projection is based on MNI-coordinates
 %    - If the original scout has less than 4 vertices, the projected scout consists in the set of projected vertices
 %    - Else, the boundary of the original scout vertices is projected and used find the projected scout
@@ -207,7 +208,6 @@ else
     % ===== PROCESS ATLAS/SCOUTS =====
     for iAtlas = 1:length(sAtlas)
         for iScout = 1:length(sAtlas(iAtlas).Scouts)
-            disp(sAtlas(iAtlas).Scouts(iScout).Label)
             nOrgVertices = length(sAtlas(iAtlas).Scouts(iScout).Vertices);
             % SCS coordinates
             scs_coords = GridLoc(sAtlas(iAtlas).Scouts(iScout).Vertices, :);
@@ -243,7 +243,7 @@ else
             sAtlas(iAtlas).Scouts(iScout).Vertices = vi;
             % Set seed for new Scout
             sAtlas(iAtlas).Scouts(iScout) = panel_scout('SetScoutsSeed', sAtlas(iAtlas).Scouts(iScout), GridLoc);
-            % Grow new scout around it seed to march the number of vertices in origin scout
+            % Grow new scout around it seed to match the number of vertices in origin scout
             nToGrow = nOrgVertices - length(vi);
             if nToGrow ~= 0
                 seedXYZ = GridLoc(sAtlas(iAtlas).Scouts(iScout).Seed, :);
@@ -276,4 +276,3 @@ else
         end
     end
 end
-        


### PR DESCRIPTION
Allow contralateral projection of volume scouts
- Projection is done in the MNI space (changing x-axis sign)
- For polyhedron scouts (>= 4 vertices), the boundary is projected, then this is used to find the projected scout
- For "open" scouts (< 4), the closest grid points to the projected vertices are used for the projected scout

Examples: In the two images below, all the scouts in the right hemisphere are projections from scouts in the left hemisphere

![Screenshot from 2023-03-09 14-31-36](https://user-images.githubusercontent.com/8238803/224187886-b49eb6d2-0723-4b06-a779-9d761ec153e4.png)


![image](https://user-images.githubusercontent.com/8238803/224187998-bc2cd1f1-9900-4d77-84ce-d06afcaab734.png)


