### PR TITLE
Bugfix: On `channel_find` NIRS

### DIFF
--- a/toolbox/sensors/channel_find.m
+++ b/toolbox/sensors/channel_find.m
@@ -61,13 +61,13 @@ for i = 1:length(target)
     else
         iChan = find(strcmpi(allNames, target{i}));
         % Search for NIRS channels using Source, Detector or Wavelength
-        if ismember('NIRS', allTypes)
+        if isempty(iChan) && ismember('NIRS', allTypes)
             % Find tokens in provided target
             % Token 1: Source,               e.g. 'S1'
             % Token 2: Detector,             e.g. 'D1'
             % Token 1: Wavelength or Metric, e.g. 'WL830'
             target_tokens = regexp(target{i}, '^(S([0-9]+)?)?(D([0-9]+)?)?(WL\d+|HbO|HbR|HbT)?$', 'tokens');
-            if isempty(target_tokens)
+            if isempty(target_tokens) 
                 continue;
             end 
             target_tokens = target_tokens{1};

--- a/toolbox/sensors/channel_find.m
+++ b/toolbox/sensors/channel_find.m
@@ -67,7 +67,7 @@ for i = 1:length(target)
             % Token 2: Detector,             e.g. 'D1'
             % Token 1: Wavelength or Metric, e.g. 'WL830'
             target_tokens = regexp(target{i}, '^(S([0-9]+)?)?(D([0-9]+)?)?(WL\d+|HbO|HbR|HbT)?$', 'tokens');
-            if isempty(target_tokens) 
+            if isempty(target_tokens)
                 continue;
             end 
             target_tokens = target_tokens{1};


### PR DESCRIPTION
Fix a bug introduced in https://github.com/brainstorm-tools/brainstorm3/pull/709

Convidering the following channel find: 
![image](https://github.com/user-attachments/assets/35bb1650-c7d6-4315-b9bb-e6d936bf7774)


channel_find would not work to find the channel called 'AUX1' (for trigger identification). 
This PR fix the bug. This quite crucial as it is affecting all the fNIRS pipeline. 