### PR TITLE
Bugfix in `in_tess`

### DIFF
--- a/toolbox/io/in_tess.m
+++ b/toolbox/io/in_tess.m
@@ -278,7 +278,7 @@ end
 %% ===== COMMENT =====
 % Add a comment field to the TessMat structure.
 
-if ~isempty(sMri)
+if ~isempty(sMri) && isfield(sMri, 'FileName')
     % Get the current subject
     sSubject = bst_get('MriFile', sMri.FileName);
     % Unique comment


### PR DESCRIPTION
Introduced in: https://github.com/brainstorm-tools/brainstorm3/pull/716

1. Right click on subject > `Import anatomy folder` (Type: `SimNIBS`) and click `Open`.
2. Set the fiducials in the MRI viewer manually. Click `Save`.
3. The error pops up as under.
![Screenshot 2025-02-06 012414](https://github.com/user-attachments/assets/e548cf72-7ef2-4453-b8d0-63bc91d00101)

**Cause:** While saving the MRI after entering fiducials, the `FileName` field is removed from the MRI structure. See this: https://github.com/brainstorm-tools/brainstorm3/blob/cc9ccc5f41fa040fb85eb44d0633c6c5087c32a4/toolbox/gui/figure_mri.m#L2571-L2575. @tmedani @rcassani any idea why this was done ? I am still trying to figure out. Because if I pass `bst_save(MriFileFull, sMri, 'v7')` (tested on Windows, Mac, Linux), it saves the structure with the `FileName` so why go with removing the field in the first place.