### PR TITLE
Bugfix megreg

### DIFF
--- a/toolbox/process/functions/process_megreg.m
+++ b/toolbox/process/functions/process_megreg.m
@@ -170,7 +170,12 @@ function [OutputFiles, maxDist] = Run(sProcess, sInputs) %#ok<DEFNU>
     elseif ~isModifData
         bst_report('Info', sProcess, sInputs, 'All the channel files are equivalent. No modification will be performed on the data files.');
     end
-    
+    % Do not allow shared channel for raw data files
+    if isShareChan && any(strcmpi({sInputs.FileType}, 'raw'))
+        bst_report('Error', sProcess, [], 'Raw files should not use shared channel as all projectors from pre-processing will be lost');
+        return;
+    end
+
     
     %% ===== COMPUTE TRANSFORMATION =====
     % Base: first channel file in the list
@@ -244,18 +249,18 @@ function [OutputFiles, maxDist] = Run(sProcess, sInputs) %#ok<DEFNU>
         % return;
     end
     % Combine SSP from all the files
-    if isShareChan
-        Projector = [];
-        for iFile = 1:length(ChannelMats)
-            if isfield(ChannelMats{iFile}, 'Projector') && ~isempty(ChannelMats{iFile}.Projector)
-                if isempty(Projector)
-                    Projector = ChannelMats{iFile};
-                else
-                    bst_report('Warning', sProcess, sInputs, 'Ignoring Projector matrix (SSP and ICA). Using only the one from the first channel file.');
-                end
-            end
-        end
-    end
+%     if isShareChan
+%         Projector = [];
+%         for iFile = 1:length(ChannelMats)
+%             if isfield(ChannelMats{iFile}, 'Projector') && ~isempty(ChannelMats{iFile}.Projector)
+%                 if isempty(Projector)
+%                     Projector = ChannelMats{iFile};
+%                 else
+%                     bst_report('Warning', sProcess, sInputs, 'Ignoring Projector matrix (SSP and ICA). Using only the one from the first channel file.');
+%                 end
+%             end
+%         end
+%     end
     
     
     %% ===== UPDATE CHANNEL FILES =====

--- a/toolbox/process/functions/process_megreg.m
+++ b/toolbox/process/functions/process_megreg.m
@@ -61,9 +61,11 @@ function sProcess = GetDescription() %#ok<DEFNU>
     % === SHARE CHANNEL FILE
     sProcess.options.label2.Type    = 'label';
     sProcess.options.label2.Comment = '<BR>Use default channel file :';
+    sProcess.options.label2.InputTypes   = {'data'};
     sProcess.options.sharechan.Comment = {'Yes, share the same channel file between runs', 'No, do not modify the database organization (recommended)'};
     sProcess.options.sharechan.Type    = 'radio';
     sProcess.options.sharechan.Value   = 2;
+    sProcess.options.sharechan.InputTypes   = {'data'};
     % === EPSILON 
     sProcess.options.label3.Type    = 'label';
     sProcess.options.label3.Comment = ' ';

--- a/toolbox/process/functions/process_megreg.m
+++ b/toolbox/process/functions/process_megreg.m
@@ -174,7 +174,7 @@ function [OutputFiles, maxDist] = Run(sProcess, sInputs) %#ok<DEFNU>
     end
     % Do not allow shared channel for raw data files
     if isShareChan && any(strcmpi({sInputs.FileType}, 'raw'))
-        bst_report('Error', sProcess, [], 'Raw files should not use shared channel as all projectors from pre-processing will be lost');
+        bst_report('Error', sProcess, [], 'Shared channel file not currently supported for interpolating raw files');
         return;
     end
 

--- a/toolbox/process/functions/process_megreg.m
+++ b/toolbox/process/functions/process_megreg.m
@@ -180,6 +180,8 @@ function [OutputFiles, maxDist] = Run(sProcess, sInputs) %#ok<DEFNU>
     %% ===== COMPUTE TRANSFORMATION =====
     % Base: first channel file in the list
     AvgChannelMat = ChannelMats{1};
+    % Remove projectors from average channel
+    isAvgChan = rmfield(isAvgChan, 'Projector');
     % Compute average channel structure (include ALL the sensor types)
     if isAvgChan && ~all(isChanEqual)
         [AvgChannelMat, Message] = channel_average(ChannelMats);


### PR DESCRIPTION
This PR originated from the forum question: https://neuroimage.usc.edu/forums/t//40145 and offline discussions with @Moo-Marc. These are the changes:

- Do not allow to have a channel shared for raw files, as this action will delete all the previous projectors from those raw files

- The `Projector` field is removed from the average channel structure that is saved only using the options "shared channel" and "non-raw" files.


