### PR TITLE
change default color order  for nirs

### DIFF
--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3250,6 +3250,10 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
     if (TsInfo.ShowLegend)
         if isempty(LinesColor)
             ColorOrder = panel_scout('GetScoutsColorTable');
+            if ~isempty(strfind(TsInfo.DisplayUnits,'mol'))
+                ColorOrder([1,3,2],:) = ColorOrder([2,1,3],: );
+
+            end
         else
             ColorOrder = [];
         end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3256,16 +3256,12 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
             iHbT = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbT')));
             
             if ~isempty(iHbO) ||  ~isempty(iHbR) || ~isempty(iHbT)
+
                 ColorOrderNew = ColorOrder;
-                if ~isempty(iHbO) 
-                    ColorOrderNew(iHbO,:) = ColorOrder(2, :);
-                end
-                if ~isempty(iHbR)
-                    ColorOrderNew(iHbR,:) = ColorOrder(3, :);
-                end
-                if ~isempty(iHbT)
-                    ColorOrderNew(iHbT,:) = ColorOrder(1, :);
-                end
+                ColorOrderNew(iHbO,:) = repmat( ColorOrder(2, :), length(iHbO),1);
+                ColorOrderNew(iHbR,:) = repmat(ColorOrder(3, :), length(iHbR),1);
+                ColorOrderNew(iHbT,:) = repmat( ColorOrder(1, :), length(iHbT),1);
+
                 ColorOrder = ColorOrderNew;
             end
 

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3254,7 +3254,7 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
                 iHbO = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbO')));
                 iHbR = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbR')));
                 iHbT = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbT')));
-                if ~isempty(iHbO) ||  ~isempty(iHbR) || ~isempty(iHbT)
+                if (~isempty(iHbO) &&  ~isempty(iHbR)) || (~isempty(iHbO) &&  ~isempty(iHbT)) || (~isempty(iHbT) &&  ~isempty(iHbR))
                     ColorsGRB = ColorOrder(1:3,:);
                     ColorOrder(iHbO,:) = repmat(ColorsGRB(2,:), length(iHbO),1); % Red
                     ColorOrder(iHbR,:) = repmat(ColorsGRB(3,:), length(iHbR),1); % Blue

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3250,21 +3250,17 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
     if (TsInfo.ShowLegend)
         if isempty(LinesColor)
             ColorOrder = panel_scout('GetScoutsColorTable');
-
-            iHbO = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbO')));
-            iHbR = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbR')));
-            iHbT = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbT')));
-            
-            if ~isempty(iHbO) ||  ~isempty(iHbR) || ~isempty(iHbT)
-
-                ColorOrderNew = ColorOrder;
-                ColorOrderNew(iHbO,:) = repmat( ColorOrder(2, :), length(iHbO),1);
-                ColorOrderNew(iHbR,:) = repmat(ColorOrder(3, :), length(iHbR),1);
-                ColorOrderNew(iHbT,:) = repmat( ColorOrder(1, :), length(iHbT),1);
-
-                ColorOrder = ColorOrderNew;
+            if strcmpi(TsInfo.Modality, 'NIRS')
+                iHbO = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbO')));
+                iHbR = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbR')));
+                iHbT = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbT')));
+                if ~isempty(iHbO) ||  ~isempty(iHbR) || ~isempty(iHbT)
+                    ColorsGRB = ColorOrder(1:3,:);
+                    ColorOrder(iHbO,:) = repmat(ColorsGRB(2,:), length(iHbO),1); % Red
+                    ColorOrder(iHbR,:) = repmat(ColorsGRB(3,:), length(iHbR),1); % Blue
+                    ColorOrder(iHbT,:) = repmat(ColorsGRB(1,:), length(iHbT),1); % Green
+                end
             end
-
         else
             ColorOrder = [];
         end

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3250,10 +3250,25 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
     if (TsInfo.ShowLegend)
         if isempty(LinesColor)
             ColorOrder = panel_scout('GetScoutsColorTable');
-            if ~isempty(strfind(TsInfo.DisplayUnits,'mol'))
-                ColorOrder([1,3,2],:) = ColorOrder([2,1,3],: );
 
+            iHbO = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbO')));
+            iHbR = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbR')));
+            iHbT = find(cellfun(@(x)~isempty(x), strfind(LinesLabels, 'HbT')));
+            
+            if ~isempty(iHbO) ||  ~isempty(iHbR) || ~isempty(iHbT)
+                ColorOrderNew = ColorOrder;
+                if ~isempty(iHbO) 
+                    ColorOrderNew(iHbO,:) = ColorOrder(2, :);
+                end
+                if ~isempty(iHbR)
+                    ColorOrderNew(iHbR,:) = ColorOrder(3, :);
+                end
+                if ~isempty(iHbT)
+                    ColorOrderNew(iHbT,:) = ColorOrder(1, :);
+                end
+                ColorOrder = ColorOrderNew;
             end
+
         else
             ColorOrder = [];
         end


### PR DESCRIPTION
By convention, we prefer to have HbO in red, HbR in blue, and HbT in green. This changes the order so the colors are good without modifying the figure. 

Before; 
![image](https://github.com/user-attachments/assets/83966344-3541-46dc-a902-bdd3aa4d4148)


After:

![image](https://github.com/user-attachments/assets/c4fe44fd-95e9-415c-a18c-205682a6a88d)


one small limitation with this fix is that displaying multiple HbO signals will make them all red. 