### PR TITLE
[bugfix] tess_isosurface, panel_ieeg

### DIFF
--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -171,9 +171,7 @@ if isSave
     % Display mesh with 3D orthogonal slices of the default MRI
     MriFile = sSubject.Anatomy(1).FileName;
     hFig = bst_figures('GetFiguresByType', '3DViz');
-    if ~isempty(hFig)
-        hFig = view_mri_3d(MriFile, [], 0.3, hFig);
-    else
+    if isempty(hFig)
         hFig = view_mri_3d(MriFile, [], 0.3, []);
     end
     view_surface(MeshFile, 0.6, [], hFig, []);    

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -170,7 +170,12 @@ if isSave
     iSurface = db_add_surface(iSubject, MeshFile, sMesh.Comment);
     % Display mesh with 3D orthogonal slices of the default MRI
     MriFile = sSubject.Anatomy(1).FileName;
-    hFig = view_mri_3d(MriFile, [], 0.3, []);
+    hFig = bst_figures('GetFiguresByType', '3DViz');
+    if ~isempty(hFig)
+        hFig = view_mri_3d(MriFile, [], 0.3, hFig);
+    else
+        hFig = view_mri_3d(MriFile, [], 0.3, []);
+    end
     view_surface(MeshFile, 0.6, [], hFig, []);    
     panel_surface('SetIsoValue', isoValue);
 else

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -363,8 +363,8 @@ function UpdatePanel()
     if isempty(ctrl)
         return;
     end
-    % Get current electrodes
-    [sElectrodes, iDS, iFig, hFig] = GetElectrodes();
+    % Get current figure
+    hFig = bst_figures('GetCurrentFigure');
     % If a surface is available for current figure
     if ~isempty(hFig)
         gui_enable([ctrl.jPanelElecList, ctrl.jToolbar], 1);

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -1979,7 +1979,7 @@ end
 %% ===== SET DISPLAY MODE =====
 function SetDisplayMode(DisplayMode)
     % Get current figure
-    [sElectrodes, iDS, iFig, hFig] = GetElectrodes();
+    hFig = bst_figures('GetCurrentFigure');
     if isempty(hFig)
         return;
     end


### PR DESCRIPTION
**ISSUES (tess_isosurface):**
1. In functional view, go to an **implantation node> SEEG/ECOG (with some channels)**
2. Double click to open 3D VIZ and MRI Viewer
3. Use **Thresh** slider to update iso surface 
     **Updated figure is generated in  a new 3D Viz.**
5. Add coordinates panel. Repeat step 3.
     **A bunch of errors pop up**

**SOLUTION:** https://github.com/brainstorm-tools/brainstorm3/pull/697/commits/424a5da6f118561ffa153408e46ee598485a2003

**ISSUES (panel_ieeg):**
When trying to update view type between depth electrode and sphere, the update always occurs in MRI Viewer only. 

**SOLUTION:** https://github.com/brainstorm-tools/brainstorm3/pull/697/commits/ddcefc856efdf3f1c1dbb394dd07bd9abc1af894