### PR TITLE
Add a replacement font to Courier New

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -3920,7 +3920,7 @@ switch contextName
         % Font types
         fontTypes = {};
         if (nargin >= 3)
-            fontTypes{end + 1} = varargin{3};
+            fontTypes = varargin{3};
         else
             fontTypes{end + 1} = 'Arial';            % Default font
             fontTypes{end + 1} = 'Liberation Sans';  % Free Arial substitute

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -3920,7 +3920,11 @@ switch contextName
         % Font types
         fontTypes = {};
         if (nargin >= 3)
-            fontTypes = varargin{3};
+            if ischar(varargin{3})
+                fontTypes = varargin(3);
+            else
+                fontTypes = varargin{3};
+            end
         else
             fontTypes{end + 1} = 'Arial';            % Default font
             fontTypes{end + 1} = 'Liberation Sans';  % Free Arial substitute

--- a/toolbox/gui/view_text.m
+++ b/toolbox/gui/view_text.m
@@ -69,7 +69,7 @@ jTextArea = java_create('javax.swing.JTextArea', 'Ljava.lang.String;', wndText);
 jTextArea.setEditable(0);
 jTextArea.setBackground(Color(1,1,1));
 jTextArea.setMargin(java_create('java.awt.Insets', 'IIII', 10,25,10,25));
-jTextArea.setFont(bst_get('Font', 12, {'Courier New';'Ubuntu Mono'}));
+jTextArea.setFont(bst_get('Font', 12, {'Courier New', 'Ubuntu Mono', 'Monospaced'}));
 jFrame.getContentPane.add(JScrollPane(jTextArea));
 
 % Add OK button if need to wait

--- a/toolbox/gui/view_text.m
+++ b/toolbox/gui/view_text.m
@@ -69,7 +69,7 @@ jTextArea = java_create('javax.swing.JTextArea', 'Ljava.lang.String;', wndText);
 jTextArea.setEditable(0);
 jTextArea.setBackground(Color(1,1,1));
 jTextArea.setMargin(java_create('java.awt.Insets', 'IIII', 10,25,10,25));
-jTextArea.setFont(bst_get('Font', 12, 'Courier New'));
+jTextArea.setFont(bst_get('Font', 12, {'Courier New';'Ubuntu Mono'}));
 jFrame.getContentPane.add(JScrollPane(jTextArea));
 
 % Add OK button if need to wait


### PR DESCRIPTION
Continuation of https://github.com/brainstorm-tools/brainstorm3/commit/2163f7ed20461aebc10a4d267aecc1e26570fc79 

It seems I don't have Courier new available on my version of Ubuntu. 

Otherwise, I like 'Noto Sans Mono SemiCondensed Light'. Ubuntu mono has a weird letter for 'w'
