### PR TITLE
Process: Sync recordings, add `xcorr` as sync method

### DIFF
--- a/toolbox/process/functions/process_sync_recordings.m
+++ b/toolbox/process/functions/process_sync_recordings.m
@@ -48,17 +48,13 @@ function sProcess = GetDescription()
     sProcess.options.src.Comment  = 'Sync event name: ';
     sProcess.options.src.Type     = 'text';
     sProcess.options.src.Value    = '';
-
-    sProcess.options.method_title.Comment    = '<BR><B><U>Method for event synchronization:</U></B>:';
-    sProcess.options.method_title.Type       = 'label';
-
-    sProcess.options.method.Comment = {'Mean :  minimize the mean difference between the event timing of the two files', ... 
-                                       'Correlation: maximize the correlation between the event timing of the two files';  ...
-                                       'mean', 'xcorr'};
+    % Sync method
+    sProcess.options.method_title.Comment = '<BR><B><U>Method for event synchronization:</U></B>:';
+    sProcess.options.method_title.Type    = 'label';
+    sProcess.options.method.Comment = {'<B>xcorr</B> : maximize the correlation between the event timing of the two files',  ...                                       '<B>Mean</B> :  minimize the mean difference between the event timing of the two files'; ...
+                                       'xcorr', 'mean'};
     sProcess.options.method.Type    = 'radio_label';
-    sProcess.options.method.Value   = 'mean';
-    
- 
+    sProcess.options.method.Value   = 'xcorr';
 end
 
 

--- a/toolbox/process/functions/process_sync_recordings.m
+++ b/toolbox/process/functions/process_sync_recordings.m
@@ -130,7 +130,7 @@ function OutputFiles = Run(sProcess, sInputs)
             offsetStd = std(shifting);
         end
 
-        if  size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2) || offsetStd > 1000
+        if  size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2) || offsetStd > 1
 
             if size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2)
                 bst_report('Warning', sProcess, sInputs, 'Files doesnt have the same number of sync events. Using approximation');

--- a/toolbox/process/functions/process_sync_recordings.m
+++ b/toolbox/process/functions/process_sync_recordings.m
@@ -124,20 +124,22 @@ function OutputFiles = Run(sProcess, sInputs)
     new_times{1}  = sOldTiming{1}.Time;
     mean_shifting = zeros(1, nInputs);
     for iInput = 2:nInputs
-        if size(sEvtSync(iInput).times, 2) == size(sEvtSync(1).times, 2)
+        isSameNumberEvts = size(sEvtSync(iInput).times, 2) == size(sEvtSync(1).times, 2);
+        % Same number of sync events
+        if isSameNumberEvts
             shifting = sEvtSync(iInput).times - sEvtSync(1).times;
             mean_shifting(iInput) = mean(shifting);
             offsetStd = std(shifting);
         end
-
-        if  size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2) || offsetStd > 1
-
-            if size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2)
-                bst_report('Warning', sProcess, sInputs, 'Files doesnt have the same number of sync events. Using approximation');
+        % Diff number of sync events OR shift std > 1s
+        if ~isSameNumberEvts || offsetStd > 1
+            if ~isSameNumberEvts
+                strWarning = 'Files doesnt have the same number of sync events.';
             else
-                bst_report('Warning', sProcess, sInputs, 'Large uncertainty on the synchronization. Using approximation instead');
+                strWarning = sprintf('Files have the same number of sync events, but large shift std (%.3f s)', offsetStd);
             end
-
+            strWarning = [strWarning, 10, 'Using cross-correlation approximation'];
+            bst_report('Warning', sProcess, sInputs, strWarning);
             % Cross-correlate trigger signals; need to be at the same sampling frequency
             tmp_fs      = max(fs(iInput), fs(1));
             tmp_time_a  = sOldTiming{iInput}.Time(1):1/tmp_fs:sOldTiming{iInput}.Time(end);

--- a/toolbox/process/functions/process_sync_recordings.m
+++ b/toolbox/process/functions/process_sync_recordings.m
@@ -128,8 +128,16 @@ function OutputFiles = Run(sProcess, sInputs)
             shifting = sEvtSync(iInput).times - sEvtSync(1).times;
             mean_shifting(iInput) = mean(shifting);
             offsetStd = std(shifting);
-        else
-            bst_report('Warning', sProcess, sInputs, 'Files doesnt have the same number of sync events. Using approximation');
+        end
+
+        if  size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2) || offsetStd > 1000
+
+            if size(sEvtSync(iInput).times, 2) ~= size(sEvtSync(1).times, 2)
+                bst_report('Warning', sProcess, sInputs, 'Files doesnt have the same number of sync events. Using approximation');
+            else
+                bst_report('Warning', sProcess, sInputs, 'Large uncertainty on the synchronization. Using approximation instead');
+            end
+
             % Cross-correlate trigger signals; need to be at the same sampling frequency
             tmp_fs      = max(fs(iInput), fs(1));
             tmp_time_a  = sOldTiming{iInput}.Time(1):1/tmp_fs:sOldTiming{iInput}.Time(end);


### PR DESCRIPTION
Hello, 

This is a PR to use the approximation when std is detected to be large: 


Before: 
```
Lag difference between @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-eeg_run-02_band_notch_resample and @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-physio_run-02_resample : 91683.58 ms **(std: 83872.79 ms)**
Lag difference between @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-eeg_run-02_band_notch_resample and @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-nirs_run-02 : -277246.51 ms (std: 125.73 ms)
```

![image](https://github.com/user-attachments/assets/a5b9130e-ed90-42b0-a5a3-573031e24868)


The events are no longer synced with the analog trigger

After: 
```

Lag difference between @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-eeg_run-02_band_notch_resample and @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-physio_run-02_resample : 108628.00 ms (std: 0.00 ms)
Lag difference between @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-eeg_run-02_band_notch_resample and @rawsub-PA13_ses-EEGfNIRS02_task-sleep_mod-nirs_run-02 : -277228.00 ms (std: 0.00 ms)

```

![image](https://github.com/user-attachments/assets/8253511f-891c-4704-9eb3-c5a41ab59f10)

(synchronization are well aligned with the analog trigger)



