### PR TITLE
Add electrode with just 3D figure open

### DIFF
--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -4800,6 +4800,31 @@ function JumpMaximum(hFig)
     UpdateMriDisplay(hFig, [1 2 3], TessInfo, iAnatomy);
 end
 
+%% ===== GET LOCATION FROM 3D FIGURE =====
+function XYZ = GetLocation(cs, hFig)
+    XYZ = [];
+    CoordinatesSelector = getappdata(hFig, 'CoordinatesSelector');
+    isSelectingCoordinates = getappdata(hFig, 'isSelectingCoordinates');
+    % Exit early if required data is missing or selection is inactive
+    if isempty(CoordinatesSelector) || isempty(CoordinatesSelector.MRI) || ~isSelectingCoordinates
+        return;
+    end
+    % Determine which coordinate set to return based on input
+    switch lower(cs)
+        case 'mni'
+            XYZ = CoordinatesSelector.MNI;
+        case 'mri'
+            XYZ = CoordinatesSelector.MRI;
+        case 'scs'
+            XYZ = CoordinatesSelector.SCS;
+        case 'voxel'
+            XYZ = CoordinatesSelector.Voxel;
+        case 'world'
+            XYZ = CoordinatesSelector.World;
+        otherwise
+            bst_error('Invalid coordinate conversion', 'Get location (3D)');
+    end
+end
 
 %% ===== SET LOCATION MRI =====
 function SetLocationMri(hFig, cs, XYZ)

--- a/toolbox/gui/panel_coordinates.m
+++ b/toolbox/gui/panel_coordinates.m
@@ -431,8 +431,9 @@ function vi = SelectPoint(hFig, AcceptMri, isCentroid) %#ok<DEFNU>
          'Tag',             'ptCoordinates');
     % Update "Coordinates" panel
     UpdatePanel();
-    % Open MRI viewer for SEEG
-    if isCentroid
+    % Update MRI viewer (if open)
+    hFigMri = bst_figures('GetFiguresByType', {'MriViewer'});
+    if ~isempty(hFigMri)
         ViewInMriViewer();
     end
 end


### PR DESCRIPTION
Does two things:

1. Can set electrodes directly from 3D Viz (without having to open MRI Viewer):
    - For SEEG > Display sensors in MRI 3D slices > add SEEG IsoSurface to figure (Surface tab) > Add electrode and enable Select tool (iEEG tab) > Select points in 3D IsoSurface and Set tip and Skull entry to create the electrode.
    - The steps work for ECoG as well (Either use [test data](https://drive.google.com/drive/folders/1v6IvXRbxUeawT-jB3VAJinrIzPxVPtMT?usp=sharing)) or just use the SEEG IsoSurface above to create dummy ECoG).
    - This gives option to the user to create electrodes directly in 3D without having to open MRI Viewer.
    
2. Commit 17cc586 fixes the issue below (point # 6 in #732)

> Display sensors in MRI 3D slices, add IsoSurface to figure (surface tab), add new SEEG electrode (in IEEG tab), enable Select tool (in EEG tab), click on isosurface. Result: MRI viewer opens (why?), all electrodes disappear of GUI and Electrode configuration is disabled. Electrodes are visible in 3D figure.
