### PR TITLE
Contactsheets for 3D-slices behave as 3D-surfaces

### DIFF
--- a/toolbox/gui/view_contactsheet.m
+++ b/toolbox/gui/view_contactsheet.m
@@ -350,27 +350,21 @@ end
 
 
 %% ===== REMOVE USELESS BACKGROUND =====
-% Only in the case of MRI slices without data
-if (dim ~= 0) && strcmpi('volume', inctype) && isempty(TessInfo.Data)
-    % Get background points
-    background = double(AlphaSheet == 0);
-    % If there are no transparent points on the surface: detect "black" points
-    if (nnz(background) == 0)
-        background = double(sqrt(sum(double(ImgSheet).^2,3)) < .05);
-    end
-    % Grow background region, to remove all the small parasites
-    kernel = ones(5,5);
-    background = double(conv2(background, kernel, 'same') > 0);
-    % Grow foreground regions, to cut at least 10 pixels away from each meaningful block of data
-    kernel = ones(11);
-    background = conv2(double(background == 0), kernel, 'same') == 0;
-    % Detect the empty columns and arrows
-    iEmptyCol = find(all(background, 1));
-    iEmptyRow = find(all(background, 2));
-    % Remove empty lines and columns
-    ImgSheet(iEmptyRow, :, :) = [];
-    ImgSheet(:, iEmptyCol, :) = [];
+% Get background points
+background = double(AlphaSheet == 0);
+% If there are no transparent points on the surface: detect "black" points
+if (nnz(background) == 0)
+    background = double(sqrt(sum(double(ImgSheet).^2,3)) < .05);
 end
+% Grow foreground regions, to cut at least 10 pixels away from each meaningful block of data
+kernel = ones(11);
+background = conv2(double(background == 0), kernel, 'same') == 0;
+% Detect the empty columns and rows
+iEmptyCol = find(all(background, 1));
+iEmptyRow = find(all(background, 2));
+% Remove empty lines and columns
+ImgSheet(iEmptyRow, :, :) = [];
+ImgSheet(:, iEmptyCol, :) = [];
 
 
 %% ===== RE-INTERPOLATE IMAGE =====

--- a/toolbox/gui/view_contactsheet.m
+++ b/toolbox/gui/view_contactsheet.m
@@ -242,9 +242,6 @@ nbCols = ceil(nImages / nbRows);
 % Initialize buffer of images
 ImgBuffer   = zeros(H, W, 3, nImages, class(testImg));
 AlphaBuffer = zeros(H, W, 1, nImages);
-
-%ImgSheet   = zeros(nbRows * H, nbCols * W, 3, class(testImg));
-%AlphaSheet = zeros(nbRows * H, nbCols * W);
 % Backup current view for 3D figures
 if is3D && dim ~= 0
     hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
@@ -317,11 +314,6 @@ for iSample = 1:nImages
     alpha = ones(size(img,1), size(img,2), 1);
     ImgBuffer(:,:,:,iSample) = img;
     AlphaBuffer(:,:,:,iSample) = alpha;
-%     % Find extacted image position in final sheet
-%     i = floor((iSample-1) / nbCols);
-%     j = mod(iSample-1, nbCols);
-%     ImgSheet(i*H+1:(i+1)*H, j*W+1:(j+1)*W, :) = img;
-%     AlphaSheet(i*H+1:(i+1)*H, j*W+1:(j+1)*W) = alpha;
 end
 
 %% ===== RESTORE INITIAL POSITION =====

--- a/toolbox/gui/view_contactsheet.m
+++ b/toolbox/gui/view_contactsheet.m
@@ -239,9 +239,8 @@ W = size(testImg, 2);
 % Get number of column and rows of the contact sheet
 nbRows = floor(sqrt(nImages));
 nbCols = ceil(nImages / nbRows);
-% Initialize buffer of images
-ImgBuffer   = zeros(H, W, 3, nImages, class(testImg));
-AlphaBuffer = zeros(H, W, 1, nImages);
+% Initialize array for images
+ImgBuffer = zeros(H, W, 3, nImages, class(testImg));
 % Backup current view for 3D figures
 if is3D && dim ~= 0
     hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
@@ -311,9 +310,7 @@ for iSample = 1:nImages
         case 'freq',    img = out_figure_image(hFig, [], FreqLabels{iSample});
         case 'volume',  img = out_figure_image(hFig, [], '');
     end
-    alpha = ones(size(img,1), size(img,2), 1);
     ImgBuffer(:,:,:,iSample) = img;
-    AlphaBuffer(:,:,:,iSample) = alpha;
 end
 
 %% ===== RESTORE INITIAL POSITION =====
@@ -363,7 +360,7 @@ if (dim ~= 0)
     % Remove empty lines and columns
     ImgBuffer(iEmptyRow, :, :, :) = [];
     ImgBuffer(:, iEmptyCol, :, :) = [];
-    % New image size
+    % Update image size
     H = size(ImgBuffer, 1);
     W = size(ImgBuffer, 2);
 end
@@ -371,13 +368,11 @@ end
 
 %% ===== CONCATENATE FINAL IMAGE =====
 ImgSheet   = zeros(nbRows * H, nbCols * W, 3, class(testImg));
-AlphaSheet = zeros(nbRows * H, nbCols * W);
 for iSample = 1:nImages
     % Find extacted image position in final sheet
     i = floor((iSample-1) / nbCols);
     j = mod(iSample-1, nbCols);
     ImgSheet(i*H+1:(i+1)*H, j*W+1:(j+1)*W, :) = ImgBuffer(:,:,:,iSample);
-    AlphaSheet(i*H+1:(i+1)*H, j*W+1:(j+1)*W)  = ones(size(ImgBuffer,1), size(ImgBuffer,2), 1);
 end
 
 


### PR DESCRIPTION
This PR has as goal to have the same functionality in ContactSheets for 3D figures: MRI slices and surfaces. The difference was reported in this Forum thread: 

https://neuroimage.usc.edu/forums/t/45757/10

With these changes, contact sheets from 3D MRI slices will now have:

* Time stamp
* Colorbar 

These two elements will be hidden (as the current behaviour) if and only if there is not data (sources and TF) plotted on the MRI slices, AND volume contact sheets are requested.

For MRI slices: contactsheet `Time` with `Data` (source values)
| Before      | With this PR |
| ----------- | ----------- |
| ![img_1_1](https://github.com/brainstorm-tools/brainstorm3/assets/8238803/81e1081b-b764-4d31-b25c-8508d445a8f2) | ![img_1_2](https://github.com/brainstorm-tools/brainstorm3/assets/8238803/9b90e464-4ed2-4653-a862-8f1e506ecd3d) |

For MRI slices: contactsheet `Volume` without Data
| Before      | With this PR |
| ----------- | ----------- |
| ![img_2_1](https://github.com/brainstorm-tools/brainstorm3/assets/8238803/770c064e-5738-487e-b00e-708f7d347b75) | ![img_2_2](https://github.com/brainstorm-tools/brainstorm3/assets/8238803/b15bdfba-4c9b-415c-b3d6-5fdec0e6226f) |

EDIT: Images have been updated to current state of PR





