### PR TITLE
view_channel_3d: take an already created figure as input

### DIFF
--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -43,7 +43,7 @@ global GlobalData;
 iDS = [];
 iFig = [];
 if (nargin < 6) || isempty(hFig)
-    hFig = [];
+    hFig = 'NewFigure';
 elseif ishandle(hFig)
     hFig = bst_figures('GetFigure', hFig);
 else
@@ -101,9 +101,7 @@ if ~isempty(sSubject)
                     case 'ECOG',  SurfAlpha = .2;
                     otherwise,    SurfAlpha = opaqueAlpha;
                 end
-                if isempty(hFig)
-                    hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
-                end
+                hFig = view_surface(SurfaceFile, SurfAlpha, [], hFig);
             end
         case 'innerskull'
             if ~isempty(sSubject.iInnerSkull) && (sSubject.iInnerSkull <= length(sSubject.Surface))
@@ -115,9 +113,7 @@ if ~isempty(sSubject)
                     case 'ECOG',  SurfAlpha = .2;
                     otherwise,    SurfAlpha = opaqueAlpha;
                 end
-                if isempty(hFig)
-                    hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
-                end
+                hFig = view_surface(SurfaceFile, SurfAlpha, [], hFig);
             end
         case 'scalp'
             if ~isempty(sSubject.iScalp) && (sSubject.iScalp <= length(sSubject.Surface))
@@ -136,9 +132,7 @@ if ~isempty(sSubject)
                     otherwise
                         SurfAlpha = opaqueAlpha;
                 end
-                if isempty(hFig)
-                    hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
-                end
+                hFig = view_surface(SurfaceFile, SurfAlpha, [], hFig);
             end
         case {'anatomy', 'subjectimage'}
             if ~isempty(sSubject.iAnatomy) && (sSubject.iAnatomy <= length(sSubject.Anatomy))
@@ -146,10 +140,9 @@ if ~isempty(sSubject)
                     SurfaceFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
                 end
                 SurfAlpha = .1;
-                if isempty(hFig)
-                    hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, 'NewFigure');
-                end
+                hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, hFig);
             end
+        otherwise
     end
 end
 % Warning if no surface was found

--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -1,4 +1,4 @@
-function [hFig, iDS, iFig] = view_channels_3d(FileNames, Modality, SurfaceType, is3DElectrodes, isDetails)
+function [hFig, iDS, iFig] = view_channels_3d(FileNames, Modality, SurfaceType, is3DElectrodes, isDetails,hFig)
 % VIEW_CHANNELS_3D: Display channel files on top of subject anatomy.
 
 % @=============================================================================
@@ -23,6 +23,22 @@ function [hFig, iDS, iFig] = view_channels_3d(FileNames, Modality, SurfaceType, 
 
 global GlobalData;
 % Parse inputs
+% Get options
+NewFigure = 0;
+if (nargin < 6) || isempty(hFig)
+    hFig = [];
+elseif ischar(hFig) && strcmpi(hFig, 'NewFigure')
+    hFig = [];
+    NewFigure = 1;
+elseif ishandle(hFig)
+    [hFig,iFig,iDS] = bst_figures('GetFigure', hFig);
+elseif (round(hFig) == hFig) && (hFig <= length(GlobalData.DataSet))
+    iDS = hFig;
+    hFig = [];
+else
+    error('Invalid figure handle.');
+end
+
 if (nargin < 5) || isempty(isDetails)
     isDetails = 0;
 end
@@ -35,7 +51,6 @@ end
 if ischar(FileNames)
     FileNames = {FileNames};
 end
-hFig = [];
 iDS = [];
 iFig = [];
 % Coils or channel markers?
@@ -76,7 +91,9 @@ if ~isempty(sSubject)
                     case 'ECOG',  SurfAlpha = .2;
                     otherwise,    SurfAlpha = opaqueAlpha;
                 end
-                hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
+                if isempty(hFig) || NewFigure
+                    hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
+                end
             end
         case 'innerskull'
             if ~isempty(sSubject.iInnerSkull) && (sSubject.iInnerSkull <= length(sSubject.Surface))
@@ -88,7 +105,9 @@ if ~isempty(sSubject)
                     case 'ECOG',  SurfAlpha = .2;
                     otherwise,    SurfAlpha = opaqueAlpha;
                 end
-                hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
+                if isempty(hFig) || NewFigure
+                    hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
+                end
             end
         case 'scalp'
             if ~isempty(sSubject.iScalp) && (sSubject.iScalp <= length(sSubject.Surface))
@@ -107,7 +126,9 @@ if ~isempty(sSubject)
                     otherwise
                         SurfAlpha = opaqueAlpha;
                 end
-                hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
+                if isempty(hFig) || NewFigure
+                    hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
+                end
             end
         case {'anatomy', 'subjectimage'}
             if ~isempty(sSubject.iAnatomy) && (sSubject.iAnatomy <= length(sSubject.Anatomy))
@@ -115,9 +136,12 @@ if ~isempty(sSubject)
                     SurfaceFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
                 end
                 SurfAlpha = .1;
-                hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, 'NewFigure');
+                if isempty(hFig) || NewFigure
+                    hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, 'NewFigure');
+                end
             end
     end
+
 end
 % Warning if no surface was found
 if isempty(hFig)

--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -146,7 +146,7 @@ if ~isempty(sSubject)
                     SurfaceFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
                 end
                 SurfAlpha = .1;
-                if isempty(hFig) || NewFigure
+                if isempty(hFig)
                     hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, 'NewFigure');
                 end
             end

--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -1,5 +1,21 @@
-function [hFig, iDS, iFig] = view_channels_3d(FileNames, Modality, SurfaceType, is3DElectrodes, isDetails,hFig)
+function [hFig, iDS, iFig] = view_channels_3d(FileNames, Modality, SurfaceType, is3DElectrodes, isDetails, hFig)
 % VIEW_CHANNELS_3D: Display channel files on top of subject anatomy.
+%
+% INPUT:
+%     - FileNames   : path to the channel file to display
+%     - Modality    : modality of sensors
+%     - SurfaceType : surface to display sensors on (scalp)
+%     - is3DElectrodes
+%     - isDetails
+%     - hFig : TargetFigure:
+%        |- []      : New figure (default)
+%        |- hFig    : Specify the figure in which to display the channels
+%
+% OUTPUT :
+%     - hFig : Matlab handle to the 3DViz figure that was created or updated
+%     - iDS  : DataSet index in the GlobalData variable
+%     - iFig : Indice of returned figure in the GlobalData(iDS).Figure array
+% If an error occurs : all the returned variables are set to an empty matrix []
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -22,19 +38,14 @@ function [hFig, iDS, iFig] = view_channels_3d(FileNames, Modality, SurfaceType, 
 % Authors: Francois Tadel, 2010-2019
 
 global GlobalData;
-% Parse inputs
-% Get options
-NewFigure = 0;
+
+%% ===== PARSE INPUTS =====
+iDS = [];
+iFig = [];
 if (nargin < 6) || isempty(hFig)
     hFig = [];
-elseif ischar(hFig) && strcmpi(hFig, 'NewFigure')
-    hFig = [];
-    NewFigure = 1;
 elseif ishandle(hFig)
-    [hFig,iFig,iDS] = bst_figures('GetFigure', hFig);
-elseif (round(hFig) == hFig) && (hFig <= length(GlobalData.DataSet))
-    iDS = hFig;
-    hFig = [];
+    hFig = bst_figures('GetFigure', hFig);
 else
     error('Invalid figure handle.');
 end
@@ -51,8 +62,7 @@ end
 if ischar(FileNames)
     FileNames = {FileNames};
 end
-iDS = [];
-iFig = [];
+
 % Coils or channel markers?
 isShowCoils = ismember(Modality, {'Vectorview306', 'CTF', '4D', 'KIT', 'KRISS', 'BabyMEG', 'NIRS-BRS', 'RICOH'});
 
@@ -91,7 +101,7 @@ if ~isempty(sSubject)
                     case 'ECOG',  SurfAlpha = .2;
                     otherwise,    SurfAlpha = opaqueAlpha;
                 end
-                if isempty(hFig) || NewFigure
+                if isempty(hFig)
                     hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
                 end
             end
@@ -105,7 +115,7 @@ if ~isempty(sSubject)
                     case 'ECOG',  SurfAlpha = .2;
                     otherwise,    SurfAlpha = opaqueAlpha;
                 end
-                if isempty(hFig) || NewFigure
+                if isempty(hFig)
                     hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
                 end
             end
@@ -126,7 +136,7 @@ if ~isempty(sSubject)
                     otherwise
                         SurfAlpha = opaqueAlpha;
                 end
-                if isempty(hFig) || NewFigure
+                if isempty(hFig)
                     hFig = view_surface(SurfaceFile, SurfAlpha, [], 'NewFigure');
                 end
             end
@@ -141,7 +151,6 @@ if ~isempty(sSubject)
                 end
             end
     end
-
 end
 % Warning if no surface was found
 if isempty(hFig)

--- a/toolbox/gui/view_mri_3d.m
+++ b/toolbox/gui/view_mri_3d.m
@@ -132,7 +132,7 @@ else
 end
 % If there is already a volume displayed in this figure, create a new one
 TessInfo = getappdata(hFig, 'Surface');
-if ~isempty(TessInfo) && ismember('Anatomy', {TessInfo.Name})
+if ~isempty(TessInfo) && ismember('Anatomy', {TessInfo.Name}) && ~ismember(MriFile, {TessInfo.SurfaceFile})
     [hFig, iFig, isNewFig] = bst_figures('CreateFigure', iDS, FigureId, 'AlwaysCreate');
 end
 % Set application data


### PR DESCRIPTION
This PR allows the following code to work: 

```matlab

hFig  = bst_figures('GetFigureWithSurface', SurfaceFile);
hFig  = view_surface_data(SurfaceFile, OverlayFile, [], hFig, 1);
hFig  = view_surface(ScalpFile, 0, [], hFig, 1);
hFig  = view_channels_3d(channelFile, 'NIRS-BRS', 'scalp', 0, 1,hFig);

```

This code produce the following image and solve my problem from here: https://neuroimage.usc.edu/forums/t/visualizing-sensors-on-top-of-cortical-activity/44950/2

<img width="672" alt="image" src="https://github.com/brainstorm-tools/brainstorm3/assets/24530402/f24c84b2-09b4-4d51-bf41-986e3fc07892">


hs: is there a better way to create an empty figure than : hFig bst_figures('GetFigureWithSurface', SurfaceFile); ?


