### PR TITLE
add function to get brain entropy version

### DIFF
--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -2215,21 +2215,33 @@ function strList = List(Target, isGui)
             strDate = '';
             strPath = '';
         end
-
-        if isfield(PlugDesc(iPlug),'GetVersionFcn') && ~isempty(PlugDesc(iPlug).GetVersionFcn)
-            try
-                if ischar(PlugDesc(iPlug).GetVersionFcn)
-                    plugVer     = eval(PlugDesc(iPlug).GetVersionFcn);
-                else
-                    plugVer     = PlugDesc(iPlug).GetVersionFcn();
-                end
-            catch 
-                plugVer = PlugDesc(iPlug).Version;
-            end
-        elseif (length(PlugDesc(iPlug).Version) > 13)   % Cut version string (short github SHA)
+        % Get installed version
+        if (length(PlugDesc(iPlug).Version) > 13)   % Cut version string (short github SHA)
             plugVer = ['git @', PlugDesc(iPlug).Version(1:7)];
         else
             plugVer = PlugDesc(iPlug).Version;
+        end
+        % Get installed version with GetVersionFcn
+        if isempty(plugVer) && isfield(PlugDesc(iPlug),'GetVersionFcn') && ~isempty(PlugDesc(iPlug).GetVersionFcn)
+            % Load plugin if needed
+            tmpLoad = 0;
+            if ~PlugDesc(iPlug).isLoaded
+                tmpLoad = 1;
+                Load(PlugDesc(iPlug), 0);
+            end
+            try
+                if ischar(PlugDesc(iPlug).GetVersionFcn)
+                    plugVer = eval(PlugDesc(iPlug).GetVersionFcn);
+                elseif isa(PlugDesc(iPlug).GetVersionFcn, 'function_handle')
+                    plugVer = feval(PlugDesc(iPlug).GetVersionFcn);
+                end
+            catch 
+                disp(['BST> Could not get installed version with callback: ' PlugDesc(iPlug).GetVersionFcn]);
+            end
+            % Unload plugin
+            if tmpLoad
+                Unload(PlugDesc(iPlug), 0);
+            end
         end
         % Assemble plugin text row
         strList = [strList strLoaded, ...

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -733,6 +733,12 @@ function [Version, URLzip] = GetVersionOnline(PlugName, URLzip, isCache)
                 disp(['BST> Checking latest online version for ' PlugName '...']);
                 str = bst_webread('https://raw.githubusercontent.com/Nirstorm/nirstorm/master/bst_plugin/VERSION');
                 Version = strtrim(str(9:end));
+            case 'brainentropy'
+                bst_progress('text', ['Checking latest online version for ' PlugName '...']);
+                disp(['BST> Checking latest online version for ' PlugName '...']);
+                str = bst_webread('https://raw.githubusercontent.com/multifunkim/best-brainstorm/master/best/VERSION.txt');
+                str = strsplit(str,'\n');
+                Version = strtrim(str{1});
             otherwise
                 % If downloading from github: Get last GitHub commit SHA
                 if isGithubMaster(URLzip)

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -240,6 +240,7 @@ function PlugDesc = GetSupported(SelPlug)
     PlugDesc(end).AutoLoad       = 1;
     PlugDesc(end).CompiledStatus = 2;
     PlugDesc(end).LoadFolders    = {'*'};
+    PlugDesc(end).GetVersionFcn  = @be_versions;
     PlugDesc(end).DeleteFiles    = {'docs', '.github'};
     
     % === I/O: ADI-SDK ===      ADInstrument SDK for reading LabChart files

--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -2215,8 +2215,18 @@ function strList = List(Target, isGui)
             strDate = '';
             strPath = '';
         end
-        % Cut version string (short github SHA)
-        if (length(PlugDesc(iPlug).Version) > 13)
+
+        if isfield(PlugDesc(iPlug),'GetVersionFcn') && ~isempty(PlugDesc(iPlug).GetVersionFcn)
+            try
+                if ischar(PlugDesc(iPlug).GetVersionFcn)
+                    plugVer     = eval(PlugDesc(iPlug).GetVersionFcn);
+                else
+                    plugVer     = PlugDesc(iPlug).GetVersionFcn();
+                end
+            catch 
+                plugVer = PlugDesc(iPlug).Version;
+            end
+        elseif (length(PlugDesc(iPlug).Version) > 13)   % Cut version string (short github SHA)
             plugVer = ['git @', PlugDesc(iPlug).Version(1:7)];
         else
             plugVer = PlugDesc(iPlug).Version;


### PR DESCRIPTION
This adds the function to read the VERSION.txt file to get the version number of the toolbox (added here: https://github.com/multifunkim/best-brainstorm/pull/8)

When looking at the installed plugin, shouldn't this number appear instead of 'Github-master' ?
edit: Done here https://github.com/brainstorm-tools/brainstorm3/pull/636/commits/6c3017b77f7f40860602dc6e788a6528cec73b67

![Screenshot from 2023-08-09 13-45-46](https://github.com/brainstorm-tools/brainstorm3/assets/24530402/59e8bca6-34a5-4cf4-bc43-71db15f8b544)

The following code 
```
>> PluginDescription  = bst_plugin('GetInstalled', 'brainentropy');
>> PluginDescription.GetVersionFcn()
```

return

    '2.7.3'


Note: this is ready for review :)
