### PR TITLE
Add `IsoSurface` option for `Add Surface`

### DIFF
--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -845,7 +845,7 @@ function ButtonAddSurfaceCallback(surfaceType)
             typesList{end+1} = 'Subcortical';
         end
         % IsoSurface
-        iIsoSurface = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {sSubject.Surface.FileName}));
+        iIsoSurface = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {sSubject.Surface.FileName}), 1);
         if ~isempty(iIsoSurface)
             typesList{end+1} = 'IsoSurface';
         end

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -853,6 +853,9 @@ function ButtonAddSurfaceCallback(surfaceType)
         if ~isempty(TessInfo)
             typesList = setdiff(typesList, {TessInfo.Name});
         end
+        % Order of surfacetypes
+        typeListOrder = {'Anatomy', 'Scalp', 'OuterSkull', 'InnerSkull', 'Cortex', 'White', 'Fibers', 'FEM', 'IsoSurface'};
+        typesList = intersect(typeListOrder, typesList, 'stable');
         % Nothing more
         if isempty(typesList)
             bst_error('There are no additional anatomy files that you can add to this figure.', 'Add surface', 0);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -844,6 +844,11 @@ function ButtonAddSurfaceCallback(surfaceType)
         if ~isempty(iSubCortical)
             typesList{end+1} = 'Subcortical';
         end
+        % IsoSurface
+        iIsoSurface = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {sSubject.Surface.FileName}));
+        if ~isempty(iIsoSurface)
+            typesList{end+1} = 'IsoSurface';
+        end
         % Remove surfaces that are already displayed
         if ~isempty(TessInfo)
             typesList = setdiff(typesList, {TessInfo.Name});
@@ -881,6 +886,8 @@ function ButtonAddSurfaceCallback(surfaceType)
             SurfaceFile = sSubject.Surface(iSubCortical).FileName;
         case 'White'
             SurfaceFile = sSubject.Surface(iWhite).FileName;
+        case 'IsoSurface'
+            SurfaceFile = sSubject.Surface(iIsoSurface).FileName;
         case 'Other'
             % Offer all the other surfaces
             Comment = java_dialog('combo', '<HTML>Select the surface to add:<BR><BR>', 'Select surface', [], {sSubject.Surface.Comment});

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -845,7 +845,7 @@ function ButtonAddSurfaceCallback(surfaceType)
             typesList{end+1} = 'Subcortical';
         end
         % IsoSurface
-        iIsoSurface = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {sSubject.Surface.FileName}));
+        iIsoSurface = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {sSubject.Surface.FileName}));
         if ~isempty(iIsoSurface)
             typesList{end+1} = 'IsoSurface';
         end


### PR DESCRIPTION
If a subject does not have any other surface but just an isoSurface. User double clicks on SEEG channel and it opens the 3D MRI viewer with the SEEG electrodes. To check for alignment of the electrodes, user wants to overlay the 3D Isosurface on it.

Click on ![iconSurfaceAdd](https://github.com/user-attachments/assets/eaa7530b-435e-4416-a546-72c0b05e22b1) from panel_surface > shows message that is no additional surface available.
![Screenshot 2025-03-18 122649](https://github.com/user-attachments/assets/0de229b2-ddd3-4ab7-8dd0-fa38cc49d00d)


The proposed solution adds an **IsoSurface** option to the menu if it is present:
![Screenshot 2025-03-18 121815](https://github.com/user-attachments/assets/b646a3ea-0e24-4840-afc9-408445b56a7a)