### PR TITLE
CT masking for hiding region outside skull

### DIFF
--- a/toolbox/anatomy/mri_coregister.m
+++ b/toolbox/anatomy/mri_coregister.m
@@ -351,7 +351,7 @@ switch lower(Method)
                     sMriMask.NCS = sMriRef.NCS;
                 end
             end
-            
+
             % Reslice the volume
             bst_progress('text', 'Performing Reslicing...');
             [sMriReg, errMsg] = mri_reslice(sMriReg, sMriRef, 'scs', 'scs', isAtlas);
@@ -496,3 +496,4 @@ end
 if ~isProgress
     bst_progress('stop');
 end
+

--- a/toolbox/anatomy/mri_coregister.m
+++ b/toolbox/anatomy/mri_coregister.m
@@ -312,7 +312,6 @@ switch lower(Method)
                 errMsg = ['BrainSuite failed at step BSE.', 10, 'Check the Matlab command window for more information.'];
                 return    
             end
-    
             % Get the mask
             NiiMaskFile = bst_fullfile(TmpDir, 'bse_smooth_brain.mask.nii.gz');
             sMriMask = in_mri(NiiMaskFile, 'ALL', 0, 0);
@@ -338,7 +337,6 @@ switch lower(Method)
             % Use the reference SCS coordinates
             if isfield(sMriRef, 'SCS')
                 sMriReg.SCS = sMriRef.SCS;
-                
                 if isMask
                     sMriMask.SCS = sMriRef.SCS;
                 end
@@ -346,7 +344,6 @@ switch lower(Method)
             % Use the reference NCS coordinates
             if isfield(sMriRef, 'NCS')
                 sMriReg.NCS = sMriRef.NCS;
-                
                 if isMask
                     sMriMask.NCS = sMriRef.NCS;
                 end
@@ -356,11 +353,9 @@ switch lower(Method)
             bst_progress('text', 'Performing Reslicing...');
             [sMriReg, errMsg] = mri_reslice(sMriReg, sMriRef, 'scs', 'scs', isAtlas);
             
-            % Apply the mask to the co-registered CT to get a clean skull
-            % stripped CT
+            % Apply the mask to the co-registered CT to get a clean skull stripped CT
             if isMask
                 [sMriMask, errMsg] = mri_reslice(sMriMask, sMriRef, 'scs', 'scs', isAtlas);
-
                 bst_progress('text', 'Applying Mask...');
                 sMriReg.Cube = sMriReg.Cube.*(sMriMask.Cube);
                 fileTag = [fileTag, '_masked'];

--- a/toolbox/anatomy/mri_coregister.m
+++ b/toolbox/anatomy/mri_coregister.m
@@ -1,4 +1,4 @@
-function [MriFileReg, errMsg, fileTag, sMriReg] = mri_coregister(MriFileSrc, MriFileRef, Method, isReslice, isAtlas)
+function [MriFileReg, errMsg, fileTag, sMriReg] = mri_coregister(MriFileSrc, MriFileRef, Method, isReslice, isAtlas, isMask)
 % MRI_COREGISTER: Compute the linear transformations on both input volumes, then register the first on the second.
 %
 % USAGE:  [MriFileReg, errMsg, fileTag, sMriReg] = mri_coregister(MriFileSrc, MriFileRef, Method, isReslice)
@@ -12,6 +12,7 @@ function [MriFileReg, errMsg, fileTag, sMriReg] = mri_coregister(MriFileSrc, Mri
 %    - Method     : Method used for the coregistration of the volume: 'spm', 'mni', 'vox2ras'
 %    - isReslice  : If 1, reslice the output volume to match dimensions of the reference volume
 %    - isAtlas    : If 1, perform only integer/nearest neighbors interpolations (MNI and VOX2RAS registration only)
+%    - isMask     : if 1, perform masking out region outside the skull using BrainSuite skull stripping (CT2MRI registration only) 
 %
 % OUTPUTS:
 %    - MriFileReg : Relative path to the new Brainstorm MRI file (containing the structure sMriReg)
@@ -256,13 +257,6 @@ switch lower(Method)
         % Save reference MRI in .nii format
         NiiRefFile = bst_fullfile(TmpDir, 'ct2mri_ref.nii');
         out_mri_nii(sMriRef, NiiRefFile);
-        
-        % Ask if the user wants to mask out wires outside skull in CT
-        % returns 'True'if user selects 'Yes'
-        isMask = java_dialog('confirm', [...
-            '<HTML><B>Clean the CT volume?</B><BR><BR>' ...
-            'This operation cleans the CT to exclude any thing outside the skull.' ...
-            '<BR><BR></HTML>'], 'Import CT');
 
         if isMask
             % Check for BrainSuite Installation

--- a/toolbox/anatomy/mri_coregister.m
+++ b/toolbox/anatomy/mri_coregister.m
@@ -256,8 +256,71 @@ switch lower(Method)
         % Save reference MRI in .nii format
         NiiRefFile = bst_fullfile(TmpDir, 'ct2mri_ref.nii');
         out_mri_nii(sMriRef, NiiRefFile);
+        
+        % Ask if the user wants to mask out wires outside skull in CT
+        % returns 'True'if user selects 'Yes'
+        isMask = java_dialog('confirm', [...
+            '<HTML><B>Clean the CT volume?</B><BR><BR>' ...
+            'This operation cleans the CT to exclude any thing outside the skull.' ...
+            '<BR><BR></HTML>'], 'Import CT');
 
-        % Save registered file in .nii.gz format
+        if isMask
+            % Check for Brainsuite Installation
+            if ~ispc
+                bdp_exe = 'bdp.sh';
+            else
+                bdp_exe = 'bdp';
+            end
+    
+            bst_progress('text', 'Testing BrainSuite installation...');
+            % Check BrainSuite installation
+            status = system([bdp_exe ' --version']);
+            if (status ~= 0)
+                % Get BrainSuite path from Brainstorm preferences
+                BsDir = bst_get('BrainSuiteDir');
+                BsBinDir = bst_fullfile(BsDir, 'bin');
+                BsBdpDir = bst_fullfile(BsDir, 'bdp');
+                % Add BrainSuite path to system path
+                if ~isempty(BsDir) && file_exist(BsBinDir) && file_exist(BsBdpDir)
+                    disp(['BST> Adding to system path: ' BsBinDir]);
+                    disp(['BST> Adding to system path: ' BsBdpDir]);
+                    setenv('PATH', [getenv('PATH'), pathsep, BsBinDir, pathsep, BsBdpDir]);
+                    % Check again
+                    status = system([bdp_exe  ' --version']);
+                end
+                % Brainsuite is not installed
+                if (status ~= 0)
+                    errMsg = ['BrainSuite is not installed on your computer.' 10 ...
+                              'Download it from http://brainsuite.org and install it.' 10 ...
+                              'Then set its installation folder in the Brainstorm options (File > Edit preferences)'];
+                    return
+                end
+            end
+    
+            % Perform BRAIN SURFACE EXTRACTOR (BSE)
+            bst_progress('text', 'Brain surface extractor...');
+            strCall = [...
+                'bse -i "' NiiRefFile '" --auto' ...
+                ' -o "' fullfile(TmpDir, 'skull_stripped_mri.nii.gz"') ...
+                ' --trim --mask "' fullfile(TmpDir, 'bse_smooth_brain.mask.nii.gz"') ...
+                ' --hires "' fullfile(TmpDir, 'bse_detailled_brain.mask.nii.gz"') ...
+                ' --cortex "' fullfile(TmpDir, 'bse_cortex_file.nii.gz"')];
+            disp(['BST> System call: ' strCall]);
+            status = system(strCall);
+            % Error handling
+            if (status ~= 0)
+                errMsg = ['BrainSuite failed at step BSE.', 10, 'Check the Matlab command window for more information.'];
+                return    
+            end
+    
+            % Get the mask
+            NiiMaskFile = bst_fullfile(TmpDir, 'bse_smooth_brain.mask.nii.gz');
+            sMriMask = in_mri(NiiMaskFile, 'ALL', 0, 0);
+            sMriMask.Cube = sMriMask.Cube/255;
+            sMriMask.Cube = sMriMask.Cube & ~mri_dilate(~sMriMask.Cube, 3); % erode
+        end
+        
+        % Perform the co-registration of the unmasked CT to MRI
         NiiRegFile = bst_fullfile(TmpDir, 'contrastmri2preMRI.nii.gz');
         bst_progress('text', 'Performing co-registration using ct2mrireg plugin...');
         NiiRegFile = ct2mrireg(NiiSrcFile, NiiRefFile, NiiRegFile);
@@ -275,14 +338,33 @@ switch lower(Method)
             % Use the reference SCS coordinates
             if isfield(sMriRef, 'SCS')
                 sMriReg.SCS = sMriRef.SCS;
+                
+                if isMask
+                    sMriMask.SCS = sMriRef.SCS;
+                end
             end
             % Use the reference NCS coordinates
             if isfield(sMriRef, 'NCS')
                 sMriReg.NCS = sMriRef.NCS;
+                
+                if isMask
+                    sMriMask.NCS = sMriRef.NCS;
+                end
             end
-
+            
             % Reslice the volume
+            bst_progress('text', 'Performing Reslicing...');
             [sMriReg, errMsg] = mri_reslice(sMriReg, sMriRef, 'scs', 'scs', isAtlas);
+            
+            % Apply the mask to the co-registered CT to get a clean skull
+            % stripped CT
+            if isMask
+                [sMriMask, errMsg] = mri_reslice(sMriMask, sMriRef, 'scs', 'scs', isAtlas);
+
+                bst_progress('text', 'Applying Mask...');
+                sMriReg.Cube = sMriReg.Cube.*(sMriMask.Cube);
+                fileTag = [fileTag, '_masked'];
+            end
         else
             isUpdateScs = 1;
             isUpdateNcs = 1;
@@ -414,4 +496,3 @@ end
 if ~isProgress
     bst_progress('stop');
 end
-

--- a/toolbox/anatomy/mri_coregister.m
+++ b/toolbox/anatomy/mri_coregister.m
@@ -265,37 +265,8 @@ switch lower(Method)
             '<BR><BR></HTML>'], 'Import CT');
 
         if isMask
-            % Check for Brainsuite Installation
-            if ~ispc
-                bdp_exe = 'bdp.sh';
-            else
-                bdp_exe = 'bdp';
-            end
-    
-            bst_progress('text', 'Testing BrainSuite installation...');
-            % Check BrainSuite installation
-            status = system([bdp_exe ' --version']);
-            if (status ~= 0)
-                % Get BrainSuite path from Brainstorm preferences
-                BsDir = bst_get('BrainSuiteDir');
-                BsBinDir = bst_fullfile(BsDir, 'bin');
-                BsBdpDir = bst_fullfile(BsDir, 'bdp');
-                % Add BrainSuite path to system path
-                if ~isempty(BsDir) && file_exist(BsBinDir) && file_exist(BsBdpDir)
-                    disp(['BST> Adding to system path: ' BsBinDir]);
-                    disp(['BST> Adding to system path: ' BsBdpDir]);
-                    setenv('PATH', [getenv('PATH'), pathsep, BsBinDir, pathsep, BsBdpDir]);
-                    % Check again
-                    status = system([bdp_exe  ' --version']);
-                end
-                % Brainsuite is not installed
-                if (status ~= 0)
-                    errMsg = ['BrainSuite is not installed on your computer.' 10 ...
-                              'Download it from http://brainsuite.org and install it.' 10 ...
-                              'Then set its installation folder in the Brainstorm options (File > Edit preferences)'];
-                    return
-                end
-            end
+            % Check for BrainSuite Installation
+            [bdp_exe, errMsg] = process_dwi2dti('CheckBrainSuiteInstall');
     
             % Perform BRAIN SURFACE EXTRACTOR (BSE)
             bst_progress('text', 'Brain surface extractor...');
@@ -312,6 +283,7 @@ switch lower(Method)
                 errMsg = ['BrainSuite failed at step BSE.', 10, 'Check the Matlab command window for more information.'];
                 return    
             end
+
             % Get the mask
             NiiMaskFile = bst_fullfile(TmpDir, 'bse_smooth_brain.mask.nii.gz');
             sMriMask = in_mri(NiiMaskFile, 'ALL', 0, 0);

--- a/toolbox/anatomy/mri_coregister.m
+++ b/toolbox/anatomy/mri_coregister.m
@@ -9,10 +9,10 @@ function [MriFileReg, errMsg, fileTag, sMriReg] = mri_coregister(MriFileSrc, Mri
 %    - MriFileRef : Relative path to the Brainstorm MRI file used as a reference
 %    - sMriSrc    : Brainstorm MRI structure to register (fields Cube, Voxsize, SCS, NCS...)
 %    - sMriRef    : Brainstorm MRI structure used as a reference
-%    - Method     : Method used for the coregistration of the volume: 'spm', 'mni', 'vox2ras'
+%    - Method     : Method used for the coregistration of the volume: 'spm', 'mni', 'vox2ras', 'ct2mri'
 %    - isReslice  : If 1, reslice the output volume to match dimensions of the reference volume
 %    - isAtlas    : If 1, perform only integer/nearest neighbors interpolations (MNI and VOX2RAS registration only)
-%    - isMask     : if 1, perform masking out region outside the skull using BrainSuite skull stripping (CT2MRI registration only) 
+%    - isMask     : If 1, mask out regions outside the skull using BrainSuite skull stripping (CT2MRI registration only)
 %
 % OUTPUTS:
 %    - MriFileReg : Relative path to the new Brainstorm MRI file (containing the structure sMriReg)

--- a/toolbox/io/import_mri.m
+++ b/toolbox/io/import_mri.m
@@ -318,8 +318,13 @@ if (iAnatomy > 1) && (isInteractive || isAutoAdjust)
                 % Register the new MRI on the existing one using SPM + RESLICE
                 [sMri, errMsg, fileTag] = mri_coregister(sMri, sMriRef, 'spm', isReslice, isAtlas);
             case 'CT2MRI'
+                % Ask if the user wants to mask out region outside skull in CT
+                isMask = java_dialog('confirm', [...
+                    '<HTML><B>Clean the CT volume?</B><BR><BR>' ...
+                    'This operation cleans the CT to exclude any thing outside the skull.' ...
+                    '<BR><BR></HTML>'], 'Import CT');
                 % Register the CT to excisting MRI using USC's ct2mrireg plugin
-                [sMri, errMsg, fileTag] = mri_coregister(sMri, sMriRef, 'ct2mri', isReslice, isAtlas);
+                [sMri, errMsg, fileTag] = mri_coregister(sMri, sMriRef, 'ct2mri', isReslice, isAtlas, isMask);
             case 'Ignore'
                 if isReslice
                     % Register the new MRI on the existing one using the transformation in the input files (files already registered)


### PR DESCRIPTION
When users select CT2MRI registration as per https://neuroimage.usc.edu/brainstorm/Tutorials/ImportAnatomy#Import_CT, 
this will prompt the user if they want to clean the CT as under so as to mask out unwanted regions/wiring/artefacts out side the skull area.
![Screenshot 2024-02-02 131721](https://github.com/brainstorm-tools/brainstorm3/assets/21283733/4d81956a-6dc6-4101-a723-7415404917d4)

This is without masking and how it currently generates in BST or if the user selects **No** above:
![Screenshot 2024-02-02 132651](https://github.com/brainstorm-tools/brainstorm3/assets/21283733/8f9f22f2-1487-4dd4-911e-1d149d5f72c2)

If the user chooses **Yes** then:
![Screenshot 2024-02-02 132413](https://github.com/brainstorm-tools/brainstorm3/assets/21283733/ccf89e11-5bb8-42bd-967e-afab406f009a)

This gives a clean CT to perform operations on.