### PR TITLE
extract scouts bugfix: result without datafile

### DIFF
--- a/toolbox/io/in_bst.m
+++ b/toolbox/io/in_bst.m
@@ -278,6 +278,20 @@ switch(fileType)
     case 'headmodel'
         sMatrix = in_bst_headmodel(FileName);
         matName = 'Gain';
+
+    case 'unknown'
+        if isempty(FileName)
+            disp('BST> Warning: No file provided.');
+        else
+            disp('BST> Error: Unknown file type.');
+        end
+        sMatrix = [];
+        matName = '';
+        
+    otherwise
+        disp('BST> Error: Unrecognized file type.');
+        sMatrix = [];
+        matName = '';
 end
 end
 

--- a/toolbox/process/functions/process_extract_scout.m
+++ b/toolbox/process/functions/process_extract_scout.m
@@ -646,8 +646,12 @@ function [sResults, matSourceValues, matDataValues, fileComment] = LoadFile(sPro
             % Load results
             sResults = in_bst_results(sInputs(iInput).FileName, 0);
             % Always load data file to recover its comment. Necessary for matrix to be identifiable in tree.
-            sMat = in_bst(sResults.DataFile, TimeWindow);
-            if ~isempty(sMat.Comment)
+            if ~isempty(sResults.DataFile)
+                sMat = in_bst(sResults.DataFile, TimeWindow);
+            else
+                sMat = [];
+            end
+            if ~isempty(sMat) && ~isempty(sMat.Comment)
                 sResults.Comment = sMat.Comment;
             end
             % FULL RESULTS
@@ -659,12 +663,16 @@ function [sResults, matSourceValues, matDataValues, fileComment] = LoadFile(sPro
                 sResults = rmfield(sResults, 'ImageGridAmp');
             % KERNEL ONLY
             elseif isfield(sResults, 'ImagingKernel') && ~isempty(sResults.ImagingKernel) && nargout > 1
-                matDataValues = sMat.F;
+                if isempty(sMat)
+                    bst_report('Warning', sProcess, sInputs(iInput), 'Inverse kernel without associated data file.');
+                else
+                    matDataValues = sMat.F;
+                end
                 % sResults already has a copy of the sMat (data file) fields: Time, nAvg, Leff, ChannelFlag.
                 matSourceValues = [];
             end
             % Keep both data file and inverse model histories, but only if not previously done, e.g. with temporary flattened result files.
-            if isempty(sMat.History) || isempty(sResults.History) || ~isequal(sMat.History{1}, sResults.History{1})
+            if ~isempty(sMat) && ~isempty(sMat.History) && (isempty(sResults.History) || ~isequal(sMat.History{1}, sResults.History{1}))
                 sResults.History = cat(1, sMat.History, sResults.History);
             end
             % Input filename


### PR DESCRIPTION
Fix for recent changes associated with PCA.  Bug reported on forum: https://neuroimage.usc.edu/forums/t/statistical-source-analysis-problem-relative-to-smatrix-and-in-bst-function/40699
Issue was related to some result files no longer having an associated data file, e.g. template projected maps.