### PR TITLE
Export ROI as Freesurfer annotation

### DIFF
--- a/external/freesurfer/write_annotation.m
+++ b/external/freesurfer/write_annotation.m
@@ -1,0 +1,150 @@
+% Contact ythomas@csail.mit.edu or msabuncu@csail.mit.edu for bugs or questions 
+%
+%=========================================================================
+%
+%  Copyright (c) 2008 Thomas Yeo and Mert Sabuncu
+%  All rights reserved.
+%
+%Redistribution and use in source and binary forms, with or without
+%modification, are permitted provided that the following conditions are met:
+%
+%    * Redistributions of source code must retain the above copyright notice,
+%      this list of conditions and the following disclaimer.
+%
+%    * Redistributions in binary form must reproduce the above copyright notice,
+%      this list of conditions and the following disclaimer in the documentation
+%      and/or other materials provided with the distribution.
+%
+%    * Neither the names of the copyright holders nor the names of future
+%      contributors may be used to endorse or promote products derived from this
+%      software without specific prior written permission.
+%
+%THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+%ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+%WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+%DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+%ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+%(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+%LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+%ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+%(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+%SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.    
+%
+%=========================================================================
+function write_annotation(filename, vertices, label, ct)
+
+% write_annotation(filename, vertices, label, ct)
+%
+% Only writes version 2...
+%
+% vertices expected to be simply from 0 to number of vertices - 1;
+% label is the vector of annotation
+%
+% ct is a struct
+% ct.numEntries = number of Entries
+% ct.orig_tab = name of original ct
+% ct.struct_names = list of structure names (e.g. central sulcus and so on)
+% ct.table = n x 5 matrix. 1st column is r, 2nd column is g, 3rd column
+% is b, 4th column is transparency (1 - alpha), 5th column is resultant integer
+% values calculated from r + g*2^8 + b*2^16.
+
+fp = fopen(filename, 'w', 'b');
+
+% first write vertices and label
+
+count = fwrite(fp, int32(length(label)), 'int');
+if(count~=1)
+   error('write_annotation: Writing #vertices/labels not successful!!');
+end
+
+temp = zeros(length(label)*2,1);
+temp(1:2:end) = vertices;
+temp(2:2:end) = label;
+temp = int32(temp);
+
+count = fwrite(fp, int32(temp), 'int');
+if(count~=length(temp))
+   error('write_annotation: Writing labels/vertices not successful!!');
+end
+
+%Write that ct exists
+count = fwrite(fp, int32(1), 'int');
+if(count~=1)
+   error('write_annotation: Unable to write flag that ct exists!!');
+end
+
+%write version number
+count = fwrite(fp, int32(-2), 'int');
+if(count~=1)
+    error('write_annotation: Unable to write version number!!');
+end
+
+%write number of entries
+count = fwrite(fp, int32(ct.numEntries), 'int');
+if(count~=1)
+    error('write_annotation: Unable to write number of entries in ct!!');
+end
+
+%write original table
+orig_tab = [ct.orig_tab char(0)];
+count = fwrite(fp, int32(length(orig_tab)), 'int');
+if(count~=1)
+    error('write_annotation: Unable to write length of ct source!!');
+end
+
+count = fwrite(fp, orig_tab, 'char');
+if(count~=length(orig_tab))
+    error('write_annotation: Unable to write orig_tab!!');
+end
+
+%write number of entries
+count = fwrite(fp, int32(ct.numEntries), 'int');
+if(count~=1)
+    error('write_annotation: Unable to write number of entries in ct!!');
+end
+
+%write ct
+for i = 1:ct.numEntries
+    count = fwrite(fp, int32(i-1), 'int');
+    if(count~=1)
+        error('write_annotation: Unable to write structure number!!');
+    end
+    
+    structure_name = [ct.struct_names{i} char(0)];
+    count = fwrite(fp, int32(length(structure_name)), 'int');
+    if(count~=1)
+        error('write_annotation: Unable to write length of structure name!!');
+    end
+    count = fwrite(fp, structure_name, 'char');
+    if(count~=length(structure_name))
+        error('write_annotation: Unable to write structure name!!');
+    end
+    
+    count = fwrite(fp, int32(ct.table(i, 1)), 'int');
+    if(count~=1)
+       error('write_annotation: Unable to write red color'); 
+    end
+    
+    count = fwrite(fp, int32(ct.table(i, 2)), 'int');
+    if(count~=1)
+       error('write_annotation: Unable to write blue color'); 
+    end
+    
+    count = fwrite(fp, int32(ct.table(i, 3)), 'int');
+    if(count~=1)
+       error('write_annotation: Unable to write green color'); 
+    end
+    
+    count = fwrite(fp, int32(ct.table(i, 4)), 'int');
+    if(count~=1)
+       error('write_annotation: Unable to write transparency');
+    end 
+    
+end
+
+fclose(fp);
+
+
+
+
+

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -5321,7 +5321,7 @@ function SaveScouts(varargin)
             if length(sScouts) == 1
              out_label_fs(ScoutFile, sScouts.Label, sScouts.Vertices - 1, sSurf.Vertices(sScouts.Vertices,:), ones(1, length(sScouts.Vertices)));
             else
-              bst_error('FreeSurfer label file corresponds can only store a single ROI. Please export each label separatly');
+              bst_error('FreeSurfer label file can only store a single ROI. Please export each label separatly');
               return;
             end
     end

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -5357,6 +5357,30 @@ function SaveScouts(varargin)
                     end
                 end
             end
+            % Check again for unique colors, if duplicate colors get random RGB
+            [C,ia,ic] = unique(cat(1, sScouts.Color), 'rows');
+            if length(C) ~= length(sScouts)
+                % Find indexes of duplicate colors
+                repIxs = [];
+                for iia = 1 : length(ia)
+                    rep = find(ic == ic(ia(iia)));
+                    if length(rep) > 1
+                        repIxs = [repIxs, rep(2:end)];
+                    end
+                end
+                % Get a unique random color for each duplicate color
+                colorsRnd = [];
+                while size(colorsRnd, 1) < length(repIxs)
+                     colorRnd = randi(256, 1, 3) - 1;
+                     if ~ismember(colorRnd, C)
+                         C = [C; colorRnd];
+                         colorsRnd = [colorsRnd; colorRnd];
+                     end
+                end
+                for ix = 1 : length(repIxs)
+                    sScouts(repIxs(ix)).Color = colorsRnd(ix, :);
+                end
+            end
 
             for iScout = 1:length(sScouts)
                 ct.table(iScout,1:3) = sScouts(iScout).Color;

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -5300,7 +5300,8 @@ function SaveScouts(varargin)
     [ScoutFile, FileFormat] = java_getfile('save', 'Save selected scouts', ScoutFile, ... 
                              'single', 'files', ...
                              {{'_scout'}, 'Brainstorm cortical scouts (*scout*.mat)', 'BST'; ...
-                              {'.label'}, 'FreeSurfer ROI, single scout (*.label)', 'FS-LABEL-SINGLE'}, 1);
+                              {'.label'}, 'FreeSurfer ROI, single scout (*.label)', 'FS-LABEL-SINGLE'; ...
+                              {'.annot'}, 'FreeSurfer annotation, multiple scout(*.annot)', 'FS-ANNOT'}, 1);
     if isempty(ScoutFile)
         return;
     end
@@ -5321,9 +5322,26 @@ function SaveScouts(varargin)
             if length(sScouts) == 1
              out_label_fs(ScoutFile, sScouts.Label, sScouts.Vertices - 1, sSurf.Vertices(sScouts.Vertices,:), ones(1, length(sScouts.Vertices)));
             else
-              bst_error('FreeSurfer label file can only store a single ROI. Please export each label separatly');
+              bst_error('FreeSurfer label file can only store a single scout. Please export each scout separatly');
               return;
             end
+        case 'FS-ANNOT'
+            vertices = [];
+            label = [];
+            ct = struct();
+            ct.numEntries = length(sScouts);
+            ct.orig_tab   = sAtlas.Name;
+            ct.struct_names  = {sScouts.Label};
+            ct.table = zeros(length(sScouts),5);
+
+            for iScout = 1:length(sScouts)
+                vertices = [vertices , sScouts(iScout).Vertices - 1];
+                ct.table(iScout,1:3) = round(sScouts(iScout).Color * 255);
+                
+                ct.table(iScout,5) = ct.table(iScout,1)  + ct.table(iScout,2) *2^8 + ct.table(iScout,3) *2^16;
+                label    = [label , ct.table(iScout,5)*ones(1, length(sScouts(iScout).Vertices))];
+            end
+            write_annotation(ScoutFile, vertices, label, ct)
     end
 end
 

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -5301,7 +5301,7 @@ function SaveScouts(varargin)
                              'single', 'files', ...
                              {{'_scout'}, 'Brainstorm cortical scouts (*scout*.mat)', 'BST'; ...
                               {'.label'}, 'FreeSurfer ROI, single scout (*.label)', 'FS-LABEL-SINGLE'; ...
-                              {'.annot'}, 'FreeSurfer annotation, multiple scout(*.annot)', 'FS-ANNOT'}, 1);
+                              {'.annot'}, 'FreeSurfer annotation, multiple scouts (*.annot)', 'FS-ANNOT'}, 1);
     if isempty(ScoutFile)
         return;
     end
@@ -5320,10 +5320,10 @@ function SaveScouts(varargin)
             bst_save(ScoutFile, sAtlas, 'v7');
         case 'FS-LABEL-SINGLE'
             if length(sScouts) == 1
-             out_label_fs(ScoutFile, sScouts.Label, sScouts.Vertices - 1, sSurf.Vertices(sScouts.Vertices,:), ones(1, length(sScouts.Vertices)));
+                out_label_fs(ScoutFile, sScouts.Label, sScouts.Vertices - 1, sSurf.Vertices(sScouts.Vertices,:), ones(1, length(sScouts.Vertices)));
             else
-              bst_error('FreeSurfer label file can only store a single scout. Please export each scout separatly');
-              return;
+                bst_error('FreeSurfer label file can only store a single scout. Please export each scout separatly');
+                return;
             end
         case 'FS-ANNOT'
             vertices = [];

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -5318,7 +5318,12 @@ function SaveScouts(varargin)
             % Save file
             bst_save(ScoutFile, sAtlas, 'v7');
         case 'FS-LABEL-SINGLE'
-            out_label_fs(ScoutFile, sScouts.Label, sScouts.Vertices - 1, sSurf.Vertices(sScouts.Vertices,:), ones(1, length(sScouts.Vertices)));
+            if length(sScouts) == 1
+             out_label_fs(ScoutFile, sScouts.Label, sScouts.Vertices - 1, sSurf.Vertices(sScouts.Vertices,:), ones(1, length(sScouts.Vertices)));
+            else
+              bst_error('FreeSurfer label file corresponds can only store a single ROI. Please export each label separatly');
+              return;
+            end
     end
 end
 

--- a/toolbox/io/import_label.m
+++ b/toolbox/io/import_label.m
@@ -197,7 +197,7 @@ for iFile = 1:length(LabelFiles)
 
             % === CONVERT TO SCOUTS ===
             % Convert to scouts structures
-            lablist = colortable.table(:,5);
+            lablist = unique(labels);
             % Loop on each label
             for i = 1:length(lablist)
                 % Find entry in the colortable

--- a/toolbox/io/import_label.m
+++ b/toolbox/io/import_label.m
@@ -182,18 +182,14 @@ for iFile = 1:length(LabelFiles)
         % ===== FREESURFER ANNOT =====
         case 'FS-ANNOT'
             % === READ FILE ===
-            % Read label file
+            % Read .annot file
+            % Number of labels (and vertices) in annot file can be different from number of vertices in surface
             try
                 [vertices, labels, colortable] = read_annotation(LabelFiles{iFile}, 0);
             catch
                 Messages = [Messages, sprintf('%s: read_annotation crashed: %s\n', [fBase, fExt], lasterr)];
                 continue
             end
-            % Check sizes
-%             if (length(labels) ~= length(Vertices))
-%                 Messages = [Messages, sprintf('%s: Number of vertices in the surface (%d) and the label file (%d) do not match.\n', [fBase, fExt], length(Vertices), length(labels))];
-%                 continue
-%             end
 
             % === CONVERT TO SCOUTS ===
             % Convert to scouts structures

--- a/toolbox/io/import_label.m
+++ b/toolbox/io/import_label.m
@@ -190,14 +190,14 @@ for iFile = 1:length(LabelFiles)
                 continue
             end
             % Check sizes
-            if (length(labels) ~= length(Vertices))
-                Messages = [Messages, sprintf('%s: Number of vertices in the surface (%d) and the label file (%d) do not match.\n', [fBase, fExt], length(Vertices), length(labels))];
-                continue
-            end
+%             if (length(labels) ~= length(Vertices))
+%                 Messages = [Messages, sprintf('%s: Number of vertices in the surface (%d) and the label file (%d) do not match.\n', [fBase, fExt], length(Vertices), length(labels))];
+%                 continue
+%             end
 
             % === CONVERT TO SCOUTS ===
             % Convert to scouts structures
-            lablist = unique(labels);
+            lablist = colortable.table(:,5);
             % Loop on each label
             for i = 1:length(lablist)
                 % Find entry in the colortable
@@ -208,7 +208,7 @@ for iFile = 1:length(LabelFiles)
                 end             
                 % New scout index
                 iScout = length(sAtlas.Scouts) + 1;
-                sAtlas.Scouts(iScout).Vertices = find(labels == lablist(i))';
+                sAtlas.Scouts(iScout).Vertices = 1 + vertices(labels == lablist(i))';
                 if ~isempty(colortable.struct_names{iTable})
                     % Strip uselss parts of Schaeffer labels
                     Label = colortable.struct_names{iTable};


### PR DESCRIPTION
This PR is doing three things : 
- Give a better error when trying to export multiple ROI using FreeSurfer label format (that only support on ROI per file)
https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles

- Export multiple ROI as annotation files   https://surfer.nmr.mgh.harvard.edu/fswiki/AnnotFiles 
- Fix a small bug in the reading of annotation file  https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotationfiledesignsurprise

