### PR TITLE
Add support for importing FreeSurfer results from 'recon-all-clinical.sh'

### DIFF
--- a/toolbox/io/import_anatomy_fs.m
+++ b/toolbox/io/import_anatomy_fs.m
@@ -134,8 +134,8 @@ if ~isReconAllClinical
     T1File = file_find(FsDir, 'T1.mgz', 2);
     T2File = file_find(FsDir, 'T2.mgz', 2);
 else
-    T1File = file_find(FsDir, 'native.mgz', 2);
-    T2File = file_find(FsDir, 'synthSR.mgz', 2);
+    T1File = file_find(FsDir, 'synthSR.raw.mgz', 2);
+    T2File = file_find(FsDir, 'native.mgz', 2);
 end
 
 if isempty(T1File)
@@ -146,6 +146,9 @@ if isempty(T1File)
     else
         errorMsg = [errorMsg 'MRI file was not found: T1.mgz' 10];
     end
+elseif isReconAllClinical
+    T1Comment = 'MRI (synthSR)';
+    T2Comment = 'MRI (native)';
 elseif ~isempty(T1File) && ~isempty(T2File)
     T1Comment = 'MRI T1';
     T2Comment = 'MRI T2';

--- a/toolbox/io/import_anatomy_fs.m
+++ b/toolbox/io/import_anatomy_fs.m
@@ -1,5 +1,5 @@
 function errorMsg = import_anatomy_fs(iSubject, FsDir, nVertices, isInteractive, sFid, isExtraMaps, isVolumeAtlas, isKeepMri)
-% IMPORT_ANATOMY_FS: Import a full FreeSurfer folder as the subject's anatomy.
+% IMPORT_ANATOMY_FS: Import a full FreeSurfer folder as the subject's anatomy, obtained with either 'recon-all' or 'recon-all-clinical'
 %
 % USAGE:  errorMsg = import_anatomy_fs(iSubject, FsDir=[ask], nVertices=[ask], isInteractive=1, sFid=[], isExtraMaps=0, isVolumeAtlas=1, isKeepMri=0)
 %

--- a/toolbox/io/import_anatomy_fs.m
+++ b/toolbox/io/import_anatomy_fs.m
@@ -127,10 +127,20 @@ nVertHemi = round(nVertices / 2);
 %% ===== PARSE FREESURFER FOLDER =====
 bst_progress('start', 'Import FreeSurfer folder', 'Parsing folder...');
 % Find MRI
-T1File = file_find(FsDir, 'T1.mgz', 2);
-T2File = file_find(FsDir, 'T2.mgz', 2);
+
+isReconAllClinical = ~isempty(file_find(FsDir, 'synthSR.mgz', 2));
+
+if ~isReconAllClinical
+    T1File = file_find(FsDir, 'T1.mgz', 2);
+    T2File = file_find(FsDir, 'T2.mgz', 2);
+else
+    T1File = file_find(FsDir, 'native.mgz', 2);
+    T2File = file_find(FsDir, 'synthSR.mgz', 2);
+end
+
 if isempty(T1File)
     T1File = file_find(FsDir, '*.nii.gz', 0);
+
     if ~isempty(T1File)
         T1Comment = 'MRI';
     else

--- a/toolbox/io/in_mri.m
+++ b/toolbox/io/in_mri.m
@@ -133,7 +133,13 @@ switch (FileFormat)
         if isInteractive
             [MRI, vox2ras, tReorient] = in_mri_mgh(MriFile, [], []);
         else
-            [MRI, vox2ras, tReorient] = in_mri_mgh(MriFile, 1, 0);
+            mriDir = bst_fileparts(MriFile);
+            isReconAllClinical = ~isempty(file_find(mriDir, 'synthSR.mgz', 2));
+            if isReconAllClinical
+                [MRI, vox2ras, tReorient] = in_mri_mgh(MriFile, 0, 1);
+            else
+                [MRI, vox2ras, tReorient] = in_mri_mgh(MriFile, 1, 0);
+            end
         end
     case 'KIT'
         error('Not supported yet');

--- a/toolbox/io/in_mri_mgh.m
+++ b/toolbox/io/in_mri_mgh.m
@@ -7,7 +7,7 @@ function [sMri, vox2ras, tReorient] = in_mri_mgh(MriFile, isApplyBst, isApplyVox
 %    - MriFile    : full path to a MRI file, WITH EXTENSION
 %    - isApplyBst : If 1, apply best orientation found to match Brainstorm convention
 %                   considering that the volume is aligned as the standard T1.mgz in the 
-%                   FreeSurfer output folder.
+%                   FreeSurfer output folder from 'recon-all'.
 %    - isApplyVox2ras : Apply additional transformation to the volume
 % OUTPUT:
 %    - sMri      : Standard brainstorm structure for MRI volumes
@@ -142,7 +142,7 @@ end
 if isempty(isApplyBst)
     isApplyBst = java_dialog('confirm', ['Apply the standard transformation FreeSurfer=>Brainstorm?' 10 10 ...
                                          'Answer "yes" if importing transformed volumes such as T1.mgz in the' 10 ...
-                                         'FreeSurfer output folder, or other volumes in the same folder.' 10 10],  'MRI orientation');
+                                         'FreeSurfer output folder from ''recon-call'', or other volumes in the same folder.' 10 10],  'MRI orientation');
 end
 
 % Apply transformation


### PR DESCRIPTION
Add support to import the output folder from the FreeSurfer `recon-all-clinical.sh` pipeline

Requested here: https://neuroimage.usc.edu/forums/t/47017

* Description of the files in the output folder:
  https://surfer.nmr.mgh.harvard.edu/fswiki/recon-all-clinical

* The standard transformation FreeSurfer=>Brainstorm required for results from `recon-all` is not needed for results from `recon-all-clinical`
  https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/io/in_mri_mgh.m#L140-L146

* Anatomical atlases have a different size, due to padding in `recon-all-clinical.sh`
  https://github.com/freesurfer/freesurfer/blob/fdd7a75ae623db77b33ee32b7c13bd161e3e4815/recon_all_clinical/recon-all-clinical.sh#L225
  
* Updated tutorial page: https://neuroimage.usc.edu/brainstorm/Tutorials/LabelFreeSurfer

- [x] Add support in Brainstorm
- [x] Document in Brainstorm pages
