### PR TITLE
Bugfix display config menu

### DIFF
--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -2738,9 +2738,16 @@ function DisplayConfigMenu(hFig, jParent)
                             matlabMouse(2) - matlabFig(2) - matlabButton(2) - matlabButton(4) + 1];
             % Move popup accordingly
             ScreenDef = bst_get('ScreenDef');
+            if (length(ScreenDef) == 1)
+                ZoomFactor = ScreenDef(1).zoomFactor;
+            elseif (matlabFig(1) < ScreenDef(1).matlabPos(1) + ScreenDef(1).matlabPos(3))
+                ZoomFactor = ScreenDef(1).zoomFactor;
+            else
+                ZoomFactor = ScreenDef(2).zoomFactor;
+            end
             jPopup.setLocation(java.awt.Point(...
-                javaMouse.getX() - matlabOffset(1).*ScreenDef.zoomFactor - jPopup.getWidth(), ...
-                javaMouse.getY() + matlabOffset(2).*ScreenDef.zoomFactor));
+                javaMouse.getX() - matlabOffset(1).*ZoomFactor - jPopup.getWidth(), ...
+                javaMouse.getY() + matlabOffset(2).*ZoomFactor));
         end
     end
 end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -4382,8 +4382,14 @@ function ScaleToFitY(hFig, ev)
                 TF = reshape(TF(:,1,:), [size(TF,1), size(TF,3)]);
         end
     else
-        TF = GetFigureData(iDS, iFig);
-        TF = TF{1};
+        switch file_gettype(TsInfo.FileName)
+            case 'data'
+                TF = GetFigureData(iDS, iFig);
+                TF = TF{1};
+            case 'matrix'
+                sMatrix = in_bst_matrix(TsInfo.FileName, 'Value');
+                TF = sMatrix.Value;
+        end
         [XVector, iTime] = bst_memory('GetTimeVector', iDS, [], 'UserTimeWindow');
         XVector = XVector(iTime);
     end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -4411,7 +4411,7 @@ function ScaleToFitY(hFig, ev)
     iStart = max(iStartMin, iStart);
     [val, iEnd] = min(abs(XVector - XLim(2)));
     curTF = TF(:, iStart:iEnd);
-    isYLog = strcmpi(TsInfo.YScale, 'log');
+    isYLog = isfield(TsInfo, 'YScale') && strcmpi(TsInfo.YScale, 'log');
     if isYLog
         YLim = [min(curTF(:)), max(curTF(:))] * PlotHandles.DisplayFactor;
         if YLim(1) <= 0

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -4346,7 +4346,7 @@ function ScaleToFitY(hFig, ev)
     FigureId = getappdata(hFig, 'FigureId');
     isSpectrum = strcmpi(FigureId.Type, 'spectrum');
     [PlotHandles, iFig, iDS] = bst_figures('GetFigureHandles', hFig);
-    hAxes = PlotHandles.hAxes;
+    hAxes = [PlotHandles(:).hAxes];
     % Get initial YLim
     YLimInit = getappdata(hAxes(1), 'YLimInit');
 
@@ -4382,6 +4382,7 @@ function ScaleToFitY(hFig, ev)
                 TF = reshape(TF(:,1,:), [size(TF,1), size(TF,3)]);
         end
     else
+        TF = [];
         switch file_gettype(TsInfo.FileName)
             case 'data'
                 TF = GetFigureData(iDS, iFig);
@@ -4390,12 +4391,21 @@ function ScaleToFitY(hFig, ev)
                 sMatrix = in_bst_matrix(TsInfo.FileName, 'Value');
                 TF = sMatrix.Value;
         end
+        if isempty(TF)
+           % Get the Y data from all Axes
+            for ix = 1 : length(hAxes)
+                dataLineObjs = findobj(hAxes(ix), 'Tag', 'DataLine');
+                TF = vertcat(TF, vertcat(get(dataLineObjs, 'YData')));
+            end
+            % Correct for display factor
+            TF = TF ./ PlotHandles(1).DisplayFactor;
+        end
         [XVector, iTime] = bst_memory('GetTimeVector', iDS, [], 'UserTimeWindow');
         XVector = XVector(iTime);
     end
     
     % Get limits of currently plotted data
-    XLim = get(hAxes, 'XLim');    
+    XLim = get(hAxes(1), 'XLim');
     % For linear y axis spectrum, ignore very low frequencies with high amplitudes. Use the first local maximum
     if isSpectrum && ~isequal(lower(FigureId.SubType), 'timeseries') && ~isBands && ...
             any(strcmpi(TfInfo.Function, {'power', 'magnitude'})) && strcmpi(TsInfo.YScale, 'linear') && all(TF(:)>=0)
@@ -4413,13 +4423,13 @@ function ScaleToFitY(hFig, ev)
     curTF = TF(:, iStart:iEnd);
     isYLog = isfield(TsInfo, 'YScale') && strcmpi(TsInfo.YScale, 'log');
     if isYLog
-        YLim = [min(curTF(:)), max(curTF(:))] * PlotHandles.DisplayFactor;
+        YLim = [min(curTF(:)), max(curTF(:))] * PlotHandles(1).DisplayFactor;
         if YLim(1) <= 0
-            YLim(1) = min(curTF(curTF(:)>0)) * PlotHandles.DisplayFactor;
+            YLim(1) = min(curTF(curTF(:)>0)) * PlotHandles(1).DisplayFactor;
         end
         YLim = log10(YLim);
     else
-        YLim = [min(curTF(:)), max(curTF(:))] * PlotHandles.DisplayFactor;
+        YLim = [min(curTF(:)), max(curTF(:))] * PlotHandles(1).DisplayFactor;
     end
     % Add 5% margin above and below
     YSpan = YLim(2) - YLim(1);
@@ -4428,22 +4438,32 @@ function ScaleToFitY(hFig, ev)
     if isYLog
         YLim = 10.^YLim;
     end
+    % Keep YLim(1) as 0 if it was initially 0
+    if YLimInit(1) == 0
+        YLim(1) = 0;
+    end
+    % Keep YLim symetric if it was initially symetric
+    if YLimInit(1) == -YLimInit(2)
+        [tmp, imax] = max(abs(YLim));
+        [tmp, imin] = min(abs(YLim));
+        YLim(imin) = -YLim(imax);
+    end
     % Respect data limits
     if isSpectrum 
         if ~isempty(YLimInit) && YLimInit(1) ~= YLimInit (2)
             YLim(1) = max(YLim(1), YLimInit(1));
             YLim(2) = min(YLim(2), YLimInit(2));
-        elseif PlotHandles.DataMinMax(1) ~= PlotHandles.DataMinMax(2)
-            YLim(1) = max(YLim(1), PlotHandles.DataMinMax(1) * PlotHandles.DisplayFactor);
-            YLim(2) = min(YLim(2), PlotHandles.DataMinMax(2) * PlotHandles.DisplayFactor);
+        elseif PlotHandles(1).DataMinMax(1) ~= PlotHandles(1).DataMinMax(2)
+            YLim(1) = max(YLim(1), PlotHandles(1).DataMinMax(1) * PlotHandles(1).DisplayFactor);
+            YLim(2) = min(YLim(2), PlotHandles(1).DataMinMax(2) * PlotHandles(1).DisplayFactor);
         end
     end
     % Catch exceptions
     if YLim(1) == YLim (2)
         if ~isempty(YLimInit) && YLimInit(1) ~= YLimInit (2)
             YLim = YLimInit;
-        elseif PlotHandles.DataMinMax(1) ~= PlotHandles.DataMinMax(2)
-            YLim = PlotHandles.DataMinMax;
+        elseif PlotHandles(1).DataMinMax(1) ~= PlotHandles(1).DataMinMax(2)
+            YLim = PlotHandles(1).DataMinMax;
         else
             YLim = [-1, 1];
         end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -4442,7 +4442,7 @@ function ScaleToFitY(hFig, ev)
     if YLimInit(1) == 0
         YLim(1) = 0;
     end
-    % Keep YLim symetric if it was initially symetric
+    % Keep YLim symmetric if it was initially symmetric
     if YLimInit(1) == -YLimInit(2)
         [tmp, imax] = max(abs(YLim));
         [tmp, imin] = min(abs(YLim));

--- a/toolbox/gui/gui_layout.m
+++ b/toolbox/gui/gui_layout.m
@@ -247,7 +247,7 @@ function ScreenDef = GetScreenClientArea()
         % === SCALING ===
         try
             % Adjust with the OS scaling factor (for high-DPI screens)
-            javaScreenSize = jScreens(i).getDisplayMode().getWidth();
+            javaScreenSize = jScreens(i).getDefaultConfiguration().getBounds().getWidth();
             if (i == 1) || (i > size(MonitorPositions,1))
                 matlabScreenSize = MonitorPositions(1,3) - MonitorPositions(1,1) + 1;
             else


### PR DESCRIPTION
Fix bugs related to the menu `Display configuration > Y Amplitude >  Y Scale to fit screen` in Time series figures (data and matrix)

1. Correct position of `Display configuration` popup menu in case of +2 screens
2. Loads matrix values
3. Avoid error `YScale` in non spectrum plots 
4. The ZoomFactor for each screen is computed using it's bounds, rather than the total screen (merged) size


Edit: For Scout and Cluster time series, `YData` is obtained directly from the Axes in Figure