### PR TITLE
Fix brainstorm window with gaps for window 11

### DIFF
--- a/toolbox/gui/gui_layout.m
+++ b/toolbox/gui/gui_layout.m
@@ -77,8 +77,8 @@ function decorationSize = GetDecorationSize(jBstWindow)
         jBstWindow.getBounds.getHeight() - jBstWindow.getRootPane.getBounds.getHeight() - jBstWindow.getRootPane.getBounds.getY(), ...
         20, ...% jBstWindow.getJMenuBar.getSize.getHeight(), ...
         28]; % TOOLBAR HEIGHT
-    % For windows 10 and macos, remove the borders of the figures (they are transparent)
-    if ispc && ~isempty(strfind(system_dependent('getos'), '10'))
+    % For windows 10, 11 and macos, remove the borders of the figures (they are transparent)
+    if ispc && (~isempty(strfind(system_dependent('getos'), '10')) || ~isempty(strfind(system_dependent('getos'), '11')))
         decorationSize(1) = 0;
         decorationSize(2) = 31;
         decorationSize(3) = 2;

--- a/toolbox/gui/gui_layout.m
+++ b/toolbox/gui/gui_layout.m
@@ -77,7 +77,7 @@ function decorationSize = GetDecorationSize(jBstWindow)
         jBstWindow.getBounds.getHeight() - jBstWindow.getRootPane.getBounds.getHeight() - jBstWindow.getRootPane.getBounds.getY(), ...
         20, ...% jBstWindow.getJMenuBar.getSize.getHeight(), ...
         28]; % TOOLBAR HEIGHT
-    % For windows 10, 11 and macos, remove the borders of the figures (they are transparent)
+    % For Windows 10 and 11, remove the borders of the figures (they are transparent)
     if ispc && (~isempty(strfind(system_dependent('getos'), '10')) || ~isempty(strfind(system_dependent('getos'), '11')))
         decorationSize(1) = 0;
         decorationSize(2) = 31;


### PR DESCRIPTION
reported here: https://neuroimage.usc.edu/forums/t/brainstorm-windows-with-gaps/47010

**BEFORE FIX**
![Screenshot 2024-06-26 173358](https://github.com/brainstorm-tools/brainstorm3/assets/21283733/d916ffae-24a4-4cc5-ab01-e068057a9acd)

**AFTER FIX**
![Screenshot 2024-06-26 173516](https://github.com/brainstorm-tools/brainstorm3/assets/21283733/561c810b-2f20-4de9-a868-1ed5d688572b)
