### PR TITLE
pac and tpac averaging bug fixes

### DIFF
--- a/toolbox/connectivity/bst_pac.m
+++ b/toolbox/connectivity/bst_pac.m
@@ -1,7 +1,7 @@
 function [DirectPAC, LowFreqs, HighFreqs] = bst_pac(F, sRate, bandNesting, bandNested, isUseParallel, isUseMex, numfreqs)
 % BST_PAC: Calculate the DirectPAC metric for all the input time series.
 %
-% USAGE:  sPAC = bst_pac(F, sRate, bandNesting, bandNested, isUseParallel=0, isUseMex=0, numfreqs=[])
+% USAGE: [DirectPAC, NestingFreqs, NestedFreqs] = bst_pac(F, sRate, bandNesting, bandNested, isUseParallel=0, isUseMex=0, numfreqs=[])
 % 
 % INPUTS:
 %    - F             : Signal time series [nSignals x nTime]
@@ -15,9 +15,10 @@ function [DirectPAC, LowFreqs, HighFreqs] = bst_pac(F, sRate, bandNesting, bandN
 %    - numfreqs      : Number of frequency bins to use (if 0 or empty, use round(sRate/9))
 % 
 % OUTPUTS:
-%    - DirectPAC   : Full array of direct PAC measures for all frequyency pairs
-%    - LowFreqs    : List of nesting frequency for the DirectPAC maps (frequency for phase)
-%    - NestedFreq  : List of nested frequency for the DirectPAC maps (frequency for amplitude)
+%    - DirectPAC    : Full array of direct PAC measures for all frequency pairs
+%                     [nSignals, nTime=1, nNestingFreqs, nNestedFreqs]
+%    - NestingFreqs : List of nesting frequency for the DirectPAC maps (frequency for phase)
+%    - NestedFreq   : List of nested frequency for the DirectPAC maps (frequency for amplitude)
 %
 % DOCUMENTATION:
 %    - For more information, please refer to the method described in the following article:

--- a/toolbox/process/functions/process_pac.m
+++ b/toolbox/process/functions/process_pac.m
@@ -295,7 +295,7 @@ function OutputFiles = Run(sProcess, sInputA) %#ok<DEFNU>
             if isempty(DirectPAC)
                 DirectPAC = zeros(nSignals, 1, size(DirectPAC_block,3), size(DirectPAC_block,4));
             end
-            % Copy block results to output variable
+            % Copy block results to output variable [nSignals, nTime=1, nNestingFreqs, nNestedFreqs]
             DirectPAC(iSignals,:,:,:) = DirectPAC_block;
             % Display processing time
             % disp(sprintf('Block #%d/%d: %fs', iBlock, nBlocks, toc));

--- a/toolbox/process/functions/process_pac_average.m
+++ b/toolbox/process/functions/process_pac_average.m
@@ -1,6 +1,17 @@
 function varargout = process_pac_average( varargin )
 % PROCESS_PAC_AVERAGE: average pac maps.
 %
+% Averages all "full" PAC value arrays across files and/or trials.  Then the max PAC fields (TF,
+% NestingFreq, NestedFreq, PhasePAC) are recomputed from the averages.  However, DyncamicPAC may
+% already be the max across several nesting frequencies and this average should be interpreted with
+% caution.
+%
+% For time-resolved (dynamic) PAC, trials could have been concatenated in 4th dim of the DynamicPAC
+% field; these are also averaged here.  If using the phase in averaging, the returned DynamicPhase
+% is the phase of the averaged (complex) PAC, otherwise it is empty.  Similarly for TF & PhasePAC
+% which are the max values over all frequencies for amplitude.  DynamicNesting (frequency for phase)
+% values are also removed since they are different between files.
+%
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
@@ -20,14 +31,7 @@ function varargout = process_pac_average( varargin )
 % =============================================================================@
 %
 % Authors: Soheila Samiee, 2015-2017
-%   - 2.0: SS. Aug. 2017 
-%                - Imported in public brainstorm rep
-%   - 2.1: SS Sep. 2017
-%                - Bug fix for averaging multiple files with different 
-%                number of sources
-%
-%   - 2.2: SS Sep 2017
-%                - Bug fix - donot store f_nesting information 
+%          Marc Lalancette, 2023
 eval(macro_method);
 end
 
@@ -73,162 +77,198 @@ function OutputFiles = Run(sProcess, sInput) %#ok<DEFNU>
 
     usePhase = sProcess.options.usePhase.Value;
 
-    % Get current progressbar position
-    if bst_progress('isVisible')
-        curProgress = bst_progress('get');
-    else
-        curProgress = [];
-    end
+    %     % Get current progressbar position
+    %     if bst_progress('isVisible')
+    %         curProgress = bst_progress('get');
+    %     else
+    %         curProgress = [];
+    %     end
 
-    % Load TF file
-    tpacMat = in_bst_timefreq(sInput(1).FileName, 0);
-    % Error
-    if isempty(tpacMat)
-        bst_report('Error', sProcess, sInput, Messages);
-        return;
-    end
-    
     switch(sProcess.options.analyze_type.Value)
         % === EVERYTHING ===
         case 1
-            [tpacMat, tag, FileTag] = AverageFilesPAC(sInput, tpacMat,usePhase);
-            N = length(sInput);
-            tpacMat.nAvg = N;
-            isAvgFile = 1;
-            
+            [tpacMat, FileTag] = AverageFilesPAC(sInput, usePhase);
+            if isempty(tpacMat) % Error already reported.
+                OutputFiles = {};
+                return;
+            end
             % Save the results
-            OutputFiles = save_pac_files(sProcess, sInput, FileTag, tag, tpacMat, isAvgFile);
+            OutputFiles = save_pac_files(sProcess, sInput, FileTag, tpacMat);
             
             % === BY SUBJECT ===
         case 2
             % Process each subject independently
-            uniqueSubj = unique({sInput.SubjectFile});
-            for i = 1:length(uniqueSubj)
-                % Set progress bar at the same level for each loop
-                if ~isempty(curProgress)
-                    bst_progress('set', curProgress);
-                end
+            [~, iSubj, iUniq] = unique({sInput.SubjectFile});
+            nSubj = length(iSubj);
+            OutputFiles = cell(nSubj,1);
+            for i = 1:nSubj
                 % Get all the files for subject #i
-                iInputSubj = find(strcmpi(uniqueSubj{i}, {sInput.SubjectFile}));
-                N = length(sInput(iInputSubj));
-                if N>1
-                    % Load TF file
-                    tpacMat = in_bst_timefreq(sInput(iInputSubj(1)).FileName, 0);
-                    % Process the average of subject #i
-                    [tpacMat, tag, FileTag] = AverageFilesPAC(sInput(iInputSubj(2:end)), tpacMat, usePhase);
-                    isAvgFile = 1;
-                else
-                    % Process the average of subject #i
-                    [tpacMat, tag, FileTag] = AverageFilesPAC(sInput(iInputSubj(1)), tpacMat, usePhase);
-                    isAvgFile = 0;
+                isInputSubj = (i == iUniq);
+                [tpacMat, FileTag] = AverageFilesPAC(sInput(isInputSubj), usePhase);
+                if isempty(tpacMat) % Error already reported.
+                    OutputFiles = {};
+                    return;
                 end
-                tpacMat.nAvg = N;
-                tpacMat.Options.usePhase = usePhase;
-                
                 % Save the results
-                OutputFiles = save_pac_files(sProcess, sInput(iInputSubj), FileTag, tag, tpacMat, isAvgFile);
+                OutputFiles(i) = save_pac_files(sProcess, sInput(isInputSubj), FileTag, tpacMat);
             end
     end
 end
 
 
 
-function [tpacMat, tag, FileTag] = AverageFilesPAC(sInput, tpacMat, usePhase)
-        tag = '|avg_file';
+function [tpacMat, FileTag] = AverageFilesPAC(sInput, usePhase)
         N = length(sInput);
-        spac = tpacMat.sPAC;
+        % Load TF file
+        tpacMat = in_bst_timefreq(sInput(1).FileName, 0);
+        if isempty(tpacMat)
+            bst_report('Error', sProcess, sInput, 'Error loading input file.');
+            return;
+        end
+        tpacMat.Options.usePhase = usePhase;
         
-        if isfield(spac,'DirectPAC')
-            pac = tpacMat.sPAC.DirectPAC/N;
-            for iFile = 2:N
-                tmp = in_bst_timefreq(sInput(iFile).FileName, 0);
-                pac = pac + tmp.sPAC.DirectPAC/N;
+        if isfield(tpacMat.sPAC, 'DirectPAC')
+            % size is [nSignals, nTime=1, nLowFreqs, nHighFreqs]
+            tpacMat.sPAC.DirectPAC = zeros(size(tpacMat.sPAC.DirectPAC));
+            tpacMat.nAvg = 0;
+            for iFile = 1:N
+                if iFile > 1
+                    tpacIn = in_bst_timefreq(sInput(iFile).FileName, 0);
+                    if ~isequal(tpacMat.sPAC.LowFreqs, tpacIn.sPAC.LowFreqs) || ~isequal(tpacMat.sPAC.HighFreqs, tpacIn.sPAC.HighFreqs)
+                        Message = ['Frequencies of file #',num2str(iFile),' is not the same as previous files.'];
+                        bst_report('Error', 'process_pac_average', sInput, Message);
+                        tpacMat = [];
+                        return;
+                    elseif ~isequal(size(tpacMat.sPAC.DirectPAC), size(tpacIn.sPAC.DirectPAC))
+                        Message = ['Size of PAC array of file #',num2str(iFile),' is not the same as previous files.'];
+                        bst_report('Error', 'process_pac_average', sInput, Message);
+                        tpacMat = [];
+                        return;
+                    end
+                end
+                % Check full maps were saved.
+                if isempty(tpacMat.sPAC.DirectPAC)
+                    Message = ['Frequencies of file #',num2str(iFile),' is not the same as previous files.'];
+                    bst_report('Error', 'process_pac_average', sInput, Message);
+                    tpacMat = [];
+                    return;
+                end
+                tpacMat.sPAC.DirectPAC = tpacMat.sPAC.DirectPAC + tpacIn.sPAC.DirectPAC;
+                if isempty(tpacIn.nAvg)
+                    tpacIn.nAvg = 1;
+                end
+                tpacMat.nAvg = tpacMat.nAvg + tpacIn.nAvg;
             end
-            tpacMat.sPAC.DirectPAC = pac;
             FileTag = 'timefreq_pac_fullmaps';
-            %% Recompute nesting frequencies
-            pacDims = size(pac);
+            % Divide by total number of trials for average.
+            tpacMat.sPAC.DirectPAC = tpacMat.sPAC.DirectPAC / tpacMat.nAvg;
+
+            % Recompute max over all fA and fP pairs, saved in TF, and save corresponding frequencies (NestingFreq and NestedFreq).
+            % Ensure we have 4 dimensions
+            pacDims = size(tpacMat.sPAC.DirectPAC);
             if length(pacDims) < 4
-                % Ensure we have 4 dimensions
                 pacDims = [ones(1,4-length(pacDims)), pacDims];
-                pac = reshape(pac,pacDims);
+                tpacMat.sPAC.DirectPAC = reshape(tpacMat.sPAC.DirectPAC, pacDims);
             end
-            [nSources, nWindows, nLow, nHigh] = size(pac);
-            for iSource = 1:nSources
-                for iWindow = 1:nWindows
-                    curPac = pac(iSource,iWindow,:,:);
-                    [tmp, maxInd] = max(curPac(:));
-                    [indFa, indFp] = ind2sub([nLow, nHigh], maxInd);
-                    tpacMat.sPAC.NestingFreq(iSource,iWindow) = tpacMat.sPAC.LowFreqs(indFp);
-                    tpacMat.sPAC.NestedFreq(iSource,iWindow) = tpacMat.sPAC.HighFreqs(indFa);
-                end
-            end
+            [nSources, nWindows, nLow, nHigh] = size(tpacMat.sPAC.DirectPAC);
+            [tpacMat.sPAC.TF, maxInd] = max(tpacMat.sPAC.DirectPAC(:, :, :), 3); % max over all fA and fP pairs.
+            [iFp, iFa] = ind2sub([nLow, nHigh], maxInd); 
+            tpacMat.sPAC.NestingFreq = tpacMat.LowFreq(iFp);
+            tpacMat.sPAC.NestedFreq = tpacMat.HighFreqs(iFa);
             
-        elseif isfield(spac,'DynamicPAC')    
-            if usePhase
-                tpac = tpacMat.sPAC.DynamicPAC.*exp(1i*tpacMat.sPAC.DynamicPhase)/N;
-            else
-                tpac = tpacMat.sPAC.DynamicPAC/N;
-            end
-%             Nesting = tpacMat.sPAC.DynamicNesting;
-            for iFile = 2:N
-                tmp = in_bst_timefreq(sInput(iFile).FileName, 0);
-                if ~isequal(tmp.Time,tpacMat.Time) || ~isequal(tmp.sPAC.HighFreqs, tpacMat.sPAC.HighFreqs)
-                    Message = ['Format of file#',num2str(iFile),' does not match the first file'];
-                    bst_report('Error', 'process_pac_average', sInput, Message);
-                    return;
-                end 
-                if ~isequal(size(tpac,1), size(tmp.sPAC.DynamicPAC,1))
-                    Message = ['Number of sources in File #',num2str(iFile),' is not the same as previous files -- average on sources before averaging files'];
-                    bst_report('Error', 'process_pac_average', sInput, Message);
-                    return;
-                end 
-                if usePhase && isequal(size(tpac,1), size(tmp.sPAC.DynamicPhase,1))
-                    tpac = tpac + tmp.sPAC.DynamicPAC.*exp(1i*tmp.sPAC.DynamicPhase)/N;
-                elseif ~isequal(size(tpac,1), size(tmp.sPAC.DynamicPAC,1))                    
-                    Message = ['Number of sources for phase in File #',num2str(iFile),' is not the same as previous files -- You cannot use phase in averaging'];
-                    bst_report('Error', 'process_pac_average', sInput, Message);
-                    return;
-                else
-                    tpac = tpac + tmp.sPAC.DynamicPAC/N;
+        elseif isfield(tpacMat.sPAC, 'DynamicPAC')
+            % size is [nSignals, nTime, nHighFreqs, nTrials], 4th dim if "averaging"/concatenating was selected in process_pac_dynamic.
+            tpacMat.sPAC.DynamicPAC = zeros(size(tpacMat.sPAC.DynamicPAC));
+            tpacMat.nAvg = 0;
+            %             Nesting = tpacMat.sPAC.DynamicNesting;
+            for iFile = 1:N
+                if iFile > 1
+                    tpacIn = in_bst_timefreq(sInput(iFile).FileName, 0);
+                    if ~isequal(tpacIn.Time, tpacMat.Time) || ~isequal(tpacIn.sPAC.HighFreqs, tpacMat.sPAC.HighFreqs)
+                        Message = ['Format of file #',num2str(iFile),' does not match the first file'];
+                        bst_report('Error', 'process_pac_average', sInput, Message);
+                        tpacMat = [];
+                        return;
+                    elseif ~isequal(size(tpacIn.sPAC.DynamicPAC,1), size(tpacMat.sPAC.DynamicPAC,1))
+                        Message = ['Number of sources in file #',num2str(iFile),' is not the same as previous files -- average on sources before averaging files'];
+                        bst_report('Error', 'process_pac_average', sInput, Message);
+                        tpacMat = [];
+                        return;
+                    elseif usePhase && ~isequal(size(tpacIn.sPAC.DynamicPhase,1), size(tpacMat.sPAC.DynamicPhase,1))
+                        Message = ['Number of sources for phase in file #',num2str(iFile),' is not the same as previous files -- You cannot use phase in averaging'];
+                        bst_report('Error', 'process_pac_average', sInput, Message);
+                        tpacMat = [];
+                        return;
+                    end
                 end
-%                 Nesting = cat(5,Nesting,tmp.sPAC.DynamicNesting);
+                if usePhase
+                    tpacMat.sPAC.DynamicPAC = tpacMat.sPAC.DynamicPAC + sum(tpacIn.sPAC.DynamicPAC.*exp(1i*tpacIn.sPAC.DynamicPhase), 4);
+                else
+                    tpacMat.sPAC.DynamicPAC = tpacMat.sPAC.DynamicPAC + sum(tpacIn.sPAC.DynamicPAC, 4);
+                end
+                % Sum number of trials averaged. Double-check size to be safe in case of concatenated trials.
+                nTrials = size(tpacIn.sPAC.DynamicPAC, 4);
+                if isempty(tpacIn.nAvg) || (tpacIn.nAvg == 1 && nTrials > 1)
+                    tpacIn.nAvg = nTrials;
+                elseif tpacIn.nAvg ~= nTrials && nTrials > 1
+                    Message = sprintf('Unexpected number of averages in input file; nAvg=%d, nTrials=%d.  Using nTrials.', tpacMat.nAvg, nTrials);
+                    bst_report('Warning', 'process_pac_average', sInput, Message);
+                    tpacIn.nAvg = nTrials;
+                end
+                tpacMat.nAvg = tpacMat.nAvg + tpacIn.nAvg;
+                %                 Nesting = cat(5,Nesting,tmp.sPAC.DynamicNesting);
             end
-            tpacMat.sPAC.DynamicPAC = abs(tpac);
+            % Divide by total number of trials for average.
+            tpacMat.sPAC.DynamicPAC = tpacMat.sPAC.DynamicPAC / tpacMat.nAvg;
+
+            % Recompute max over fA across averaged tPAC, i.e. do max of mean, not mean of max.
+            % Careful: not same array dim order than where this happens in process_pac_dynamic.
+            [tpacMat.sPAC.TF, maxInd] = max(abs(tpacMat.sPAC.DynamicPAC), [], 3); 
+            tpacMat.sPAC.NestedFreq = HighFreqs(maxInd); % vector to 2d array.
+            tpacMat.sPAC.NestingFreq = []; % no longer meaningful.
+
             if usePhase
-                tpacMat.sPAC.PhasePAC = angle(tpac);
-                tpacMat.sPAC.DynamicPhase = angle(tpac);
+                tpacMat.sPAC.DynamicPhase = angle(tpacMat.sPAC.DynamicPAC);
+                tpacMat.sPAC.PhasePAC = tpacMat.sPAC.DynamicPhase(:,:,maxInd); % phase of TF (ValPAC)
+                % Go back to real values after phases extracted.
+                tpacMat.sPAC.DynamicPAC = abs(tpacMat.sPAC.DynamicPAC);
+            else
+                tpacMat.sPAC.PhasePAC = [];
+                tpacMat.sPAC.DynamicPhase = [];
             end
-            tpacMat.sPAC.DynamicNesting = [];%Nesting;
+            % Averaged PAC over different fP's, so fP no longer meaningful; don't average it.
+            tpacMat.sPAC.DynamicNesting = []; 
             FileTag = 'timefreq_dpac_fullmaps';
-        end                
+
+        else
+            Message = 'Unknown file type, not recognized as PAC.';
+            bst_report('Error', 'process_pac_average', sInput, Message);
+            tpacMat = [];
+            return;
+        end
 end
 
 
 
-function OutputFiles = save_pac_files(sProcess, sInput, FileTag, tag, tpacMat, isAvgFile)
+function OutputFiles = save_pac_files(sProcess, sInput, FileTag, tpacMat)
     % === SAVING THE DATA IN BRAINSTORM ===
     % Getting the study
     [sOutputStudy, iOutputStudy, comment, uniqueDataFile] = bst_process('GetOutputStudy', sProcess, sInput);
 
     % Comment
+    tag = '| avg';
     tpacMat.Comment = [tpacMat.Comment, ' ', tag];
 
     % Preparing the output file
     OutputFiles{1} = bst_process('GetNewFilename', bst_fileparts(sOutputStudy.FileName), FileTag); 
-    OutputFiles{1} = file_unique(OutputFiles{1});
 
-    if isAvgFile
-        % Averaging results from the different data file: reset the "DataFile" field
-        if isfield(tpacMat, 'DataFile') && ~isempty(tpacMat.DataFile) && (length(uniqueDataFile) ~= 1)
-            tpacMat.DataFile = [];
-        end
-
+    % Averaging results from the different data file: reset the "DataFile" field
+    if isfield(tpacMat, 'DataFile') && ~isempty(tpacMat.DataFile) && (length(uniqueDataFile) ~= 1)
+        tpacMat.DataFile = [];
     end
 
     % Save on disk
     bst_save(OutputFiles{1}, tpacMat, 'v6');
     % Register in database
     db_add_data(iOutputStudy, OutputFiles{1}, tpacMat);
-
 end

--- a/toolbox/process/functions/process_pac_dynamic.m
+++ b/toolbox/process/functions/process_pac_dynamic.m
@@ -38,7 +38,6 @@ function varargout = process_pac_dynamic( varargin )
 %   - 1.1.4:  Soheila, (isFull) display is fixed - Line 175, also comment is modified in save file section, June 2016
 %   - 1.2.0:  Soheila, optimizing in terms of running time with decreasing
 %             loop over time, July 2016
-%
 %   - 2.0.1: Soheila : MAJOR CHANGES (Oct. 2016)
 %                - Loop on Fa before time => faster + Less edge artifact
 %                - Filters bandwidth and stop band: modified
@@ -49,31 +48,24 @@ function varargout = process_pac_dynamic( varargin )
 %                - Detection of Fp => Not multiplied by normalizing vector
 %                  but check if any peak available in PSD of original 
 %                  signal close by
-%                  
 %   - 2.1.0: SS, Nov. 2016
 %                - Filters are all updated to new filters in Brainstorm
 %                  (bst_bandpass_hfilter)
 %   - 2.1.1: SS, Dec. 2016
 %                - Improve in confirmation of fp* selected in the algorithm
-%
 %   - 2.2.0: SS, Dec. 2016
 %                - Complete saving of phase info.
-%
 %   - 2.3.0: SS. Dec. 2016
 %                - Adding the possibility of importing data with margin
 %                included in it
-%
 %   - 2.3.1: SS. Feb. 2017
 %                - Number of points for Fourier transform is changed
-%
 %   - 2.3.2: SS. May. 2017
 %                - Add one point to the beginning and the end fp of interest 
 %                in the spectrum for better estimation of local extermum in 
 %                fp* detection  (line 830)
-%
 %   - 2.4: SS. Aug. 2017 
 %                - "dpac" name changed to "tPAC"
-%   
 %   - 2.5: SS. Aug. 2018: Bug fix
 %                - Adding TimeInit for files with "all recording" option
 %                checked
@@ -90,7 +82,7 @@ end
 %% ===== GET DESCRIPTION =====
 function sProcess = GetDescription() %#ok<DEFNU>
     % Description the process
-    sProcess.Comment     = 'tPAC ';
+    sProcess.Comment     = 'tPAC';
     sProcess.FileTag     = '';
     sProcess.Category    = 'Custom';
     sProcess.SubGroup    = {'Frequency','Time-resolved Phase-Amplitude Coupling'};
@@ -100,6 +92,7 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.OutputTypes = {'timefreq', 'timefreq', 'timefreq', 'timefreq'};
     sProcess.nInputs     = 1;
     sProcess.nMinFiles   = 1;
+    sProcess.Description = 'https://neuroimage.usc.edu/brainstorm/Tutorials/TutPac#Time-resolved_PAC_estimation_with_tPAC';
 
     % === TIME WINDOW
     sProcess.options.timewindow.Comment = 'Time:';
@@ -130,7 +123,7 @@ function sProcess = GetDescription() %#ok<DEFNU>
 %                                         '   More than one center frequencies (default: 20)' };
 %     sProcess.options.fa_type.Type    = 'radio';
 %     sProcess.options.fa_type.Value   = 2;
-
+ 
     % === FREQ RESOLUTION FOR FREQ-FOR-AMPLITUDE
     sProcess.options.fAResolution.Comment = 'Frequency resolution for frequency for amplitude:';
     sProcess.options.fAResolution.Type    = 'value';
@@ -829,17 +822,13 @@ end
 % Max PAC across fA
 % PAC size is [nFreq, nTime, nChannel], but we output these max fields with nChannel first.
 [PACmax,maxInd] = max(abs(PAC),[],1); 
-% Fnested  = squeeze(nestedCenters(maxInd))';
-% Sind     = repmat((1:nSources), nTime, 1);           % Source indices
-% Tind     = repmat((1:nTime)', 1, nSources);              % Time indices
-% linInd   = sub2ind(size(PAC),maxInd(:),Tind(:),Sind(:));
-% Fnesting = reshape(nestingFreq(linInd),nTime,nSources)';
-% phase_value    = reshape(angle(PAC(maxInd,:,:)),nTime,nSources)';
-% PACmax   = squeeze(PACmax)';
-Fnested  = permute(nestedCenters(maxInd), [3, 2, 1]); % vector to 3d array, then permute.
-Fnesting = permute(nestingFreq(maxInd,:,:), [3, 2, 1]);
-phase_value = permute(angle(PAC(maxInd,:,:)), [3, 2, 1]);
-PACmax   = permute(PACmax, [3, 2, 1]);
+Fnested  = squeeze(nestedCenters(maxInd))';
+Sind     = repmat((1:nSources), nTime, 1);           % Source indices
+Tind     = repmat((1:nTime)', 1, nSources);              % Time indices
+linInd   = sub2ind(size(PAC),maxInd(:),Tind(:),Sind(:));
+Fnesting = reshape(nestingFreq(linInd),nTime,nSources)';
+phase_value    = reshape(angle(PAC(linInd)),nTime,nSources)';
+PACmax   = squeeze(PACmax)';
 
 % ===== Interpolation in time domain for smoothing the results ==== %
 if doInterpolation


### PR DESCRIPTION
Fixes several PAC averaging bugs, some recently reported on the forums: [1](https://neuroimage.usc.edu/forums/t/error-in-averaging-pac-comodulogram-from-different-subjects/39997), [2](https://neuroimage.usc.edu/forums/t/problem-with-subject-averaging-in-time-resolved-pac/39967)

Also: hide the tPAC option for 2-seconds buffer (as discussed with @sbaillet), fix GUI typo for seconds, and added checks and error messages for consistency between files when averaging (frequency lists and array sizes).

While this fixes bugs in the averaging process, this is not the recommended way to aggregate tPAC across trials since the saved values are already "peak" values in fP.  It remains to discuss if the "average" option of the tPAC process should be improved.  It currently concatenates the "full" arrays (DynamicPAC field) - currently inconsistent with visualization (only displays first trial), while averaging the max values (TF field).
