### PR TITLE
[bugfix] panel_ieeg

### DIFF
--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3054,6 +3054,9 @@ end
 
 %% ===== CREATE NEW IMPLANTATION =====
 function CreateNewImplantation(MriFile) %#ok<DEFNU>
+    % Unload all figures and datasets before starting a new implantation
+    bst_memory('UnloadAll', 'Forced');
+    
     % Find subject
     [sSubject,iSubject,iAnatomy] = bst_get('MriFile', MriFile);
     % Get study for the new channel file

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3054,9 +3054,21 @@ end
 
 %% ===== CREATE NEW IMPLANTATION =====
 function CreateNewImplantation(MriFile) %#ok<DEFNU>
-    % Unload all figures and datasets before starting a new implantation
-    bst_memory('UnloadAll', 'Forced');
+    % Get all open figures
+    hFig = bst_figures('GetAllFigures');
     
+    % If figures are open, inform the users that to continue all figures must be closed
+    if ~isempty(hFig)
+        isCloseAllFigures = java_dialog('confirm', ['All figures will be closed. Do you want to continue?' 10 ...
+                                        '<HTML>Choose <B>No</B> to revisit the figures before starting implantation</HTML>'], 'SEEG/ECOG implantation');
+        if ~isCloseAllFigures
+            return
+        end
+
+        % Unload all figures and datasets before starting a new implantation
+        bst_memory('UnloadAll', 'Forced');
+    end
+
     % Find subject
     [sSubject,iSubject,iAnatomy] = bst_get('MriFile', MriFile);
     % Get study for the new channel file

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -505,7 +505,7 @@ function UpdateContactList(CoordSpace)
     if ~strcmpi('scs', CoordSpace)
         listModel.addElement(BstListItem('', [], 'Updating', 1));
         ctrl.jListCont.setModel(listModel);
-        sContactsMm = (cs_convert(sMri, 'scs', lower(CoordSpace), sContacts') * 1000)';
+        sContactsMm = (cs_convert(sMri, 'scs', lower(CoordSpace), cell2mat(sContacts)') * 1000)';
         switch lower(CoordSpace)
             case 'mni',   ctrl.jRadioMni.setSelected(1);
             case 'mri',   ctrl.jRadioMri.setSelected(1);
@@ -514,7 +514,7 @@ function UpdateContactList(CoordSpace)
         listModel.clear();
         ctrl.jListCont.setModel(listModel);
     else
-        sContactsMm = sContacts * 1000;
+        sContactsMm = cell2mat(sContacts) * 1000;
         ctrl.jRadioScs.setSelected(1);
     end
     % Update the list for display
@@ -798,7 +798,7 @@ function [sSelCont, sContactName, iSelCont, iDS, iFig, hFig] = GetSelectedContac
     % Get JList selected indices
     iSelCont = uint16(ctrl.jListCont.getSelectedIndices())' + 1;
     sContactName = sContactsName(iSelCont);
-    sSelCont = sContacts(:, iSelCont);
+    sSelCont = cell2mat(sContacts(:, iSelCont));
 end
 
 
@@ -1262,7 +1262,7 @@ function [sContacts, sContactsName, iDSall, iFigall, hFigall] = GetContacts(sele
     ChannelData = GlobalData.DataSet(iDSall).Channel;
     for i=1:length(ChannelData)
         if strcmpi(ChannelData(i).Group, selectedElecName)
-            sContacts = [sContacts, ChannelData(i).Loc];
+            sContacts = [sContacts, {ChannelData(i).Loc}];
             sContactsName = [sContactsName, {ChannelData(i).Name}];
         end
     end

--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -142,15 +142,12 @@ if ~isempty(sSubject)
                 SurfAlpha = .1;
                 hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, hFig);
                 if ismember(Modality, {'SEEG', 'ECOG', 'ECOG+SEEG'})
-                    % For (SEEG, ECOG, ECOG+SEEG), display 3D slices (MRI) + isosurface
+                    % For (SEEG, ECOG, ECOG+SEEG), display 3D slices (MRI), isosurface along with the MRI Viewer
                     panel_ieeg('DisplayIsosurface', sSubject, hFig, FileNames{1}, Modality);
+                    panel_ieeg('DisplayChannelsMri', FileNames{1}, Modality, 1, 0);
                 end
             end
         otherwise
-    end
-    if ismember(Modality, {'SEEG', 'ECOG', 'ECOG+SEEG'})
-        % For (SEEG, ECOG, ECOG+SEEG), display MRI viewer for all Surface Types
-        panel_ieeg('DisplayChannelsMri', FileNames{1}, Modality, 1, 0);
     end
 end
 % Warning if no surface was found

--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -141,15 +141,15 @@ if ~isempty(sSubject)
                 end
                 SurfAlpha = .1;
                 hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, hFig);
-                if strcmpi(Modality, 'SEEG')
-                    % For SEEG, display 3D slices (MRI) + isosurface
+                if ismember(Modality, {'SEEG', 'ECOG', 'ECOG+SEEG'})
+                    % For (SEEG, ECOG, ECOG+SEEG), display 3D slices (MRI) + isosurface
                     panel_ieeg('DisplayIsosurface', sSubject, hFig, FileNames{1}, Modality);
                 end
             end
         otherwise
     end
-    if strcmpi(Modality, 'SEEG')
-        % For SEEG, display MRI viewer for all Surface Types
+    if ismember(Modality, {'SEEG', 'ECOG', 'ECOG+SEEG'})
+        % For (SEEG, ECOG, ECOG+SEEG), display MRI viewer for all Surface Types
         panel_ieeg('DisplayChannelsMri', FileNames{1}, Modality, 1, 0);
     end
 end
@@ -168,7 +168,7 @@ if (length(FileNames) == 1)
     end
     isMarkers = ~isShowCoils || isDetails;
     [hFig, iDS, iFig] = view_channels(FileNames{1}, Modality, isMarkers, isLabels, hFig, is3DElectrodes);
-    % SEEG and ECOG: Open tab "iEEG"
+    % (SEEG, ECOG, ECOG+SEEG): Open tab "iEEG"
     if ismember(Modality, {'SEEG', 'ECOG', 'ECOG+SEEG'})
         gui_brainstorm('ShowToolTab', 'iEEG');
     end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -229,11 +229,11 @@ switch (lower(action))
                 % If only one modality
                 if ~isempty(DisplayMod)
                     if strcmpi(DisplayMod{1}, 'ECOG+SEEG') || (length(DisplayMod) >= 2) && all(ismember({'SEEG','ECOG'}, DisplayMod))
-                        DisplayChannels(bstNodes, 'ECOG+SEEG', 'cortex', 1);
+                        DisplayChannels(bstNodes, 'ECOG+SEEG', 'anatomy', 1);
                     elseif strcmpi(DisplayMod{1}, 'SEEG')
-                        DisplayChannels(bstNodes, DisplayMod{1}, 'anatomy', 1, 0);
+                        DisplayChannels(bstNodes, DisplayMod{1}, 'anatomy', 1);
                     elseif strcmpi(DisplayMod{1}, 'ECOG')
-                        DisplayChannels(bstNodes, DisplayMod{1}, 'cortex', 1);
+                        DisplayChannels(bstNodes, DisplayMod{1}, 'anatomy', 1);
                     elseif ismember(DisplayMod{1}, {'MEG','MEG GRAD','MEG MAG'})
                         channel_align_manual(filenameRelative, DisplayMod{1}, 0);
                     elseif strcmpi(DisplayMod{1}, 'NIRS')


### PR DESCRIPTION
**Issue-1:** If implantation is started and there is a 3DMRI+isosurface figure open, unexpected things happens.
Solution: https://github.com/brainstorm-tools/brainstorm3/pull/701/commits/fad6568ee413e061af912e16c8270a3d836fdab6

**Issue-2:** Double-clicking on the SEEG/ECOG ("number of channels") channel file in the functional tab only opens the cortex figure for ECOG and ECOG+SEEG.
Solution: https://github.com/brainstorm-tools/brainstorm3/pull/701/commits/9452f2f21fc3685b2ff60ae9705360b7246bc8cc

**Discussion:** https://neuroimage.usc.edu/forums/t/display-sensors-cortex-opens-mri-viewer-in-addition-to-cortex-view/46083/2
Do we need to have MRI Viewer display for all surface types by default ?
If no then this is the proposed solution: https://github.com/brainstorm-tools/brainstorm3/pull/701/commits/3ccd367251ad92d75fde12d652c21427ebd45c0e

**Issue-3:** Reported in https://neuroimage.usc.edu/forums/t/ieeg-panel-error/46550.
Solution: [30e5648](https://github.com/brainstorm-tools/brainstorm3/pull/701/commits/30e5648a07c51288588b0cd1ac0798cd16f7e531)