### PR TITLE
don't flip y-axis by default for NIRS

### DIFF
--- a/toolbox/gui/view_timeseries.m
+++ b/toolbox/gui/view_timeseries.m
@@ -220,7 +220,7 @@ if isNewFig
     TsInfo.MontageName   = [];
     TsInfo.DefaultFactor = figure_timeseries('GetDefaultFactor', Modality);
     TsInfo.DisplayUnits  = GlobalData.DataSet(iDS).Measures.DisplayUnits;
-    TsInfo.FlipYAxis     = ~isempty(Modality) && ismember(Modality, {'EEG','MEG','MEG GRAD','MEG MAG','SEEG','ECOG','NIRS'}) && ~isStat && bst_get('FlipYAxis');
+    TsInfo.FlipYAxis     = ~isempty(Modality) && ismember(Modality, {'EEG','MEG','MEG GRAD','MEG MAG','SEEG','ECOG'}) && ~isStat && bst_get('FlipYAxis');
     TsInfo.AutoScaleY    = bst_get('AutoScaleY');
     TsInfo.NormalizeAmp  = 0;
     TsInfo.Resolution    = [0 0];


### PR DESCRIPTION
Just a small change of the default behavior for nirs where we don't usually want the y-axis to be flipped :) 