### PR TITLE
Distance computation (euclidean / geodesic)

### DIFF
--- a/toolbox/anatomy/tess_smooth_sources.m
+++ b/toolbox/anatomy/tess_smooth_sources.m
@@ -58,7 +58,7 @@ nv = size(Vertices,1);
 Sigma = FWHM / (2 * sqrt(2*log2(2)));
 
 [vi,vj] = find(VertConn);
-meanDist = mean(sqrt((Vertices(vi,1) - Vertices(vj,1)).^2 + (Vertices(vi,2) - Vertices(vj,2)).^2 + (Vertices(vi,3) - Vertices(vj,3)).^2));
+meanDist = mean(sqrt((Vertices(vi,1) - Vertices(vj,1)).^2 + (Vertices(vi,2) - Vertices(vj,2)).^2 + (Vertices(vi,3) - Vertices(vj,3)).^2)) * 1000;
 
 
 % ===== COMPUTE DISTANCE =====

--- a/toolbox/anatomy/tess_smooth_sources.m
+++ b/toolbox/anatomy/tess_smooth_sources.m
@@ -78,18 +78,16 @@ end
 
 % ===== APPLY GAUSSIAN FUNCTION =====
 % Gaussian function
-function y = fun(x)
-    y = Kernel(x, Sigma^2);
-    function y = Kernel(x,sigma2)
-        y = 1 / sqrt(2*pi*sigma2);
-        y = y .* exp(-(x.^2/(2*sigma2)));
-    end
+function y = Kernel(x,sigma2)
+    y = 1 / sqrt(2*pi*sigma2);
+    y = y .* exp(-(x.^2/(2*sigma2)));
 end
+
 
 % Calculate interpolation as a function of distance
 [vi, vj, x] = find(Dist);
-W           = sparse(vi, vj,fun(x), nv, nv) + ...
-              speye (nv) .* fun(0);
+W           = sparse(vi, vj,Kernel(x,Sigma^2), nv, nv) + ...
+              speye (nv) .* Kernel(0,Sigma^2);
 
 % Normalize columns
 W       = bst_bsxfun(@rdivide, W, sum(W,1));

--- a/toolbox/anatomy/tess_smooth_sources.m
+++ b/toolbox/anatomy/tess_smooth_sources.m
@@ -1,21 +1,16 @@
-function W = tess_smooth_sources(Vertices, Faces, VertConn, FWHM, Method)
+function W = tess_smooth_sources(SurfaceMat, FWHM, Method)
 % TESS_SMOOTH_SOURCES: Gaussian smoothing matrix over a mesh.
 %
-% USAGE:  W = tess_smooth_sources(Vertices, Faces, VertConn=[], FWHM=0.010, Method='average')
+% USAGE:  W = tess_smooth_sources(SurfaceMat, FWHM=0.010, Method='average')
 %
 % INPUT:
-%    - Vertices : Vertices positions ([X(:) Y(:) Z(:)])
-%    - Faces    : Triangles matrix
-%    - VertConn : Vertices connectivity, logical sparse matrix [Nvert,Nvert]
-%    - FWHM     : Full width at half maximum, in meters (default=0.010)
-%    - Method   : {'euclidian', 'path', 'average', 'surface'}
+%    - SurfaceMat : cortical surface matrix
+%    - FWHM     : Full width at half maximum, in mm (default=10mm)
+%    - Method   : {'euclidian', 'geodesic_edge', 'geodesic_length'}
 % OUPUT:
 %    - W: smoothing matrix (sparse)
 %
 % DESCRIPTION: 
-%    - The distance between two points is an average of:
-%        - the direct euclidian between the two points and
-%        - the number of edges between the two points * the average length of an edge
 %    - Gaussian smoothing function on the euclidian distance:
 %      f(r) = 1 / sqrt(2*pi*sigma^2) * exp(-(r.^2/(2*sigma^2)))
 %    - Full Width at Half Maximum (FWHM) is related to sigma by:
@@ -40,159 +35,72 @@ function W = tess_smooth_sources(Vertices, Faces, VertConn, FWHM, Method)
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2010-2013
+%          Edouard Delaire, 2023
 
 
 % ===== PARSE INPUTS =====
-if (nargin < 5) || isempty(Method)
-    Method = 'average';
+if (nargin < 3) || isempty(Method)
+    Method = 'geodesic_length';
 end
-if (nargin < 4) || isempty(FWHM)
-    FWHM = 0.010;
+if (nargin < 2) || isempty(FWHM)
+    FWHM = 10;
 end
-if (nargin < 3) || isempty(VertConn)
-    VertConn = tess_vertconn(Vertices, Faces);
-end
-if ~islogical(VertConn)
-    error('Invalid vertices connectivity matrix.');
-end
+
+Vertices = SurfaceMat.Vertices;
+VertConn = SurfaceMat.VertConn;
+Faces    = SurfaceMat.Faces;
+
 nv = size(Vertices,1);
 
 
 % ===== ANALYZE INPUT =====
 % Calculate Gaussian kernel properties
 Sigma = FWHM / (2 * sqrt(2*log2(2)));
-% FWTM = 2 * sqrt(2*log2(10)) * Sigma;
-% Get the average edge length
+
 [vi,vj] = find(VertConn);
 meanDist = mean(sqrt((Vertices(vi,1) - Vertices(vj,1)).^2 + (Vertices(vi,2) - Vertices(vj,2)).^2 + (Vertices(vi,3) - Vertices(vj,3)).^2));
-% Guess the number of iterations
-nIter = min(10, ceil(FWHM / meanDist));
+
 
 % ===== COMPUTE DISTANCE =====
 switch lower(Method)
     % === METHOD 1: USE EUCLIDIAN DISTANCE ===
     case 'euclidian'
-        % Get the neighborhood around each vertex
-        VertConn = mpower(VertConn, nIter);
-        [vi,vj] = find(VertConn);
-        % Use Euclidean distance 
-        d = sqrt((Vertices(vi,1) - Vertices(vj,1)).^2 + (Vertices(vi,2) - Vertices(vj,2)).^2 + (Vertices(vi,3) - Vertices(vj,3)).^2);
-        Dist = sparse(vi, vj, d, nv, nv);
-
+        Dist = bst_tess_distance(SurfaceMat, 1:nv, 1:nv, 'euclidian', 1);
     % === METHOD 2: USE NUMBER OF CONNECTIONS =====
-    % === METHOD 3: AVERAGE METHOD 1+2 ===
-    case {'path', 'average'}
-        % Initialize loop variables
-        VertConnGrow = speye(nv);
-        VertIter = sparse(nv,nv);
-        vall = [];
-
-        % Grow and keep track of the layers
-        for iter = 1:nIter
-            disp(sprintf('SMOOTH> Iteration %d/%d', iter, nIter));
-            % Grow selection of vertices
-            VertConnPrev = VertConnGrow;
-            VertConnGrow = double(VertConnGrow * VertConn > 0);
-            % Find all the new connections
-            vind = find(VertConnGrow - VertConnPrev > 0);
-            [vi,vj] = ind2sub([nv,nv], vind);
-            VertIter = VertIter + iter * sparse(vi, vj, ones(size(vi)), nv, nv);
-        end
-
-        % Use distance in number of connections
-        Dist = VertIter * meanDist;
-        Dist(1:nv+1:nv*nv) = 0;
-        
-        % == AVERAGE WITH METHOD 1 ==
-        if strcmpi(Method, 'average')
-            % Calculate Euclidean distance 
-            [vi,vj] = find(VertConnGrow);
-            d = sqrt((Vertices(vi,1) - Vertices(vj,1)).^2 + (Vertices(vi,2) - Vertices(vj,2)).^2 + (Vertices(vi,3) - Vertices(vj,3)).^2);
-            % Average with results of method #2
-            Dist = (0.5 .* Dist + 0.5 .* sparse(vi, vj, d, nv, nv));
-        end
-        
-    % ===== METHOD 4: CALCULATE SURFACE DISTANCE =====
-    % WARNING: NOT FINISHED!!!!
-    case 'surface'
-        % Initialize loop variables
-        VertConnGrow = speye(nv);
-        Dist = sparse([], [], [], nv, nv, 3*nnz(VertConn));
-        vall = [];
-        nIter = 2;
-        % Grow until we reach an accepteable distance
-        for iter = 1:nIter
-            disp(sprintf('Iteration %d', iter));
-            % Get neighbors
-            VertConnGrow = VertConnGrow * VertConn;
-            % Get all the existing edges in the surface
-            vind = find(VertConnGrow);
-            % Remove all the previously processed connections
-            vind = setdiff(vind, vall);
-            [vi,vj] = ind2sub([nv,nv], vind);
-            % Remove diagonal
-            iDel = (vi == vj);
-            vi(iDel) = [];
-            vj(iDel) = [];
-            % Calculate the distance to the neighbor nodes
-            if (iter == 1)
-                % Calculate all the distances for all the pairs of edges
-                d = sqrt((Vertices(vi,1) - Vertices(vj,1)).^2 + (Vertices(vi,2) - Vertices(vj,2)).^2 + (Vertices(vi,3) - Vertices(vj,3)).^2);
-            else
-                % Initialize d matrix
-                d = zeros(size(vi));
-                % Process each new connection separately
-                for i = 1:length(vi)
-                    % Find nodes that are connected to both nodes
-                    iMid = find((Dist(vi(i),:) & VertConn(vj(i),:)) | (VertConn(vi(i),:) & Dist(vj(i),:)));
-                    % Find nodes for which we know one connection at least
-                    iMid0 = (Dist(vi(i),iMid) & Dist(vj(i),iMid));
-                    iMid1 = (Dist(vi(i),iMid) & ~iMid0);
-                    iMid2 = (Dist(vj(i),iMid) & ~iMid0);
-                    % Compute distances
-                    dMid = 0*iMid;
-                    dMid(iMid0) = Dist(vi(i),iMid0) + Dist(vj(i),iMid0);
-                    dMid(iMid1) = Dist(vi(i),iMid1) + sqrt((Vertices(vj(i),1) - Vertices(iMid1,1)).^2 + (Vertices(vj(i),2) - Vertices(iMid1,2)).^2 + (Vertices(vj(i),3) - Vertices(iMid1,3)).^2)';
-                    dMid(iMid2) = Dist(vj(i),iMid2) + sqrt((Vertices(vi(i),1) - Vertices(iMid2,1)).^2 + (Vertices(vi(i),2) - Vertices(iMid2,2)).^2 + (Vertices(vi(i),3) - Vertices(iMid2,3)).^2)';
-                    dMid(dMid == 0) = Inf;
-                    % Find the shortest path
-                    d(i) = min(dMid);
-                    if isinf(d(i))
-                        error('???');
-                    end
-                end
-            end
-            % Add to processed vertices
-            vall = union(vind, vall);
-            % Create a sparse distance matrix
-            Dist = Dist + sparse(vi, vj, d, nv, nv);
-        end
+    case {'geodesic_edge'}
+        Dist = bst_tess_distance(SurfaceMat, 1:nv, 1:nv, 'geodesic_edge', 1);
+        Dist = Dist .* meanDist;
+    % ===== METHOD 3: Use geodesic distance  =====
+    case {'geodesic_length'}
+        Dist = bst_tess_distance(SurfaceMat, 1:nv, 1:nv, 'geodesic_length', 1);
 end
 
 
 % ===== APPLY GAUSSIAN FUNCTION =====
 % Gaussian function
-fun = inline('1 / sqrt(2*pi*sigma2) * exp(-(x.^2/(2*sigma2)))', 'x', 'sigma2');
+fun     = @(x,sigma2) 1 / sqrt(2*pi*sigma2) * exp(-(x.^2/(2*sigma2)));
+
 % Calculate interpolation as a function of distance
 [vi,vj] = find(Dist>0);
-vind = sub2ind([nv,nv], vi, vj);
-w = fun(Dist(vind), Sigma^2);
+vind    = sub2ind([nv,nv], vi, vj);
+w       = fun(Dist(vind), Sigma^2);
+
 % Build final symmetric matrix
-%W = sparse([vi;vj], [vj;vi], [w;w], nv, nv);
-W = sparse(vi, vj, w, nv, nv);
+W       = sparse(vi, vj, w, nv, nv);
 % Add the diagonal
-W = W + fun(0,Sigma^2) * speye(nv);
+W       = W + fun(0,Sigma^2) * speye(nv);
 % Normalize columns
-W = bst_bsxfun(@rdivide, W, sum(W,1));
+W       = bst_bsxfun(@rdivide, W, sum(W,1));
 % Remove insignificant values
-[vi,vj] = find(W>0.005);
-vind = sub2ind([nv,nv], vi, vj);
-W = sparse(vi, vj, W(vind), nv, nv);
+%[vi,vj]     = find(W>0.005);
+%vind        = sub2ind([nv,nv], vi, vj);
+%W           = sparse(vi, vj, W(vind), nv, nv);
 
 
 % ===== FIX BAD TRIANGLES =====
 % Only for methods including neighbor distance
-if ismember(lower(Method), {'path', 'average'})
+% Todo: check what this is doing :)
+if ismember(lower(Method), {'geodesic_edge','geodesic_length'}) 
     % Configurations to detect: 
     %    - One face divided in 3 with a point in the middle of the face
     %    - Square divided into 4 triangles with one point in the middle
@@ -207,6 +115,4 @@ if ismember(lower(Method), {'path', 'average'})
     W(iVert,:) = AvgConn';
     W(:,iVert) = AvgConn;
 end
-
-
-
+end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -24,9 +24,10 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
 %
 % Authors: Edouard Delaire 2023
 
-    Dist = zeros(length(VerticesB),1); 
     Vertices = SurfaceMat.Vertices;
     if strcmp(metric,'euclidean')
+        Dist = zeros(length(VerticesB),1); 
+        
         y = Vertices(VerticesA,:)'*1000; 
         for i = 1:length(VerticesB)
             x = Vertices(VerticesB(i),:)'*1000; 
@@ -50,10 +51,7 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
         end
 
         G = digraph(D);
-        tmp =  distances(G, VerticesA);
-        for i =1:length(VerticesB)
-            Dist(i)=min(tmp(:,VerticesB(i)));
-        end
-        
+        Dist =  min(distances(G, VerticesA,VerticesB))';
+
     end 
 end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -1,4 +1,4 @@
-function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
+function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keepAll)
 % bst_tess_distance: For every vertex B, return the minimum distance to the vertices A using
 % either the euclidean metric (metric = euclidean), or geodesic mesuring the distance either as
 % number of edge (metric = geodesic_edge) or path lenght (geodesic_length)
@@ -31,7 +31,7 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
         y = Vertices(VerticesA,:)'*1000; 
         for i = 1:length(VerticesB)
             x = Vertices(VerticesB(i),:)'*1000; 
-            Dist(i)=min( sum((y-x).^2).^0.5); %euclidean distance calculation
+            Dist(i)=sum((y-x).^2).^0.5; %euclidean distance calculation
         end
 
     elseif contains(metric,'geodesic') 
@@ -49,7 +49,10 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
         end
 
         G    = graph(D);
-        Dist = min(distances(G, VerticesA,VerticesB))';
-
+        Dist = distances(G, VerticesA,VerticesB)';
     end 
+
+    if ~keepAll
+        Dist = min(Dist);
+    end
 end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -26,12 +26,12 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keep
 
     Vertices = SurfaceMat.Vertices;
     if strcmp(metric,'euclidean')
-        Dist = zeros(length(VerticesB),1); 
+        Dist = zeros(length(VerticesA),length(VerticesB)); 
 
         y = Vertices(VerticesA,:)'*1000; 
         for i = 1:length(VerticesB)
             x = Vertices(VerticesB(i),:)'*1000; 
-            Dist(i)=sum((y-x).^2).^0.5; %euclidean distance calculation
+            Dist(:,i)=sum((y-x).^2).^0.5; %euclidean distance calculation
         end
 
     elseif contains(metric,'geodesic') 
@@ -49,10 +49,10 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keep
         end
 
         G    = graph(D);
-        Dist = distances(G, VerticesA,VerticesB)';
+        Dist = distances(G, VerticesA,VerticesB);
     end 
 
     if ~keepAll
-        Dist = min(Dist);
+        Dist = min(Dist)';
     end
 end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -50,10 +50,10 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
         end
 
         G = digraph(D);
-
+        tmp =  distances(G, VerticesA);
         for i =1:length(VerticesB)
-            Dist(i)=min( distances(G, VerticesA,VerticesB(i)));
+            Dist(i)=min(tmp(:,VerticesB(i)));
         end
-
+        
     end 
 end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -48,13 +48,11 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keep
         end
 
     elseif contains(metric,'geodesic') 
-
-        [vi,vj] = find(SurfaceMat.VertConn);
-
         if strcmp(metric,'geodesic_length')
-            nv = size(Vertices,1);
-            x  = Vertices(vi,:)' * 1000;
-            y  = Vertices(vj,:)' * 1000;
+            [vi,vj] = find(SurfaceMat.VertConn);
+            nv      = size(Vertices,1);
+            x       = Vertices(vi,:)' * 1000;
+            y       = Vertices(vj,:)' * 1000;
 
             D  = sparse(vi, vj, sum((x-y).^2).^0.5, nv, nv);
         else

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -27,7 +27,7 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
     Vertices = SurfaceMat.Vertices;
     if strcmp(metric,'euclidean')
         Dist = zeros(length(VerticesB),1); 
-        
+
         y = Vertices(VerticesA,:)'*1000; 
         for i = 1:length(VerticesB)
             x = Vertices(VerticesB(i),:)'*1000; 
@@ -36,22 +36,20 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
 
     elseif contains(metric,'geodesic') 
 
-        D = zeros(size(SurfaceMat.VertConn));
         [vi,vj] = find(SurfaceMat.VertConn);
 
         if strcmp(metric,'geodesic_length')
-            for i=1:size(vi, 1)
-                x =  Vertices(vi(i),:)' * 1000;
-                y =  Vertices(vj(i),:)' * 1000;
+            nv = size(Vertices,1);
+            x  = Vertices(vi,:)' * 1000;
+            y  = Vertices(vj,:)' * 1000;
 
-                D(vi(i), vj(i)) =  sum((y-x).^2).^0.5;
-            end
+            D  = sparse(vi, vj, sum((x-y).^2).^0.5, nv, nv);
         else
-            D = full(SurfaceMat.VertConn);
+            D  = SurfaceMat.VertConn;
         end
 
-        G = digraph(D);
-        Dist =  min(distances(G, VerticesA,VerticesB))';
+        G    = graph(D);
+        Dist = min(distances(G, VerticesA,VerticesB))';
 
     end 
 end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -1,0 +1,59 @@
+function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric)
+% bst_tess_distance: For every vertex B, return the minimum distance to the vertices A using
+% either the euclidean metric (metric = euclidean), or geodesic mesuring the distance either as
+% number of edge (metric = geodesic_edge) or path lenght (geodesic_length)
+% When using the geodesic distance, if two nodes are not
+% connected, the distance is infinite. 
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c) University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Edouard Delaire 2023
+
+    Dist = zeros(length(VerticesB),1); 
+    Vertices = SurfaceMat.Vertices;
+    if strcmp(metric,'euclidean')
+        y = Vertices(VerticesA,:)'*1000; 
+        for i = 1:length(VerticesB)
+            x = Vertices(VerticesB(i),:)'*1000; 
+            Dist(i)=min( sum((y-x).^2).^0.5); %euclidean distance calculation
+        end
+
+    elseif contains(metric,'geodesic') 
+
+        D = zeros(size(SurfaceMat.VertConn));
+        [vi,vj] = find(SurfaceMat.VertConn);
+
+        if strcmp(metric,'geodesic_length')
+            for i=1:size(vi, 1)
+                x =  Vertices(vi(i),:)' * 1000;
+                y =  Vertices(vj(i),:)' * 1000;
+
+                D(vi(i), vj(i)) =  sum((y-x).^2).^0.5;
+            end
+        else
+            D = full(SurfaceMat.VertConn);
+        end
+
+        G = digraph(D);
+
+        for i =1:length(VerticesB)
+            Dist(i)=min( distances(G, VerticesA,VerticesB(i)));
+        end
+
+    end 
+end

--- a/toolbox/math/bst_tess_distance.m
+++ b/toolbox/math/bst_tess_distance.m
@@ -1,9 +1,22 @@
 function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keepAll)
-% bst_tess_distance: For every vertex B, return the minimum distance to the vertices A using
-% either the euclidean metric (metric = euclidean), or geodesic mesuring the distance either as
-% number of edge (metric = geodesic_edge) or path lenght (geodesic_length)
-% When using the geodesic distance, if two nodes are not
-% connected, the distance is infinite. 
+% bst_tess_distance: Distance computation between two set of vertices (A,
+% and B)
+%
+% USAGE:  W = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keepAll)
+%
+% INPUT:
+%    - Vertices : SurfaceMat: cortical surface matrix
+%    - VerticesA    : Vertices from region A
+%    - VerticesB : Vertices from region A
+%    - Method   : Metric used to compute the distance {'euclidean', 'geodesic_edge', 'geodesic_length'}
+%    - keepAll  : if false, for each vertex in region B, return the minimum
+%    distance to region A
+% OUPUT:
+%    - Dist: distance matrix. D(i,j) is the distance between vertex VerticesA(i), and
+%    VerticesB(j). If keepAll = 0, Dist is a nVertexB x 1 vector where
+%    Dist(i) is the minimum distance between VerticesB(i) and the region A.
+%    
+%
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
@@ -28,10 +41,10 @@ function Dist = bst_tess_distance(SurfaceMat, VerticesA, VerticesB, metric, keep
     if strcmp(metric,'euclidean')
         Dist = zeros(length(VerticesA),length(VerticesB)); 
 
-        y = Vertices(VerticesA,:)'*1000; 
+        x = Vertices(VerticesA,:)'*1000; 
         for i = 1:length(VerticesB)
-            x = Vertices(VerticesB(i),:)'*1000; 
-            Dist(:,i)=sum((y-x).^2).^0.5; %euclidean distance calculation
+            y = Vertices(VerticesB(i),:)'*1000; 
+            Dist(:,i)=sum((x-y).^2).^0.5; 
         end
 
     elseif contains(metric,'geodesic') 

--- a/toolbox/process/functions/process_ssmooth.m
+++ b/toolbox/process/functions/process_ssmooth.m
@@ -138,7 +138,7 @@ function sInput = Run(sProcess, sInput) %#ok<DEFNU>
         % Load surface file
         SurfaceMat = in_tess_bst(FileMat.SurfaceFile);
         % Compute the smoothing operator
-        WInterp = tess_smooth_sources(SurfaceMat.Vertices, SurfaceMat.Faces, SurfaceMat.VertConn, FWHM, Method);
+        WInterp = tess_smooth_sources(SurfaceMat,  FWHM, Method);
         % Check for errors
         if isempty(WInterp)
             sInput = [];


### PR DESCRIPTION
Hello. 

This PR adds a small function to compute the distance between two points using either the geodesic distance (as the number of edges separating the two points, or the actual distance) or the Euclidean distance.  When calculating the distance to a region (verticesA), return the minimum distance to that region.  Units are either mm or number of edge.

This was asked a few times on the forum: 
https://neuroimage.usc.edu/forums/t/geodesic-distance/1483/6


Here is an example showing the distance to the green ROI using the Euclidean distance, geodesic ( number of edge) or geodesic (path length): 

<img width="991" alt="Screenshot 2023-09-23 at 17 40 32" src="https://github.com/brainstorm-tools/brainstorm3/assets/24530402/1e349375-29dd-4d50-997e-9a9a97c5c7d2">


This needs a few more test, but I think it's ready to be reviewed :) 


HS: the last commit might help with the smoothing function.  
``` Dist = bst_tess_distance(SurfaceMat, 1:n, 1:n, 'geodesic_length', 1);``` returns a matrix where Dist(I,j) contains the geodesic distance between the vertex i, and j needed in https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/anatomy/tess_smooth_sources.m#L117-L168

Edit: done :) I guess we should only keep the function using the actual geodesic since it's not that slow (a few seconds)
Maybe we can merge this with the other smoothing process from #645 


Useful link: https://www.mathworks.com/help/matlab/ref/graph.distances.html
