### PR TITLE
Bugfix file attrib

### DIFF
--- a/toolbox/gui/panel_protocol_editor.m
+++ b/toolbox/gui/panel_protocol_editor.m
@@ -305,6 +305,12 @@ function [subjectDir, studyDir, protocolName] = SelectProtocolDir(protocolDir)
         return
     end
 
+    % Check if 'anat' or 'data' dirs were seletect
+    % Windows users loading Protocols from a symbolic link need to select any of these subfolders
+    [dirProtocolDir, protocolName] = bst_fileparts(protocolDir, 1);
+    if ismember(protocolName, {'data', 'anat'})
+        protocolDir = dirProtocolDir;
+    end
     % Look for a "brainstormsubject" file and a "brainstormstudy" file
     subjectFile = file_find(protocolDir, 'brainstormsubject*.mat', 3);
     studyFile   = file_find(protocolDir, 'brainstormstudy*.mat',   4);
@@ -315,7 +321,7 @@ function [subjectDir, studyDir, protocolName] = SelectProtocolDir(protocolDir)
                                'one for the subjects'' anatomies, and one for the recordings/results.'], ...
                                'Load protocol');
         return
-    end
+    end    
     % Extract first level of subdir
     subjectDirList = str_split(strrep(subjectFile, protocolDir, ''));
     studyDirList   = str_split(strrep(studyFile, protocolDir, ''));

--- a/toolbox/gui/panel_protocol_editor.m
+++ b/toolbox/gui/panel_protocol_editor.m
@@ -321,7 +321,7 @@ function [subjectDir, studyDir, protocolName] = SelectProtocolDir(protocolDir)
                                'one for the subjects'' anatomies, and one for the recordings/results.'], ...
                                'Load protocol');
         return
-    end    
+    end
     % Extract first level of subdir
     subjectDirList = str_split(strrep(subjectFile, protocolDir, ''));
     studyDirList   = str_split(strrep(studyFile, protocolDir, ''));

--- a/toolbox/io/file_attrib.m
+++ b/toolbox/io/file_attrib.m
@@ -53,13 +53,18 @@ elseif ~isdir(fName)
 elseif isdir(fName)
     % Get all the rights
     [tmp__,att] = fileattrib(fName);
-%     % On windows: grab write permission automatically
-%     if ispc && (right == 'w') && ~att.UserWrite
-%         % Use attrib function to update the file
-%         system(['attrib -r ' fName ' /s /d']);
-%         % Read again the permissions
-%         [tmp__,att] = fileattrib(fName);
-%     end
+    % On windows: if no write permission, check again by creating a dummy file
+    if ispc && (right == 'w') && ~att.UserWrite
+        % Create dummy file
+        fDummy = fullfile(fName, 'dummy.txt');
+        fid = fopen(fDummy, 'w');
+        if (fid > 0)
+            % File was created
+            fclose(fid);
+            delete(fDummy);
+            att.UserWrite = 1;
+        end
+    end
     % Get proper right
     switch (right)
         case 'r'


### PR DESCRIPTION
This PR has to goals:

1. Double-check the answer from `file_attrib(FILE, 'w')` in Windows, since there are reported false positives.

2. Allow Windows users to load protocols from folders that are symbolic links. Users would need to select either the `anat` or `data` folders inside the folder (which is the symbolic link).

@yashvakilna, @chinmaychinara91, please try this on different scenarios on Windows.

