### PR TITLE
[bugfix] panel_ieeg: reading coordinates must always happen from MRI Viewer 

### DIFF
--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -1190,11 +1190,7 @@ end
 function [sElectrodes, iDSall, iFigall, hFigall] = GetElectrodes()
     global GlobalData;
     % Get current figure
-    [hFigall,iFigall,iDSall] = bst_figures('GetCurrentFigure');
-    if isempty(hFigall)
-        % Try MRI viewer figure
-        [hFigall,iFigall,iDSall] = bst_figures('GetFiguresByType','MriViewer');
-    end
+    [hFigall,iFigall,iDSall] = bst_figures('GetFiguresByType','MriViewer');
 
     % Check if there are electrodes defined for this file
     if isempty(hFigall) || isempty(GlobalData.DataSet(iDSall).IntraElectrodes) || isempty(GlobalData.DataSet(iDSall).ChannelFile)


### PR DESCRIPTION
Steps:

1. Right click on CT in anatomy and do SEEG/ECOG Implantation
2. Panel iEEG opens up. Click **+**  to create a new electrode. Give a name and press **OK**. If the current active window is 3D Viz then the error below occurs:
![Screenshot 2024-03-25 152829](https://github.com/brainstorm-tools/brainstorm3/assets/21283733/1b5cccbf-0181-4aca-a2ad-83e52b692ca6)