### PR TITLE
[bugfix] import non-skull stripped version of  T2

### DIFF
--- a/toolbox/io/import_anatomy_fs.m
+++ b/toolbox/io/import_anatomy_fs.m
@@ -133,7 +133,7 @@ isReconAll         = ~isempty(file_find(FsDir, 'T1.mgz', 2)) && ~isReconAllClini
 mri1File = '';
 if isReconAll
     mri1File = file_find(FsDir, 'T1.mgz', 2);
-    mri2File = file_find(FsDir, 'T2.mgz', 2);
+    mri2File = file_find(FsDir, 'T2.norm.mgz', 2);
     mri1Comment = 'MRI T1';
     mri2Comment = 'MRI T2';
 elseif isReconAllClinical


### PR DESCRIPTION
Hello, 

Currently,  when importing T2 image from freesurfer segmentation, we import the image that has been skull stripped 
![image](https://github.com/user-attachments/assets/93b3e4b2-52a8-4457-98cf-b8c514a99e75)

However, this can be an issue later when we do segmentation inside Brainstorm using SPM (to get tissue map) as SPM is expecting a full T1 and T2. 

This is importing the full T2 image: 

![image](https://github.com/user-attachments/assets/d04ce737-e5c1-4f41-9784-b627c8f71ad3)


Regards, 
Edouard


