### PR TITLE
[MEM] Reduce file size when using wavelet-MEM 

### DIFF
--- a/toolbox/io/in_bst_results.m
+++ b/toolbox/io/in_bst_results.m
@@ -70,7 +70,6 @@ else
     if any(ismember({'ImageGridAmp','ImagingKernel'}, FieldsToRead))
         FieldsToRead{end + 1} = 'ImagingKernel';
         FieldsToRead{end + 1} = 'ImageGridAmp';
-        FieldsToRead{end + 1} = 'ImagingPostKernel';
         FieldsToRead{end + 1} = 'GoodChannel';
         FieldsToRead{end + 1} = 'OPTIONS';
         FieldsToRead{end + 1} = 'ZScore';

--- a/toolbox/io/in_bst_results.m
+++ b/toolbox/io/in_bst_results.m
@@ -261,11 +261,16 @@ if isKernel
             Results.Leff = DataMat.Leff;
         end
     end
-elseif isfield(Results,'ImagingPostKernel') && ~isempty(Results.ImagingPostKernel)
-    % Convert from time-frequency representation to time representation.
 
-    Results.ImageGridAmp  = Results.ImageGridAmp * Results.ImagingPostKernel;
-    Results.ImagingPostKernel = [];
+elseif isfield(Results,'ImageGridAmp') && iscell(Results.ImageGridAmp)
+    % Results is saved as factor decomposition: ImageGridAmp =
+    % ImageGridAmp{1} * ImageGridAmp{2} * ... * ImageGridAmp{N}
+
+    tmp = Results.ImageGridAmp{1};
+    for iDecomposition = 2 : length(Results.ImageGridAmp)
+        tmp = tmp * Results.ImageGridAmp{iDecomposition};
+    end
+    Results.ImageGridAmp = full(tmp);
 end
 
 

--- a/toolbox/io/in_bst_results.m
+++ b/toolbox/io/in_bst_results.m
@@ -260,11 +260,9 @@ if isKernel
             Results.Leff = DataMat.Leff;
         end
     end
-
+% If full results are saved as factor decomposition
 elseif isfield(Results,'ImageGridAmp') && iscell(Results.ImageGridAmp)
-    % Results is saved as factor decomposition: ImageGridAmp =
-    % ImageGridAmp{1} * ImageGridAmp{2} * ... * ImageGridAmp{N}
-
+    % ImageGridAmp = ImageGridAmp{1} * ImageGridAmp{2} * ... * ImageGridAmp{N}
     tmp = Results.ImageGridAmp{1};
     for iDecomposition = 2 : length(Results.ImageGridAmp)
         tmp = tmp * Results.ImageGridAmp{iDecomposition};

--- a/toolbox/io/in_bst_results.m
+++ b/toolbox/io/in_bst_results.m
@@ -70,6 +70,7 @@ else
     if any(ismember({'ImageGridAmp','ImagingKernel'}, FieldsToRead))
         FieldsToRead{end + 1} = 'ImagingKernel';
         FieldsToRead{end + 1} = 'ImageGridAmp';
+        FieldsToRead{end + 1} = 'ImagingPostKernel';
         FieldsToRead{end + 1} = 'GoodChannel';
         FieldsToRead{end + 1} = 'OPTIONS';
         FieldsToRead{end + 1} = 'ZScore';
@@ -260,6 +261,11 @@ if isKernel
             Results.Leff = DataMat.Leff;
         end
     end
+elseif isfield(Results,'ImagingPostKernel') && ~isempty(Results.ImagingPostKernel)
+    % Convert from time-frequency representation to time representation.
+
+    Results.ImageGridAmp  = Results.ImageGridAmp * Results.ImagingPostKernel;
+    Results.ImagingPostKernel = [];
 end
 
 

--- a/toolbox/process/functions/process_inverse_2018.m
+++ b/toolbox/process/functions/process_inverse_2018.m
@@ -694,9 +694,7 @@ function [OutputFiles, errMessage] = Compute(iStudies, iDatas, OPTIONS)
                 OPTIONS.FunctionName  = 'mem';
                 % Call the mem solver
                 [Results, OPTIONS] = be_main(HeadModel, OPTIONS);
-                if isfield(Results, 'nComponents')
-                    Results.nComponents = Results.nComponents;
-                else
+                if ~isfield(Results, 'nComponents') || isempty(Results.nComponents)
                     Results.nComponents = round(max(size(Results.ImageGridAmp,1),size(Results.ImagingKernel,1)) / nSources);
                 end
 

--- a/toolbox/process/functions/process_inverse_2018.m
+++ b/toolbox/process/functions/process_inverse_2018.m
@@ -694,7 +694,12 @@ function [OutputFiles, errMessage] = Compute(iStudies, iDatas, OPTIONS)
                 OPTIONS.FunctionName  = 'mem';
                 % Call the mem solver
                 [Results, OPTIONS] = be_main(HeadModel, OPTIONS);
-                Results.nComponents = round(max(size(Results.ImageGridAmp,1),size(Results.ImagingKernel,1)) / nSources);
+                if iscell(Results.ImageGridAmp)
+                    Results.nComponents = round(max(size(Results.ImageGridAmp{1},1),size(Results.ImagingKernel,1)) / nSources);
+                else
+                    Results.nComponents = round(max(size(Results.ImageGridAmp,1),size(Results.ImagingKernel,1)) / nSources);
+                end
+                
                 % Get outputs
                 DataFile = OPTIONS.DataFile; 
                 Time     = OPTIONS.DataTime;

--- a/toolbox/process/functions/process_inverse_2018.m
+++ b/toolbox/process/functions/process_inverse_2018.m
@@ -694,12 +694,12 @@ function [OutputFiles, errMessage] = Compute(iStudies, iDatas, OPTIONS)
                 OPTIONS.FunctionName  = 'mem';
                 % Call the mem solver
                 [Results, OPTIONS] = be_main(HeadModel, OPTIONS);
-                if iscell(Results.ImageGridAmp)
-                    Results.nComponents = round(max(size(Results.ImageGridAmp{1},1),size(Results.ImagingKernel,1)) / nSources);
+                if isfield(Results, 'nComponents')
+                    Results.nComponents = Results.nComponents;
                 else
                     Results.nComponents = round(max(size(Results.ImageGridAmp,1),size(Results.ImagingKernel,1)) / nSources);
                 end
-                
+
                 % Get outputs
                 DataFile = OPTIONS.DataFile; 
                 Time     = OPTIONS.DataTime;


### PR DESCRIPTION
Hi, 

This implements the idea I started here: https://neuroimage.usc.edu/forums/t/stange-bug-when-saving-mem-results/45901/7 when using wMEM. The main idea is to attempt to reduce the file size. this is mostly important for nirs as we are about to use wMEM for long-duration data but it is also nice for EEG/MEG. 


The principle is the following: for wMEM, the data is first transformed using a time-frequency representation (nSensor x nBox), then each time-frequency box is localized, and finally, the time-course is recreated by inverting the time-frequency transformation. 

The last step can be seen here: 
This can be seen here: https://github.com/Edouard2laire/best-brainstorm/blob/wMEM-nirs/best/wmem/solver/be_wmem_solver.m#L202-L204

```matlab

    inv_proj    =   be_wavelet_inverse( wav, OPTIONS );
    inv_proj    =   inv_proj(:,obj.info_extension.start:obj.info_extension.end);
    obj.ImageGridAmp =  obj.ImageGridAmp * inv_proj;

```

The objective of this PR is instead of saving the result of the multiplication obj.ImageGridAmp (nVertex x nBox) * inv_proj (nBox x nTimes) to save each matrix separately and compute the multiplication on loading. 


```matlab

% Results (full temporal sequence)
Results = struct(...
    'ImageGridAmp',     obj.ImageGridAmp, ...
    'ImagingPostKernel',inv_proj, ...
    'ImagingKernel',    [], ...
    'MEMoptions',       OPTIONS, ...
    'MEMdata',          obj);

```

On the EEG data for the epilepsy tutorial, it means that we go from a matrix ImageGridAmp: [15002x206 double] 
to ImageGridAmp:      [15002x29 double] and ImagingPostKernel: [29x206 double] 


so that the size of the file in brainstorm db goes down from 120356918 Bytes to 77919214 Bytes ( 35% reduction). 
Let me know if this change would be ok for you to integrate in Brainstorm. 


Note; I was not sure about the name ImagingPostKernel, so if you have a better idea :) 

Edouard


