### PR TITLE
Fix IsoSurface threshold slider range

### DIFF
--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -184,8 +184,8 @@ if isSave
     sMesh.Comment = comment;
     % Set history
     sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName ' threshold = ' num2str(isoValue) ...
-                                                       ' minRange = ' num2str(round(sMri.Histogram.whiteLevel)) ...
-                                                       ' maxRange = ' num2str(round(sMri.Histogram.intensityMax))]);
+                                                       ' minVal = ' num2str(round(sMri.Histogram.whiteLevel)) ...
+                                                       ' maxVal = ' num2str(round(sMri.Histogram.intensityMax))]);
     % Save isosurface
     bst_save(MeshFile, sMesh, 'v7', isAppend);
     % Add isosurface to database

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -183,7 +183,9 @@ if isSave
     % Set comment
     sMesh.Comment = comment;
     % Set history
-    sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName ' threshold = ' num2str(isoValue)]);
+    sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName ' threshold = ' num2str(isoValue) ...
+                                                       ' minRange = ' num2str(round(sMri.Histogram.whiteLevel)) ...
+                                                       ' maxRange = ' num2str(round(sMri.Histogram.intensityMax))]);
     % Save isosurface
     bst_save(MeshFile, sMesh, 'v7', isAppend);
     % Add isosurface to database

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -115,6 +115,7 @@ if (nargin < 2) || isempty(isoValue)
     % Get new value isoValue
     isoValue = round(str2double(res));
 end
+isoRange = double(round([sMri.Histogram.whiteLevel, sMri.Histogram.intensityMax]));
 
 % Check parameters values
 % isoValue cannot be < 0 as there cannot be negative intensity in the CT
@@ -183,9 +184,8 @@ if isSave
     % Set comment
     sMesh.Comment = comment;
     % Set history
-    sMesh = bst_history('add', sMesh, 'threshold_ct', ['Thresholded CT: ' sMri.FileName ' threshold = ' num2str(isoValue) ...
-                                                       ' minVal = ' num2str(round(sMri.Histogram.whiteLevel)) ...
-                                                       ' maxVal = ' num2str(round(sMri.Histogram.intensityMax))]);
+    sMesh = bst_history('add', sMesh, 'threshold_ct', ...
+                        sprintf('Thresholded CT: %s threshold = %d minVal = %d maxVal = %d', sMri.FileName, isoValue, isoRange));
     % Save isosurface
     bst_save(MeshFile, sMesh, 'v7', isAppend);
     % Add isosurface to database

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2745,7 +2745,10 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
             isoValue = str2double(ctEntries{iEntries(end)}{1}{2});
             if any(cellfun(@isempty, ctEntries{iEntries(end)}{1}(3:4)))
                 % If range not in last History entry, load from CT file and update History accordingly
-                sCt = bst_memory('LoadMri', ctFile);
+                sCt = load(file_fullpath(ctFile), 'Histogram');
+                if ~isfield(sCt, 'Histogram')
+                    sCt = bst_memory('LoadMri', ctFile);
+                end
                 isoRange = double(round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]));
                 sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(2))];
                 sSurfTmp.History = sSurf.History;

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2735,7 +2735,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
     isoValue = [];
     isoRange = [];
     % Load the IsoSurface
-    sSurf = load(file_fullpath(isosurfaceFile));
+    sSurf = load(file_fullpath(isosurfaceFile), 'History');
     if isfield(sSurf, 'History') && ~isempty(sSurf.History)
         % Get CT file, value and range from last History entry
         ctEntries = regexp(sSurf.History(:, 3), '^Thresholded CT:\s(.*)\sthreshold\s*=\s*(\d+)(?:\sminVal\s*=\s*)?(\d+)?(?:\smaxVal\s*=\s*)?(\d+)?', 'tokens');
@@ -2751,8 +2751,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                 end
                 isoRange = double(round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]));
                 sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(2))];
-                sSurfTmp.History = sSurf.History;
-                bst_save(file_fullpath(isosurfaceFile), sSurfTmp, [], 1);
+                bst_save(file_fullpath(isosurfaceFile), sSurf, [], 1);
             else
                 isoRange = str2double(ctEntries{iEntries(end)}{1}(3:4));
             end

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2747,7 +2747,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                 % If range not in last History entry, load from CT file and update History accordingly
                 sCt = bst_memory('LoadMri', ctFile);
                 isoRange = double(round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]));
-                sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(1))];
+                sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(2))];
                 sSurfTmp.History = sSurf.History;
                 bst_save(file_fullpath(isosurfaceFile), sSurfTmp, [], 1);
             else

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2749,7 +2749,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                 minVal = round(sCt.Histogram.whiteLevel);
                 maxVal = round(sCt.Histogram.intensityMax);
                 isoRange = [minVal maxVal];
-                sSurf.History(:, 3) = cellstr([char(sSurf.History(:, 3)) ' minVal = ' num2str(minVal) ' maxVal = ' num2str(maxVal)]);
+                sSurf.History(iEntries(end), 3) = cellstr([char(sSurf.History(iEntries(end), 3)) ' minVal = ' num2str(minVal) ' maxVal = ' num2str(maxVal)]);
                 bst_save(file_fullpath(isosurfaceFile), sSurf, 'v7');
             else
                 isoRange = [str2double(ctEntries{iEntries(end)}{1}{3}) str2double(ctEntries{iEntries(end)}{1}{4})];

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2743,7 +2743,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
         if any(iEntries) && length(ctEntries{iEntries(end)}{1}) == 4
             ctFile   = ctEntries{iEntries(end)}{1}{1};
             isoValue = str2double(ctEntries{iEntries(end)}{1}{2});
-            if isempty(ctEntries{iEntries(end)}{1}{3}) && isempty(ctEntries{iEntries(end)}{1}{4})
+            if any(cellfun(@isempty, ctEntries{iEntries(end)}{1}(3:4)))
                 % If range not in last History entry, load from CT file and update History accordingly
                 sCt = bst_memory('LoadMri', ctFile);
                 isoRange = round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]);
@@ -2751,7 +2751,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                 sSurfTmp.History = sSurf.History;
                 bst_save(file_fullpath(isosurfaceFile), sSurfTmp, [], 1);
             else
-                isoRange = [str2double(ctEntries{iEntries(end)}{1}{3}) str2double(ctEntries{iEntries(end)}{1}{4})];
+                isoRange = str2double(ctEntries{iEntries(end)}{1}(3:4));
             end
         end
     end

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2752,19 +2752,21 @@ function ApplyDefaultDisplay() %#ok<DEFNU>
 end
 
 %% ===== GET ISOSURFACE PARAMETERS
-function [ctFile, isoValue] = GetIsosurfaceParams(isosurfaceFile)
+function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
     % Intialize returned variables
     ctFile = [];
     isoValue = [];
+    isoRange = [];
     % Load the IsoSurface history
     sSurf = load(file_fullpath(isosurfaceFile), 'History');
     if isfield(sSurf, 'History') && ~isempty(sSurf.History)
         % Get CT file and value from last History entry
-        ctEntries  = regexp(sSurf.History(:, 3), '^Thresholded CT:\s(.*)\sthreshold\s*=\s*(\d+)', 'tokens');
+        ctEntries  = regexp(sSurf.History(:, 3), '^Thresholded CT:\s(.*)\sthreshold\s*=\s*(\d+)\sminRange\s*=\s*(\d+)\smaxRange\s*=\s*(\d+)', 'tokens');
         iEntries =  find(~cellfun(@isempty, ctEntries));
-        if any(iEntries) && length(ctEntries{iEntries(end)}{1}) == 2
+        if any(iEntries) && length(ctEntries{iEntries(end)}{1}) == 4
             ctFile   = ctEntries{iEntries(end)}{1}{1};
             isoValue = str2double(ctEntries{iEntries(end)}{1}{2});
+            isoRange = [str2double(ctEntries{iEntries(end)}{1}{3}) str2double(ctEntries{iEntries(end)}{1}{4})];
         end
     end
 end

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2746,7 +2746,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
             if any(cellfun(@isempty, ctEntries{iEntries(end)}{1}(3:4)))
                 % If range not in last History entry, load from CT file and update History accordingly
                 sCt = bst_memory('LoadMri', ctFile);
-                isoRange = round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]);
+                isoRange = double(round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]));
                 sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(1))];
                 sSurfTmp.History = sSurf.History;
                 bst_save(file_fullpath(isosurfaceFile), sSurfTmp, [], 1);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -1150,9 +1150,10 @@ function UpdateSurfaceProperties()
     ctrl.jLabelSurfIsoValueTitle.setVisible(isIsoSurface);
     ctrl.jLabelSurfIsoValue.setVisible(isIsoSurface);
     if isIsoSurface
-        [sSubjectTmp, iSubjectTmp, iSurfaceTmp] = bst_get('SurfaceFile', TessInfo(iSurface).SurfaceFile);
-        isoValue = regexp(sSubjectTmp.Surface(iSurfaceTmp).Comment, '\d*', 'match');
-        SetIsoValue(str2double(isoValue{1}));
+        [~, isoValue, isoRange] = panel_surface('GetIsosurfaceParams', TessInfo(iSurface).SurfaceFile);
+        ctrl.jSliderSurfIsoValue.setMinimum(isoRange(1));
+        ctrl.jSliderSurfIsoValue.setMaximum(isoRange(2));
+        SetIsoValue(isoValue);
     end
     % Show sulci button
     ctrl.jButtonSurfSulci.setSelected(TessInfo(iSurface).SurfShowSulci);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2745,7 +2745,9 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
             isoValue = str2double(ctEntries{iEntries(end)}{1}{2});
             if any(cellfun(@isempty, ctEntries{iEntries(end)}{1}(3:4)))
                 % If range not in last History entry, load from CT file and update History accordingly
+                warning off
                 sCt = load(file_fullpath(ctFile), 'Histogram');
+                warning on
                 if ~isfield(sCt, 'Histogram')
                     sCt = bst_memory('LoadMri', ctFile);
                 end

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2750,7 +2750,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                     sCt = bst_memory('LoadMri', ctFile);
                 end
                 isoRange = double(round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]));
-                sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(2))];
+                sSurf.History{iEntries(end), 3} = ['Thresholded CT: ' ctFile ' threshold = ' num2str(isoValue) ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(2))];
                 bst_save(file_fullpath(isosurfaceFile), sSurf, [], 1);
             else
                 isoRange = str2double(ctEntries{iEntries(end)}{1}(3:4));

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2749,7 +2749,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                 minVal = round(sCt.Histogram.whiteLevel);
                 maxVal = round(sCt.Histogram.intensityMax);
                 isoRange = [minVal maxVal];
-                sSurf.History(iEntries(end), 3) = cellstr([char(sSurf.History(iEntries(end), 3)) ' minVal = ' num2str(minVal) ' maxVal = ' num2str(maxVal)]);
+                sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(minVal) ' maxVal = ' num2str(maxVal)];
                 bst_save(file_fullpath(isosurfaceFile), sSurf, 'v7');
             else
                 isoRange = [str2double(ctEntries{iEntries(end)}{1}{3}) str2double(ctEntries{iEntries(end)}{1}{4})];

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -109,10 +109,10 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
 
             % Threshold title
             jLabelSurfIsoValueTitle = gui_component('label', jPanelSurfaceOptions, 'br', 'Thresh.:');
-            % Min size slider
+            % IsoSurface threshold slider
             jSliderSurfIsoValue = JSlider(1, 1000, 1);
             jSliderSurfIsoValue.setPreferredSize(Dimension(SLIDER_WIDTH, DEFAULT_HEIGHT));
-            jSliderSurfIsoValue.setToolTipText('isoSurface Threshold');
+            jSliderSurfIsoValue.setToolTipText('IsoSurface threshold');
             java_setcb(jSliderSurfIsoValue, 'MouseReleasedCallback', @(h,ev)SliderCallback(h, ev, 'SurfIsoValue'), ...
                                             'KeyPressedCallback',    @(h,ev)SliderCallback(h, ev, 'SurfIsoValue'));
             jPanelSurfaceOptions.add('tab hfill', jSliderSurfIsoValue);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2750,7 +2750,8 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                 maxVal = round(sCt.Histogram.intensityMax);
                 isoRange = [minVal maxVal];
                 sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(minVal) ' maxVal = ' num2str(maxVal)];
-                bst_save(file_fullpath(isosurfaceFile), sSurf, 'v7');
+                sSurfTmp.History = sSurf.History;
+                bst_save(file_fullpath(isosurfaceFile), sSurfTmp, [], 1);
             else
                 isoRange = [str2double(ctEntries{iEntries(end)}{1}{3}) str2double(ctEntries{iEntries(end)}{1}{4})];
             end

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -110,7 +110,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
             % Threshold title
             jLabelSurfIsoValueTitle = gui_component('label', jPanelSurfaceOptions, 'br', 'Thresh.:');
             % Min size slider
-            jSliderSurfIsoValue = JSlider(1, GetIsoValueMaxRange(), 1);
+            jSliderSurfIsoValue = JSlider(1, 1000, 1);
             jSliderSurfIsoValue.setPreferredSize(Dimension(SLIDER_WIDTH, DEFAULT_HEIGHT));
             jSliderSurfIsoValue.setToolTipText('isoSurface Threshold');
             java_setcb(jSliderSurfIsoValue, 'MouseReleasedCallback', @(h,ev)SliderCallback(h, ev, 'SurfIsoValue'), ...
@@ -535,30 +535,6 @@ function sliderSizeVector = GetSliderSizeVector(nVertices)
     end
 end
 
-%% ===== GET SLIDER ISOVALUE =====
-function isoValue = GetIsoValueMaxRange()
-    % get the handles
-    hFig = bst_figures('GetFiguresByType', '3DViz');
-    if ~isempty(hFig)
-        SubjectFile = getappdata(hFig, 'SubjectFile');
-        if ~isempty(SubjectFile)
-            sSubject = bst_get('Subject', SubjectFile);
-            CtFile = [];
-            for i=1:length(sSubject.Anatomy)
-                if ~isempty(regexp(sSubject.Anatomy(i).FileName, '_volct', 'match'))
-                    CtFile = sSubject.Anatomy(i).FileName;
-                end
-            end
-        end
-        
-        if ~isempty(CtFile)
-            sMri = bst_memory('LoadMri', CtFile);
-            isoValue = double(sMri.Histogram.intensityMax);
-        end
-    else
-        isoValue = 4500.0;
-    end
-end
 
 %% ===== SET SLIDER ISOVALUE =====
 function SetIsoValue(isoValue)

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2743,7 +2743,7 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
         if any(iEntries) && length(ctEntries{iEntries(end)}{1}) == 4
             ctFile   = ctEntries{iEntries(end)}{1}{1};
             isoValue = str2double(ctEntries{iEntries(end)}{1}{2});
-            if isempty(ctEntries{iEntries(end)}{1}{3}) || isempty(ctEntries{iEntries(end)}{1}{4})
+            if isempty(ctEntries{iEntries(end)}{1}{3}) && isempty(ctEntries{iEntries(end)}{1}{4})
                 % If range not in last History entry, load from CT file and update History accordingly
                 sCt = bst_memory('LoadMri', ctFile);
                 minVal = round(sCt.Histogram.whiteLevel);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2746,10 +2746,8 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
             if isempty(ctEntries{iEntries(end)}{1}{3}) && isempty(ctEntries{iEntries(end)}{1}{4})
                 % If range not in last History entry, load from CT file and update History accordingly
                 sCt = bst_memory('LoadMri', ctFile);
-                minVal = round(sCt.Histogram.whiteLevel);
-                maxVal = round(sCt.Histogram.intensityMax);
-                isoRange = [minVal maxVal];
-                sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(minVal) ' maxVal = ' num2str(maxVal)];
+                isoRange = round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]);
+                sSurf.History{iEntries(end), 3} = [sSurf.History{iEntries(end), 3} ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(1))];
                 sSurfTmp.History = sSurf.History;
                 bst_save(file_fullpath(isosurfaceFile), sSurfTmp, [], 1);
             else

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -2750,7 +2750,8 @@ function [ctFile, isoValue, isoRange] = GetIsosurfaceParams(isosurfaceFile)
                     sCt = bst_memory('LoadMri', ctFile);
                 end
                 isoRange = double(round([sCt.Histogram.whiteLevel, sCt.Histogram.intensityMax]));
-                sSurf.History{iEntries(end), 3} = ['Thresholded CT: ' ctFile ' threshold = ' num2str(isoValue) ' minVal = ' num2str(isoRange(1)) ' maxVal = ' num2str(isoRange(2))];
+                % Update history
+                sSurf.History{iEntries(end), 3} = sprintf('Thresholded CT: %s threshold = %d minVal = %d maxVal = %d', ctFile, isoValue, isoRange);                
                 bst_save(file_fullpath(isosurfaceFile), sSurf, [], 1);
             else
                 isoRange = str2double(ctEntries{iEntries(end)}{1}(3:4));


### PR DESCRIPTION
This PR fixes the issue below (point # 8 in PR https://github.com/brainstorm-tools/brainstorm3/pull/732)
> Slider in panel surface for thresholding CT is set only at panel creation (CreatePanel), thus it's hardcoded to 1 to 4500
> See code: https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/gui/panel_surface.m#L113

Now the slider range is updated in real time based on the IsoSurface.