### PR TITLE
[connectivity] Remove regions without signal before connectivity

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -467,6 +467,19 @@ for iFile = 1 : length(FilesA)
             sInputB = sInputA;
         end
     end
+
+    % mask 
+    mask_a = all( sInputA.Data == 0 , 2);
+    sInputA.RowNames =     sInputA.RowNames(~mask_a);
+    sInputA.Data =     sInputA.Data(~mask_a, :);
+    sInputA.Atlas.Scouts = sInputA.Atlas.Scouts(~mask_a);
+
+    mask_b = all( sInputB.Data == 0 , 2);
+    sInputB.RowNames = sInputB.RowNames(~mask_b);
+    sInputB.Data =     sInputB.Data(~mask_b, :);
+    sInputB.Atlas.Scouts = sInputB.Atlas.Scouts(~mask_b);
+
+
     % Get the sampling frequency
     sfreq = 1 ./ (sInputA.Time(2) - sInputA.Time(1));
     % Round the sampling frequency at 1e6


### PR DESCRIPTION
Hello, 

This PR is here to remove regions where the signal is constant (zero) before running the connectivity. This is mainly the case for nirs since we will only have non zero value near the sensors. (it will probably be the same for SEEG)

Before: 

![image](https://github.com/user-attachments/assets/0aff40c4-dace-4bf8-be28-7562ea35f2da)

After: 

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/77be9b8f-4a8e-4016-b9c2-498890afec41" />

Note: I only tried with the following configuration, so It probably doesn't work in the general case, but i can improve the code if this kind of solution works for you. 

![image](https://github.com/user-attachments/assets/20169529-b920-4a97-bc9e-53036e0720e5)


Edouard
