### PR TITLE
[out_mri_bst] add saving version option

### DIFF
--- a/toolbox/io/out_mri_bst.m
+++ b/toolbox/io/out_mri_bst.m
@@ -7,10 +7,10 @@ function MRI = out_mri_bst( MRI, MriFile, Version)
 %     - MRI     : Brainstorm MRI structure
 %     - MriFile : full path to file where to save the MRI in brainstorm format
 %     - Version : 'v6', fastest option, bigger files, no files >2Gb
-%                 'v7', slower option, compressed, no files >2Gb
+%                 'v7', slower option, compressed, no files >2Gb (default)
 %                 'v7.3', much slower, compressed, allows files >2Gb
 % OUTPUT:
-%     - MRI : Modificed MRI structure
+%     - MRI : Modified MRI structure
 %
 % NOTES:
 %     - MRI structure:

--- a/toolbox/io/out_mri_bst.m
+++ b/toolbox/io/out_mri_bst.m
@@ -1,4 +1,4 @@
-function MRI = out_mri_bst( MRI, MriFile )
+function MRI = out_mri_bst( MRI, MriFile, Version)
 % OUT_MRI_BST: Save a Brainstorm MRI structure.
 % 
 % USAGE:  MRI = out_mri_bst( MRI, MriFile )
@@ -6,6 +6,9 @@ function MRI = out_mri_bst( MRI, MriFile )
 % INPUT: 
 %     - MRI     : Brainstorm MRI structure
 %     - MriFile : full path to file where to save the MRI in brainstorm format
+%     - Version : 'v6', fastest option, bigger files, no files >2Gb
+%                 'v7', slower option, compressed, no files >2Gb
+%                 'v7.3', much slower, compressed, allows files >2Gb
 % OUTPUT:
 %     - MRI : Modificed MRI structure
 %
@@ -45,6 +48,10 @@ function MRI = out_mri_bst( MRI, MriFile )
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2008-2012
+
+if nargin < 3
+    Version = 'v7';
+end
 
 % ===== Clean-up MRI structure =====
 % Remove (useless or old fieldnames)
@@ -98,10 +105,10 @@ end
 
 % SAVE .mat file
 try
-    bst_save(MriFile, MRI, 'v7');
+    bst_save(MriFile, MRI, Version);
 catch
 
 end
-
+end
 
 


### PR DESCRIPTION
Very minor change to out_mri_bst: Add a parameter to change the saving option. 
Using v6 instead of v7 is saving 7 seconds when saving an MRI.  

see https://github.com/Nirstorm/nirstorm/pull/226