### PR TITLE
Code to read resection from BrainSuite SVReg added

### DIFF
--- a/toolbox/io/import_anatomy_bs.m
+++ b/toolbox/io/import_anatomy_bs.m
@@ -142,6 +142,8 @@ end
 BsDirMultiParc = fullfile(BsDir,'multiparc');
 
 SvregFile = file_find(BsDir, [FilePrefix '.svreg.label.nii.gz']);
+SvregResectionFile = file_find(BsDir, [FilePrefix '.resection.mask.nii.gz']);
+
 OtherSvregFiles = file_find(BsDirMultiParc, [FilePrefix '.svreg.*.label.nii.gz'], 2, 0);
 
 % Find surfaces
@@ -428,7 +430,7 @@ if isVolumeAtlas && ~isempty(SvregFile)
         'Accumbens L', 'Hippocampus L', 'Pallidum L', 'Putamen L', 'Thalamus L', ...
         'Accumbens R', 'Hippocampus R', 'Pallidum R', 'Putamen R', 'Thalamus R', ...
         'Brainstem', 'Cerebellum'};
-    [iSvreg, BstSvregFile] = import_surfaces(iSubject, SvregFile, 'MRI-MASK', 0, [], SelLabels, 'subcortical');
+    [iSvreg, BstSvregFile] = import_surfaces(iSubject, SvregFile, 'MRI-MASK', 0, [], SelLabels, 'subcortical');    
     % Extract cerebellum only
     try
         BstCerebFile = tess_extract_struct(BstSvregFile{1}, {'Cerebellum'}, 'svreg | cerebellum');
@@ -449,8 +451,15 @@ if isVolumeAtlas && ~isempty(SvregFile)
         file_delete({file_fullpath(BstCerebFile), file_fullpath(BstCerebLowFile)}, 1);
         db_reload_subjects(iSubject);
     end
+
+
 end
 
+%% ==== Import Resection Mask ====
+if ~isempty(SvregResectionFile)
+    [BstSvregFile, sMriSvreg] = import_mri(iSubject, SvregResectionFile, [], 0, 1, 'resection_mask');
+    [iSvregResection, BstSvregResectionFile] = import_surfaces(iSubject, SvregResectionFile, 'MRI-MASK', 0, [], [], 'resection');
+end
 
 %% ===== UPDATE GUI =====
 % Set default cortex

--- a/toolbox/io/import_anatomy_bs.m
+++ b/toolbox/io/import_anatomy_bs.m
@@ -143,7 +143,6 @@ BsDirMultiParc = fullfile(BsDir,'multiparc');
 
 SvregFile = file_find(BsDir, [FilePrefix '.svreg.label.nii.gz']);
 SvregResectionFile = file_find(BsDir, [FilePrefix '.resection.mask.nii.gz']);
-
 OtherSvregFiles = file_find(BsDirMultiParc, [FilePrefix '.svreg.*.label.nii.gz'], 2, 0);
 
 % Find surfaces
@@ -430,7 +429,7 @@ if isVolumeAtlas && ~isempty(SvregFile)
         'Accumbens L', 'Hippocampus L', 'Pallidum L', 'Putamen L', 'Thalamus L', ...
         'Accumbens R', 'Hippocampus R', 'Pallidum R', 'Putamen R', 'Thalamus R', ...
         'Brainstem', 'Cerebellum'};
-    [iSvreg, BstSvregFile] = import_surfaces(iSubject, SvregFile, 'MRI-MASK', 0, [], SelLabels, 'subcortical');    
+    [iSvreg, BstSvregFile] = import_surfaces(iSubject, SvregFile, 'MRI-MASK', 0, [], SelLabels, 'subcortical');
     % Extract cerebellum only
     try
         BstCerebFile = tess_extract_struct(BstSvregFile{1}, {'Cerebellum'}, 'svreg | cerebellum');
@@ -451,8 +450,6 @@ if isVolumeAtlas && ~isempty(SvregFile)
         file_delete({file_fullpath(BstCerebFile), file_fullpath(BstCerebLowFile)}, 1);
         db_reload_subjects(iSubject);
     end
-
-
 end
 
 %% ==== Import Resection Mask ====


### PR DESCRIPTION
The code reads resection.mask.nii.gz file if it exists, generates a resection surface from it. Both the resection mask and resection surfaces are imported in BrainStorm. Documentation update to follow.