### PR TITLE
[bugfix] exit view_surface_data peacefully

### DIFF
--- a/toolbox/gui/view_surface_data.m
+++ b/toolbox/gui/view_surface_data.m
@@ -167,6 +167,10 @@ switch (DataType)
         iDS = bst_memory('GetDataSetSubject', sSubject.FileName, 1);
 end
 
+if isempty(iDS)
+    % Something went wrong before
+    return;
+end
 
 %% ===== MODALITY =====
 if isempty(Modality)


### PR DESCRIPTION
Currently, if you open two files with different time definition, Brainstorm will show the nice error: 

'''
***************************************************************************
** Error: Time definition for this file is not compatible with the other files
** already loaded in Brainstorm.
** Close existing windows before opening this file, or use the Navigator.
***************************************************************************

''' 

followed by a matlab error: 


''''
***************************************************************************
** Error: Line 175:  isempty
** Not enough input arguments.
** 
** Call stack:
** >view_surface_data.m at 175
** >tree_callbacks.m at 293
** >bst_call.m at 28
** >panel_protocols.m>CreatePanel/protocolTreeClicked_Callback at 125
** >bst_call.m at 28
** >panel_protocols.m>@(h,ev)bst_call(@protocolTreeClicked_Callback,h,ev) at 75
** 
***************************************************************************
'''

This PR ensure that view_surface_data doesn't continue if an error occurs during loading. Removing the matlab error.