### PR TITLE
[Bug fix] Surface Smoothing

### DIFF
--- a/toolbox/anatomy/tess_smooth_sources.m
+++ b/toolbox/anatomy/tess_smooth_sources.m
@@ -63,6 +63,8 @@ else  % Sigma given in meters
     Sigma = FWHM / (2 * sqrt(2*log2(2)));
 end
 
+% Ignore long distances
+Dist(Dist > 10 * Sigma) = 0;
 % Calculate interpolation as a function of distance
 [vi, vj, x] = find(Dist);
 W           = sparse(vi, vj, GaussianKernel(x,Sigma^2), nVertices, nVertices) + ...

--- a/toolbox/process/functions/process_ssmooth_surfstat.m
+++ b/toolbox/process/functions/process_ssmooth_surfstat.m
@@ -163,7 +163,8 @@ end
 function [sData, msgInfo, warmInfo] = compute(SurfaceFile, sData, FWHM, version)
     warmInfo = '';
 
-    if ischar(SurfaceFile)% Load surface
+    % Get surface
+    if ischar(SurfaceFile)
         SurfaceMat = in_tess_bst(SurfaceFile);
     else
         SurfaceMat = SurfaceFile;
@@ -174,7 +175,7 @@ function [sData, msgInfo, warmInfo] = compute(SurfaceFile, sData, FWHM, version)
         % first estimate the connected regions 
         nVertices   = size(SurfaceMat.Vertices,1);
         Dist        = bst_tess_distance(SurfaceMat, 1:nVertices, 1:nVertices, 'geodesic_edge');
-        subRegions  = process_ssmooth('GetConnectedRegions', SurfaceMat,Dist);
+        subRegions  = process_ssmooth('GetConnectedRegions', SurfaceMat, Dist);
         % Smooth each region separately
         msgInfo    = cell(1,length(subRegions));
         for i = 1:length(subRegions)

--- a/toolbox/process/functions/process_ssmooth_surfstat.m
+++ b/toolbox/process/functions/process_ssmooth_surfstat.m
@@ -163,13 +163,18 @@ end
 function [sData, msgInfo, warmInfo] = compute(SurfaceFile, sData, FWHM, version)
     warmInfo = '';
 
-	% Load surface
-    SurfaceMat = in_tess_bst(SurfaceFile);
-    
+    if ischar(SurfaceFile)% Load surface
+        SurfaceMat = in_tess_bst(SurfaceFile);
+    else
+        SurfaceMat = SurfaceFile;
+    end
+
     if strcmp(version,'adaptive_fwhm')
         % Smooth each connenected part of the surface separately
         % first estimate the connected regions 
-        subRegions = process_ssmooth('GetConnectedRegions', SurfaceMat);
+        nVertices   = size(SurfaceMat.Vertices,1);
+        Dist        = bst_tess_distance(SurfaceMat, 1:nVertices, 1:nVertices, 'geodesic_edge');
+        subRegions  = process_ssmooth('GetConnectedRegions', SurfaceMat,Dist);
         % Smooth each region separately
         msgInfo    = cell(1,length(subRegions));
         for i = 1:length(subRegions)


### PR DESCRIPTION
As I was working on https://github.com/Nirstorm/nirstorm/issues/231 , I found this small bug. sorry for not having caught it before. 

Also, If we want to speed up a bit the computation of the smoothing kernel in tess_smooth_sources,  we can add 
```Dist(Dist > 10* Sigma) = 0 ```

https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/anatomy/tess_smooth_sources.m#L67

I guess this would be ok; since the value of the kernel for any distance larger than 10 sigma is in the order of 10^-20. 