### PR TITLE
Fix typo in process_export_spmvol

### DIFF
--- a/toolbox/process/functions/process_export_spmvol.m
+++ b/toolbox/process/functions/process_export_spmvol.m
@@ -301,7 +301,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                     % Else: Compute interpolation matrix grid points => MRI voxels
                     else
                         sMri.FileName = MriFile;
-                        GridSmooth = isempty(ResultsMat.DisplayUnits) || ~ismember(ResudltsMat.DisplayUnits, {'s','ms','t'});
+                        GridSmooth = isempty(ResultsMat.DisplayUnits) || ~ismember(ResultsMat.DisplayUnits, {'s','ms','t'});
                         switch (ResultsMat.HeadModelType)
                             case 'volume'
                                 % Compute interpolation


### PR DESCRIPTION
Reported in: https://neuroimage.usc.edu/forums/t/error-when-exporting-epileptogenicity-volume-map-as-nifti/50155

Introduced in: https://github.com/brainstorm-tools/brainstorm3/commit/58ec8ca68c6028e14bb09d93463753f9abfe9644