### PR TITLE
[bugfix] import snirf with event having only one occurance

### DIFF
--- a/toolbox/io/in_data_snirf.m
+++ b/toolbox/io/in_data_snirf.m
@@ -254,7 +254,7 @@ for iEvt = 1:length(jnirs.nirs.stim)
     if isfield(jnirs.nirs.stim(iEvt), 'dataLabels')
         nStimDataCols = length(jnirs.nirs.stim(iEvt).dataLabels);
     end
-    % Transpose if needed
+    % Transpose to match number of columns
     if size(jnirs.nirs.stim(iEvt).data, 1) == nStimDataCols && diff(size(jnirs.nirs.stim(iEvt).data)) ~= 0
         jnirs.nirs.stim(iEvt).data = jnirs.nirs.stim(iEvt).data';
     end    

--- a/toolbox/io/in_data_snirf.m
+++ b/toolbox/io/in_data_snirf.m
@@ -250,11 +250,14 @@ for iEvt = 1:length(jnirs.nirs.stim)
         continue
     end    
     % Get timing
-    
-    if size(jnirs.nirs.stim(iEvt).data,1) > 1 && size(jnirs.nirs.stim(iEvt).data,2) >  size(jnirs.nirs.stim(iEvt).data,1)
+    nStimDataCols = 3; % [starttime duration value]
+    if isfield(jnirs.nirs.stim(iEvt), 'dataLabels')
+        nStimDataCols = length(jnirs.nirs.stim(iEvt).dataLabels);
+    end
+    % Transpose if needed
+    if size(jnirs.nirs.stim(iEvt).data, 1) == nStimDataCols && diff(size(jnirs.nirs.stim(iEvt).data)) ~= 0
         jnirs.nirs.stim(iEvt).data = jnirs.nirs.stim(iEvt).data';
     end    
-
     isExtended = ~all(jnirs.nirs.stim(iEvt).data(:,2) == 0);
     if isExtended
         evtTime = [jnirs.nirs.stim(iEvt).data(:,1) ,  ...

--- a/toolbox/io/in_data_snirf.m
+++ b/toolbox/io/in_data_snirf.m
@@ -251,10 +251,10 @@ for iEvt = 1:length(jnirs.nirs.stim)
     end    
     % Get timing
     
-    if size(jnirs.nirs.stim(iEvt).data,2) >  size(jnirs.nirs.stim(iEvt).data,1)
+    if size(jnirs.nirs.stim(iEvt).data,1) > 1 && size(jnirs.nirs.stim(iEvt).data,2) >  size(jnirs.nirs.stim(iEvt).data,1)
         jnirs.nirs.stim(iEvt).data = jnirs.nirs.stim(iEvt).data';
     end    
-    
+
     isExtended = ~all(jnirs.nirs.stim(iEvt).data(:,2) == 0);
     if isExtended
         evtTime = [jnirs.nirs.stim(iEvt).data(:,1) ,  ...


### PR DESCRIPTION
Fix the following bug happening when importing a snirf where one event  has only one occurrence: 

Maybe its not the best fix. 
```matlab


***************************************************************************
** Error: Line 258: Index in position 2 exceeds array bounds. Index must not exceed 1.
** 
** Call stack:
** >in_data_snirf.m at 258
** >in_fopen.m at 221
** >import_raw.m at 132
** >bst_call.m at 28
** >tree_callbacks.m>@(h,ev)bst_call(@import_raw,[],[],iSubject) at 672
** 
********

```


Edit: maybe its not the best fix. jnirs.nirs.stim(iEvt).data should be nEvent x 3