### PR TITLE
iEEG: Different ways to start `SEEG/ECOG Implantation`

### DIFF
--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -165,7 +165,7 @@ if isSave
     
     % Save isosurface
     sMesh.Comment = sprintf('isoSurface (ISO_%d)', isoValue);
-    sMesh = bst_history('add', sMesh, 'threshold_ct', 'CT thresholded isosurface generated with Brainstorm');
+    sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName]);
     bst_save(MeshFile, sMesh, 'v7');
     iSurface = db_add_surface(iSubject, MeshFile, sMesh.Comment);
     % Display mesh with 3D orthogonal slices of the default MRI

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -165,7 +165,7 @@ if isSave
     
     % Save isosurface
     sMesh.Comment = sprintf('isoSurface (ISO_%d)', isoValue);
-    sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName]);
+    sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName ' threshold = ' num2str(isoValue)]);
     bst_save(MeshFile, sMesh, 'v7');
     iSurface = db_add_surface(iSubject, MeshFile, sMesh.Comment);
     % Display mesh with 3D orthogonal slices of the default MRI

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -968,7 +968,7 @@ switch contextName
     % Usage: [sAnalStudy, iAnalStudy] = bst_get('AnalysisIntraStudy', iSubject) 
     case 'AnalysisIntraStudy'
         % Parse inputs
-        if (nargin == 2) && isnumeric(varargin{2})
+        if (nargin == 2)
             iSubject = varargin{2};
         else
             error('Invalid call to bst_get()');

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3042,9 +3042,9 @@ end
 
 
 %% ===== CREATE IMPLANTATION =====
-function CreateImplantation(MriFile) %#ok<DEFNU>
 % USAGE: CreateImplantation(MriFile)   % Implantation on given Volume file
 %        CreateImplantation(sSubject)  % Ask user for Volume and Surface files for implantation
+function CreateImplantation(MriFile) %#ok<DEFNU>
     % Parse input
     if isstruct(MriFile)
         sSubject = MriFile;

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3304,7 +3304,6 @@ function [hFig, iDS, iFig] = DisplayChannelsMri(ChannelFile, Modality, iAnatomy,
     if isempty(hFig)
         return;
     end
-
     % Add channels to the figure
     LoadElectrodes(hFig, ChannelFile, Modality);
     % SEEG and ECOG: Open tab "iEEG"

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3151,7 +3151,7 @@ function CreateImplantation(MriFile) %#ok<DEFNU>
             sSurf = load(file_fullpath(sSubject.Surface(iSrf).FileName), 'History');
             if isfield(sSurf, 'History') && ~isempty(sSurf.History)
                 % Search for CT threshold in history
-                ctEntry = regexp([sSurf.History{:, 3}], '^Thresholded CT:\s*(\S+)', 'tokens', 'once');
+                ctEntry = regexp(sSurf.History{:, 3}, '^Thresholded CT:\s(.*)$', 'tokens', 'once');
                 % Return intersection of the found and the, update iCTVol
                 if ~isempty(ctEntry)
                     [~, iCtIso] = ismember(ctEntry{1}, {sSubject.Anatomy.FileName});

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3155,7 +3155,7 @@ function CreateImplantation(MriFile) %#ok<DEFNU>
                 % Return intersection of the found and then update iCtVol
                 if ~isempty(ctEntry)
                     [~, iCtIso] = ismember(ctEntry{1}, {sSubject.Anatomy.FileName});
-                    if ~isempty(iCtIso)
+                    if iCtIso
                         iCtVol = intersect(iCtIso, iCtVol);
                     else
                         bst_error(sprintf(['The CT that was used to create the IsoSurface cannot be found. ' 10 ...

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3361,6 +3361,10 @@ function [hFig, iDS, iFig] = DisplayIsosurface(Subject, hFig, ChannelFile, Modal
     [hFig, iDS, iFig] = view_surface(Subject.Surface(ixIsoSurf(1)).FileName, 0.6, [], hFig, []);
     % Add channels to the figure
     LoadElectrodes(hFig, ChannelFile, Modality);
+    % SEEG and ECOG: Open tab "iEEG"
+    if ismember(Modality, {'SEEG', 'ECOG', 'ECOG+SEEG'})
+        gui_brainstorm('ShowToolTab', 'iEEG'); 
+    end
 end
 
 %% ===== EXPORT CONTACT POSITIONS =====

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3042,10 +3042,16 @@ end
 
 
 %% ===== CREATE IMPLANTATION =====
-function CreateImplantation(MriFile, isAsk) %#ok<DEFNU>
-    % Find subject
-    [sSubject,iSubject,iAnatomy] = bst_get('MriFile', MriFile);
-    
+function CreateImplantation(MriFile) %#ok<DEFNU>
+% USAGE: CreateImplantation(MriFile)   % Implantation on given Volume file
+%        CreateImplantation(sSubject)  % Ask user for Volume and Surface files for implantation
+    % Parse input
+    if isstruct(MriFile)
+        sSubject = MriFile;
+        MriFile  = [];
+    else
+        sSubject = bst_get('MriFile', MriFile);
+    end
     % Get study for the new channel file
     switch (sSubject.UseDefaultChannel)
         case 0
@@ -3076,7 +3082,7 @@ function CreateImplantation(MriFile, isAsk) %#ok<DEFNU>
             sStudy = bst_get('Study', iStudy);
         case 1
             % Use default channel file
-            [sStudy, iStudy] = bst_get('AnalysisIntraStudy', iSubject);
+            [sStudy, iStudy] = bst_get('AnalysisIntraStudy', sSubject.Name);
             % The @intra study must not contain an existing channel file
             if ~isempty(sStudy.Channel) && ~isempty(sStudy.Channel(1).FileName)
                 error(['There is already a channel file for this subject:' 10 sStudy.Channel(1).FileName]);

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3152,13 +3152,13 @@ function CreateImplantation(MriFile) %#ok<DEFNU>
             if isfield(sSurf, 'History') && ~isempty(sSurf.History)
                 % Search for CT threshold in history
                 ctEntry = regexp(sSurf.History{:, 3}, '^Thresholded CT:\s(.*)\sthreshold.*$', 'tokens', 'once');
-                % Return intersection of the found and the, update iCTVol
+                % Return intersection of the found and then update iCtVol
                 if ~isempty(ctEntry)
                     [~, iCtIso] = ismember(ctEntry{1}, {sSubject.Anatomy.FileName});
                     if ~isempty(iCtIso)
                         iCtVol = intersect(iCtIso, iCtVol);
                     else
-                        bst_error(sprintf(['The CT that was used to create the IsoSurface canno be found. ' 10 ...
+                        bst_error(sprintf(['The CT that was used to create the IsoSurface cannot be found. ' 10 ...
                                            'CT file : %s'], ctEntry{1}), 'Loading CT for IsoSurface');
                         return
                     end

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3151,7 +3151,7 @@ function CreateImplantation(MriFile) %#ok<DEFNU>
             sSurf = load(file_fullpath(sSubject.Surface(iSrf).FileName), 'History');
             if isfield(sSurf, 'History') && ~isempty(sSurf.History)
                 % Search for CT threshold in history
-                ctEntry = regexp(sSurf.History{:, 3}, '^Thresholded CT:\s(.*)$', 'tokens', 'once');
+                ctEntry = regexp(sSurf.History{:, 3}, '^Thresholded CT:\s(.*)\sthreshold.*$', 'tokens', 'once');
                 % Return intersection of the found and the, update iCTVol
                 if ~isempty(ctEntry)
                     [~, iCtIso] = ismember(ctEntry{1}, {sSubject.Anatomy.FileName});

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3042,9 +3042,7 @@ end
 
 
 %% ===== CREATE IMPLANTATION =====
-% 
 function CreateImplantation(MriFile, isAsk) %#ok<DEFNU>
-    % 
     % Find subject
     [sSubject,iSubject,iAnatomy] = bst_get('MriFile', MriFile);
     

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3165,7 +3165,7 @@ function CreateImplantation(MriFile) %#ok<DEFNU>
                 end
             end
         end
-        if length(iCtVol) > 1
+        if ~strcmpi(res, 'mri') && length(iCtVol) > 1
             % Prompt for the CT file selection
             ctComment = java_dialog('combo', '<HTML>Select the CT file:<BR><BR>', 'Choose CT file', [], {sSubject.Anatomy(iCtVol).Comment});
             if isempty(ctComment)

--- a/toolbox/gui/view_channels_3d.m
+++ b/toolbox/gui/view_channels_3d.m
@@ -141,16 +141,8 @@ if ~isempty(sSubject)
                 end
                 SurfAlpha = .1;
                 hFig = view_mri_3d(SurfaceFile, [], SurfAlpha, hFig);
-                if strcmpi(Modality, 'SEEG')
-                    % For SEEG, display 3D slices (MRI) + isosurface
-                    panel_ieeg('DisplayIsosurface', sSubject, hFig, FileNames{1}, Modality);
-                end
             end
         otherwise
-    end
-    if strcmpi(Modality, 'SEEG')
-        % For SEEG, display MRI viewer for all Surface Types
-        panel_ieeg('DisplayChannelsMri', FileNames{1}, Modality, 1, 0);
     end
 end
 % Warning if no surface was found

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -702,6 +702,11 @@ switch (lower(action))
                     % fcnPopupProjectSources(0);
                 end
                 fcnPopupScoutTimeSeries(jPopup);
+                AddSeparator(jPopup);
+                % === SEEG IMPLANTATION ===
+                if ~isempty(sSubject.Anatomy)
+                    gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', sSubject.Anatomy(sSubject.iAnatomy).FileName, 1));
+                end
                 % Export menu (added later)
                 jMenuExport = gui_component('MenuItem', [], [], 'Export subject', IconLoader.ICON_SAVE, [], @(h,ev)export_protocol(bst_get('iProtocol'), iSubject));
                 
@@ -922,10 +927,6 @@ switch (lower(action))
                     fcnPopupImportChannel(bstNodes, jPopup, 2);
                 elseif ~isempty(AllMod) && any(ismember({'SEEG','ECOG','ECOG+SEEG','NIRS'}, AllMod))
                     fcnPopupImportChannel(bstNodes, jPopup, 1);
-                end
-                % === SEEG IMPLANTATION ===
-                if (length(bstNodes) == 1) && ((isempty(AllMod) && strcmpi(sStudy.Name, 'implantation')) || any(ismember({'SEEG','ECOG','ECOG+SEEG'}, AllMod)))
-                        gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)DisplayChannels(bstNodes, 'SEEG', 'anatomy', 1, 0));
                 end
                 % === SEEG CONTACT LABELLING ===
                 if (length(bstNodes) == 1) && ~isempty(AllMod) && any(ismember({'SEEG','ECOG','ECOG+SEEG'}, AllMod))
@@ -3161,8 +3162,12 @@ function fcnMriSegment(jPopup, sSubject, iSubject, iAnatomy, isAtlas, isCt)
             gui_component('MenuItem', jPopup, [], 'Deface volume', IconLoader.(volIcon), [], @(h,ev)process_mri_deface('Compute', MriFile, struct('isDefaceHead', 0)));
         end
         % === SEEG/ECOG ===
-        if (length(iAnatomy) <= 1) && iSubject ~=0
-            gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', MriFile));
+        % Right click on the subject only
+        if isempty(iAnatomy)
+            gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', MriFile, 1));
+        % Right click on a desired volume (MRI/CT) in a subject
+        elseif (length(iAnatomy) == 1) && iSubject ~=0
+                gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', MriFile, 0));
         end
           
     % === TISSUE SEGMENTATION ===

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -705,7 +705,7 @@ switch (lower(action))
                 AddSeparator(jPopup);
                 % === SEEG IMPLANTATION ===
                 if ~isempty(sSubject.Anatomy)
-                    gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', sSubject.Anatomy(sSubject.iAnatomy).FileName, 1));
+                    gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', sSubject));
                 end
                 % Export menu (added later)
                 jMenuExport = gui_component('MenuItem', [], [], 'Export subject', IconLoader.ICON_SAVE, [], @(h,ev)export_protocol(bst_get('iProtocol'), iSubject));
@@ -3164,10 +3164,10 @@ function fcnMriSegment(jPopup, sSubject, iSubject, iAnatomy, isAtlas, isCt)
         % === SEEG/ECOG ===
         % Right click on the subject only
         if isempty(iAnatomy)
-            gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', MriFile, 1));
+            gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', sSubject));
         % Right click on a desired volume (MRI/CT) in a subject
         elseif (length(iAnatomy) == 1) && iSubject ~=0
-                gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', MriFile, 0));
+                gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', MriFile));
         end
           
     % === TISSUE SEGMENTATION ===

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -704,7 +704,7 @@ switch (lower(action))
                 fcnPopupScoutTimeSeries(jPopup);
                 AddSeparator(jPopup);
                 % === SEEG IMPLANTATION ===
-                if ~isempty(sSubject.Anatomy)
+                if ~isempty(sSubject.Anatomy) && ~strcmpi(sSubject.Name, bst_get('NormalizedSubjectName'))
                     gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', sSubject));
                 end
                 % Export menu (added later)
@@ -3163,7 +3163,7 @@ function fcnMriSegment(jPopup, sSubject, iSubject, iAnatomy, isAtlas, isCt)
         end
         % === SEEG/ECOG ===
         % Right click on the subject only
-        if isempty(iAnatomy)
+        if isempty(iAnatomy) && iSubject ~=0
             gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@panel_ieeg, 'CreateImplantation', sSubject));
         % Right click on a desired volume (MRI/CT) in a subject
         elseif (length(iAnatomy) == 1) && iSubject ~=0


### PR DESCRIPTION
This PR refactors the **SEEG/ECOG Implantation** option:

1. Users can **right click on a CT or MRI** individually and start implantation. Only show MRI Viewer and load iEEG panel.

2. Users can now **right click on the Subject** both in **Anatomy** and **Functional** modes, and use the GUI above to decide on what modalities they want to proceed with. 
![Screenshot 2024-11-19 125245](https://github.com/user-attachments/assets/810a7a15-c74d-4865-aeae-cf061616a9f2)
-  `MRI`: Start implantation on the default MRI. Only show MRI Viewer and load iEEG panel. This is similar **to right click on a MRI and start implantation**.
- `CT`: Start implantation on the CT. If multiple CTs then UI pops up for users to choose. Only show MRI Viewer and load iEEG panel. This is similar **to right click on a CT and start implantation**.
- `MRI+CT`: Start implantation with CT overlayed on default MRI. If multiple CTs then UI pops up for users to choose. Only show MRI Viewer and load iEEG panel.
- `MRI+CT+Isosurface`: Start implantation with CT overlayed on default MRI. Since there can be only one isosurface per subject as of now, based on which CT file the isosurface was generated from, it loads that CT. If the associated CT is not found then UI pops up for users to choose. Show MRI Viewer, show 3D fig and load iEEG panel.

Special case (@rcassani correct me here if I am wrong):
- `CT+Isosurface`: This is a case when users would just import raw CTs and start their implantation without having an MRI. Results will be same as `MRI+CT+Isosurface` case just that MRI viewer will just have CT and 3D fig will have the isosurface+CT3D.

Relevant forum topics:
- https://neuroimage.usc.edu/forums/t/electrode-location-using-brianstrom-of-verison-25-oct-2024/48747/10