### PR TITLE
bugfix: Index Exceeds Array Bounds 

### DIFF
--- a/toolbox/gui/panel_coordinates.m
+++ b/toolbox/gui/panel_coordinates.m
@@ -484,6 +484,10 @@ function [TessInfo, iTess, pout, vout, vi, hPatch] = ClickPointInSurface(hFig, S
             patchDist(i) = norm(pout{i}' - CameraPosition);
             % Find centroid the blob mesh that contains the vertex 'vi'
             if isCentroid
+                % upper limit cap for the vertex patch index returned from "select3d" 
+                if vi{i} > size(sSurf.VertConn, 1)
+                    vi{i} = size(sSurf.VertConn, 1);
+                end
                 VertexList = FindCentroid(sSurf, find(sSurf.VertConn(vi{i},:)), [], 1, 6);
                 vout{i} = mean(sSurf.Vertices(VertexList(:), :)); % SCS of the centroid
                 vi{i} = []; % No surface vertex associated to centroid

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -420,7 +420,7 @@ function SliderCallback(hObject, event, target)
                 CtFile = [];
                 MeshFile = [];
                 for i=1:length(sSubject.Anatomy)
-                    if ~isempty(regexp(sSubject.Anatomy(i).FileName, 'CT', 'match')) 
+                    if ~isempty(regexp(sSubject.Anatomy(i).FileName, '_volct', 'match')) 
                         CtFile = sSubject.Anatomy(i).FileName;
                     end
                 end
@@ -538,7 +538,7 @@ function isoValue = GetIsoValueMaxRange()
             sSubject = bst_get('Subject', SubjectFile);
             CtFile = [];
             for i=1:length(sSubject.Anatomy)
-                if ~isempty(regexp(sSubject.Anatomy(i).FileName, 'CT', 'match')) 
+                if ~isempty(regexp(sSubject.Anatomy(i).FileName, '_volct', 'match')) 
                     CtFile = sSubject.Anatomy(i).FileName;
                 end
             end


### PR DESCRIPTION
Issue reported: https://neuroimage.usc.edu/forums/t/index-exceeds-array-bounds/47316

Test data (as provided by user): Will share privately

Steps to reproduce:
1. Load MRI,CT and generate isosurface with around 6000 threshold 
2. Start SEEG implantation and click on any contact on the isosurface.
3. Error appears

The root cause of the issue was that when the user clicked on the surface, (from the code) the vertex patch index returned from `select3d` exceeded the `sSurf.VertConn` size. This has been handled [b4b915b](https://github.com/brainstorm-tools/brainstorm3/pull/734/commits/b4b915b5b2ccc174904e2af27fcca56f01633098).

Came up with another issue while doing this was that the CT file was not being found while changing the isosurface threshold from slider. While [502d78b](https://github.com/brainstorm-tools/brainstorm3/pull/734/commits/502d78b434e6349fd8bc08133c41d41b91acb67a) might be a band-aid fix for now but this is being completely revamped here https://github.com/rcassani/brainstorm3/pull/31.