### PR TITLE
Anat: Add template `Colin27_4NIRS_2024`

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -2385,7 +2385,7 @@ switch contextName
             sTemplates(end).Name = 'Colin27_2016';
         end
         if ~ismember('colin27_4nirs_2024', lower({sTemplates.Name}))
-            sTemplates(end+1).FilePath = 'https://drive.google.com/uc?export=download&id=1kFqz-TxtXMcH-yIfO6GnFl88pAA6tat4';
+            sTemplates(end+1).FilePath = 'http://neuroimage.usc.edu/bst/getupdate.php?t=Colin27_4NIRS_2024';
             sTemplates(end).Name = 'Colin27_4NIRS_2024';
         end
         if ~ismember('colin27_brainsuite_2016', lower({sTemplates.Name}))

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -2384,6 +2384,10 @@ switch contextName
             sTemplates(end+1).FilePath = 'http://neuroimage.usc.edu/bst/getupdate.php?t=Colin27_2016';
             sTemplates(end).Name = 'Colin27_2016';
         end
+        if ~ismember('colin27_4nirs_2024', lower({sTemplates.Name}))
+            sTemplates(end+1).FilePath = 'https://drive.google.com/uc?export=download&id=1kFqz-TxtXMcH-yIfO6GnFl88pAA6tat4';
+            sTemplates(end).Name = 'Colin27_4NIRS_2024';
+        end
         if ~ismember('colin27_brainsuite_2016', lower({sTemplates.Name}))
             sTemplates(end+1).FilePath = 'http://neuroimage.usc.edu/bst/getupdate.php?t=Colin27_BrainSuite_2016';
             sTemplates(end).Name = 'Colin27_BrainSuite_2016';


### PR DESCRIPTION
Hello, 

This PR adds a specific version of Colin 27 useful for NIRS (containing Voronoi and segmentation). 

This template is nice as we also have pre-computed fluences so people can use it simply for optimal montage or source reconstruction.  

~~Currently, the template is hosted on Google Drive, but we could move it to your server if you think it would be more convenient.~~

Here is the content of the template: 

![image](https://github.com/user-attachments/assets/3d50c958-63a8-4d81-9596-56d2a8524402)


Edouard
