### PR TITLE
fix nComponent in process_inverse

### DIFF
--- a/toolbox/process/functions/process_inverse.m
+++ b/toolbox/process/functions/process_inverse.m
@@ -694,6 +694,10 @@ function [OutputFiles, errMessage] = Compute(iStudies, iDatas, OPTIONS)
                 OPTIONS.NoiseCovRaw   = NoiseCov;
                 % Call the mem solver
                 [Results, OPTIONS] = be_main(HeadModel, OPTIONS);
+                if ~isfield(Results, 'nComponents') || isempty(Results.nComponents)
+                    Results.nComponents = round(max(size(Results.ImageGridAmp,1),size(Results.ImagingKernel,1)) / nSources);
+                end
+
                 Results.nComponents = round(max(size(Results.ImageGridAmp,1),size(Results.ImagingKernel,1)) / nSources);
                 % Get outputs
                 DataFile = OPTIONS.DataFile; 


### PR DESCRIPTION
This applies the changes of https://github.com/brainstorm-tools/brainstorm3/pull/733/files to process_inverse. 

Btw, shouldn't process_inverse_mem call process_inverse_2018 (like what happens in the panel) instead of process_inverse ?