### PR TITLE
fix topography (NIRS)

### DIFF
--- a/toolbox/core/bst_figures.m
+++ b/toolbox/core/bst_figures.m
@@ -1362,6 +1362,10 @@ function hNewFig = CloneFigure(hFig)
             GlobalData.DataSet(iDS).Figure(iNewFig).Handles.Wmat        = GlobalData.DataSet(iDS).Figure(iFig).Handles.Wmat;
             GlobalData.DataSet(iDS).Figure(iNewFig).Handles.DataMinMax  = GlobalData.DataSet(iDS).Figure(iFig).Handles.DataMinMax;
         end
+        % 2DDisc: Set white background
+        if strcmpi(FigureId.Type, 'Topography') && strcmpi(FigureId.SubType, '2DDisc')
+            SetBackgroundColor(hNewFig, [1 1 1]);
+        end
         % Delete scouts
         delete(findobj(hNewAxes, 'Tag', 'ScoutLabel'));
         delete(findobj(hNewAxes, 'Tag', 'ScoutMarker'));

--- a/toolbox/core/bst_figures.m
+++ b/toolbox/core/bst_figures.m
@@ -1388,6 +1388,10 @@ function hNewFig = CloneFigure(hFig)
         end
         % Update Surfaces panel
         panel_surface('UpdatePanel');
+        % Reload figure to apply montage (Topology NIRS)
+        if strcmpi(FigureId.Type, 'Topography') && strcmpi(FigureId.Modality, 'NIRS')
+            ReloadFigures(hNewFig, 0);
+        end
         
     % ===== TIME SERIES =====
     elseif strcmpi(FigureId.Type, 'DataTimeSeries')

--- a/toolbox/core/bst_figures.m
+++ b/toolbox/core/bst_figures.m
@@ -1372,7 +1372,7 @@ function hNewFig = CloneFigure(hFig)
         delete(findobj(hNewAxes, 'Tag', 'ScoutPatch'));
         delete(findobj(hNewAxes, 'Tag', 'ScoutContour'));
         % Update current figure selection
-        if strcmpi(FigureId.Type, '3DViz') || strcmpi(FigureId.SubType, '3DSensorCap')
+        if strcmpi(FigureId.Type, '3DViz') || strcmpi(FigureId.SubType, '3DSensorCap') || strcmpi(FigureId.SubType, '3DOptodes')
             SetCurrentFigure(hNewFig, '3D');
         else
             SetCurrentFigure(hNewFig);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -581,7 +581,7 @@ function FigureMouseUpCallback(hFig, varargin)
     % Update figure selection
     if strcmpi(Figure.Id.Type, '3DViz')
         bst_figures('SetCurrentFigure', hFig, '3D');
-    elseif ismember(Figure.Id.SubType, {'3DSensorCap', '3DElectrodes'})
+    elseif ismember(Figure.Id.SubType, {'3DSensorCap', '3DElectrodes', '3DOptodes'})
         bst_figures('SetCurrentFigure', hFig, '3D');
         bst_figures('SetCurrentFigure', hFig, '2D');
     else

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2048,6 +2048,10 @@ function UpdateSurfaceColormap(hFig, iSurfaces)
     end
     
     % ===== CONFIGURE COLORBAR =====
+    % DataType for 3D topography with surface
+    if (length(iSurfaces) == 1) && isempty(TessInfo.DataSource.Type) && isempty(TessInfo.ColormapType)
+        DataType = upper(ColormapInfo.Type);
+    end
     % Display only one colorbar (preferentially the results colorbar)
     if ~isempty(ColormapInfo.Type)
         bst_colormaps('ConfigureColorbar', hFig, ColormapInfo.Type, DataType, ColormapInfo.DisplayUnits);

--- a/toolbox/math/bst_getunits.m
+++ b/toolbox/math/bst_getunits.m
@@ -40,6 +40,12 @@ if (nargin < 4) || isempty(DisplayUnits)
     DisplayUnits = [];
 end
 
+% If no modality (ex: surface mask, mri values...)
+if (nargin < 3) || isempty(DataType)
+    DataType = 'none';
+end
+
+
 % Check if there is something special in the filename
 if (nargin >= 3) && ~isempty(FileName)
     % Source files
@@ -56,10 +62,7 @@ end
 
 % Consider input data in absolute value
 val = abs(val);
-% If no modality (ex: surface mask, mri values...)
-if isempty(DataType)
-    DataType = 'none';
-end
+
 
 % If the display unit is already defined
 if ~isempty(DisplayUnits)

--- a/toolbox/math/bst_getunits.m
+++ b/toolbox/math/bst_getunits.m
@@ -40,12 +40,6 @@ if (nargin < 4) || isempty(DisplayUnits)
     DisplayUnits = [];
 end
 
-% If no modality (ex: surface mask, mri values...)
-if (nargin < 3) || isempty(DataType)
-    DataType = 'none';
-end
-
-
 % Check if there is something special in the filename
 if (nargin >= 3) && ~isempty(FileName)
     % Source files
@@ -62,7 +56,10 @@ end
 
 % Consider input data in absolute value
 val = abs(val);
-
+% If no modality (ex: surface mask, mri values...)
+if isempty(DataType)
+    DataType = 'none';
+end
 
 % If the display unit is already defined
 if ~isempty(DisplayUnits)


### PR DESCRIPTION
Hi :)
When cloning a topography figure, I had the following error : 

```
Error using cell/ismember (line 34)
Input A of class double and input B of class cell must be cell arrays of character vectors, unless one is a character
vector.

Error in bst_getunits (line 46)
    if ismember(lower(DataType), {'results', 'sources', 'source'})

Error in bst_colormaps>ConfigureColorbar (line 1470)
                    [valScaled, fFactor, DisplayUnits] = bst_getunits( fmax, DataType, 'nirs', DisplayUnits);

Error in bst_colormaps (line 74)
eval(macro_method);

Error in panel_surface>UpdateSurfaceColormap (line 2053)
        bst_colormaps('ConfigureColorbar', hFig, ColormapInfo.Type, DataType, ColormapInfo.DisplayUnits);

Error in panel_surface (line 40)
eval(macro_method);

Error in figure_3d>ColormapChangedCallback (line 167)
    panel_surface('UpdateSurfaceColormap', hFig);
```


DataType is empty when cloning a topography. I guess it's because there is no surface associated to the topography since it's at the channel level. 


This fix is not perfect as after cloning the figure, the unit is written as 'invalid scale' until a new montage is selected and the color bar is updated. 

Edouard
