### PR TITLE
Add support for `raw` files in process `Apply montage`

### DIFF
--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -322,15 +322,23 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                     % Write block
                     out_fwrite(sFileOut, ChannelMatOut, 1, iTimesBlocks(iBlock, :)-1, [], RawDataMat.F);
                 end
-                % Mark the projectors as already applied to the file
-                if isUseSsp && ~isempty(ChannelMatOut.Projector)
-                    for iProj = 1:length(ChannelMatOut.Projector)
-                        if (ChannelMatOut.Projector(iProj).Status == 1)
-                            ChannelMatOut.Projector(iProj).Status = 2;
+                % Update projectors data
+                if isUseSsp
+                    % Mark the projectors as already applied to the file
+                    if ~isempty(ChannelMatOut.Projector)
+                        for iProj = 1:length(ChannelMatOut.Projector)
+                            if (ChannelMatOut.Projector(iProj).Status == 1)
+                                ChannelMatOut.Projector(iProj).Status = 2;
+                            end
                         end
                     end
-                    bst_save(sChannelOut.FileName, ChannelMatOut);
+                else
+                    % Clear old projectors
+                    if ~isempty(ChannelMatOut.Projector)
+                        ChannelMatOut.Projector = repmat(db_template('projector'), 0);
+                    end
                 end
+                bst_save(sChannelOut.FileName, ChannelMatOut);
                 % Set and save output sFile structure (link to raw, a .mat file)
                 sInMat = in_bst(sInputs(1).FileName, [], 1);
                 sOutMat = sInMat;

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -180,8 +180,13 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                     % Create condition
                     iStudyOut = db_add_condition(sSubjectOut.Name, sInputs(iInput).Condition, 1);
                 else
-                    % Output condition name
+                    % Output Condition name must be unique for raw files
                     ConditionOut = [sInputs(iInput).Condition, '_', file_standardize(strrep(strMontage, '''', 'p'))];
+                    if isRaw
+                        % Get conditions for this subject
+                        sSubjStudies = bst_get('StudyWithSubject', sStudyChan.BrainStormSubject, 'intra_subject', 'default_study');
+                        ConditionOut = file_unique(ConditionOut, [sSubjStudies.Condition]);
+                    end
                     % Get output condition
                     [sStudyOut, iStudyOut] = bst_get('StudyWithCondition', [sSubject.Name '/' ConditionOut]);
                     % Create condition

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -317,6 +317,15 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                     % Write block
                     out_fwrite(sFileOut, ChannelMatOut, 1, iTimesBlocks(iBlock, :)-1, [], RawDataMat.F);
                 end
+                % Mark the projectors as already applied to the file
+                if isUseSsp && ~isempty(ChannelMatOut.Projector)
+                    for iProj = 1:length(ChannelMatOut.Projector)
+                        if (ChannelMatOut.Projector(iProj).Status == 1)
+                            ChannelMatOut.Projector(iProj).Status = 2;
+                        end
+                    end
+                    bst_save(sChannelOut.FileName, ChannelMatOut);
+                end
                 % Set and save output sFile structure (link to raw, a .mat file)
                 sInMat = in_bst(sInputs(1).FileName, [], 1);
                 sOutMat = sInMat;

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -36,8 +36,8 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.Index       = 307;
     sProcess.Description = 'https://neuroimage.usc.edu/brainstorm/Tutorials/MontageEditor';
     % Definition of the input accepted by this process
-    sProcess.InputTypes  = {'data'};
-    sProcess.OutputTypes = {'data'};
+    sProcess.InputTypes  = {'raw', 'data'};
+    sProcess.OutputTypes = {'raw', 'data'};
     sProcess.nInputs     = 1;
     sProcess.nMinFiles   = 1;
     % Definition of the options
@@ -84,6 +84,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         % Get subject for the channel file
         sStudyChan = bst_get('ChannelFile', allChanFiles{iChan});
         sSubject = bst_get('Subject', sStudyChan.BrainStormSubject, 1);
+        isRaw = strncmp(sStudyChan.Name, '@raw', 4);
         % Load channel file 
         ChannelMat = in_bst_channel(allChanFiles{iChan});
         % Update automatic montages
@@ -106,7 +107,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         end
         % If not creating a new channel file: montage output has to be compatible with curent channel structure
         isCompatibleChan = ~strcmpi(sMontage.Type, 'selection') && (~strcmpi(sMontage.Type, 'text') || all(sum(sMontage.Matrix,2) == 0));
-        if ~isCreateChan && ~isCompatibleChan
+        if ~isCreateChan && (~isCompatibleChan || isRaw)
             bst_report('Error', sProcess, [], ['The montage "' sMontage.Name '" cannot be applied without writing a new folders.']);
             return;
         end

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -322,6 +322,14 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 sOutMat = sInMat;
                 sOutMat.ChannelFlag = sFileOut.channelflag;
                 sOutMat.F = sFileOut;
+                % Update History
+                if isUseCtfComp && strcmp(sOutMat.F.device, 'CTF')
+                    sOutMat = bst_history('add', sOutMat, 'process', [func2str(sProcess.Function), ': Applied CTF compensation']);
+                end
+                if isUseSsp && ~isempty(ChannelMatOut.Projector)
+                    sOutMat = bst_history('add', sOutMat, 'process', [func2str(sProcess.Function), ': Applied SSP/ICA projectors']);
+                end
+                sOutMat = bst_history('add', sOutMat, 'montage', ['Applied montage: ' sMontage.Name]);
                 bst_save(MatFile, sOutMat, 'v6');
                 % Register in BST database
                 db_add_data(iStudyOut, MatFile, sOutMat);

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -338,7 +338,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                         ChannelMatOut.Projector = repmat(db_template('projector'), 0);
                     end
                 end
-                bst_save(sChannelOut.FileName, ChannelMatOut);
+                bst_save(file_fullpath(sChannelOut.FileName), ChannelMatOut);
                 % Set and save output sFile structure (link to raw, a .mat file)
                 sInMat = in_bst(sInputs(1).FileName, [], 1);
                 sOutMat = sInMat;

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -272,7 +272,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 % Load data file
                 DataMat = in_bst_data(sInputs(1).FileName, 'F', 'ChannelFlag', 'Time');
                 sFileIn = DataMat.F;
-                % Get all good channels (?)
+                % Get all good channels
                 iGoodChannels = DataMat.ChannelFlag;
                 nChannels = length(iGoodChannels);
                 % Get maximum size of a data block

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -247,7 +247,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             if isRaw
                 % Channel file in new Study
                 sChannelOut = bst_get('ChannelForStudy', iStudyOut);
-                ChannelMat = in_bst_channel(sChannelOut.FileName);
+                ChannelMatOut = in_bst_channel(sChannelOut.FileName);
                 % Full output filename derives from the condition name
                 studyOutPath = bst_fileparts(file_fullpath(sStudyOut.FileName));
                 [~, rawBaseOut] = bst_fileparts(studyOutPath);
@@ -293,10 +293,10 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                         ChannelFlag(isChanBad) = -1;
                         sFileIn.channelflag = ChannelFlag;
                         % Create an empty Brainstorm-binary file
-                        sFileOut = out_fopen(RawFileOut, 'BST-BIN', sFileIn, ChannelMat);
+                        sFileOut = out_fopen(RawFileOut, 'BST-BIN', sFileIn, ChannelMatOut);
                     end
                     % Write block
-                    out_fwrite(sFileOut, ChannelMat, 1, iTimesBlocks(iBlock, :)-1, [], RawDataMat.F);
+                    out_fwrite(sFileOut, ChannelMatOut, 1, iTimesBlocks(iBlock, :)-1, [], RawDataMat.F);
                 end
                 % Set and save output sFile structure (link to raw, a .mat file)
                 sInMat = in_bst(sInputs(1).FileName, [], 1);

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -75,9 +75,9 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % Returned variables
     OutputFiles = {};
     % Options
-    isCreateChan = (sProcess.options.createchan.Value == 1);
-    isUseCtfComp = (sProcess.options.usectfcomp.Value == 1);
-    isUseSsp     = (sProcess.options.usessp.Value == 1);
+    isCreateChan = ~isfield('createchan', sProcess.options) || (sProcess.options.createchan.Value == 1);
+    isUseCtfComp =  isfield('usectfcomp', sProcess.options) && (sProcess.options.usectfcomp.Value == 1);
+    isUseSsp     =  isfield('usessp', sProcess.options) && (sProcess.options.usessp.Value == 1);
     MontageName  = sProcess.options.montage.Value;
     % Get a simpler montage name (for automatic SEEG montages)
     strMontage = MontageName;

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -240,35 +240,37 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             else
                 iStudyOut = sInputs(iInput).iStudy;
             end
-            
-            % Apply montage
-            if isCreateChan
-                DataMat.F = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
-                % Compute channel flag
-                ChannelFlag = ones(size(DataMat.F,1),1);
-                isChanBad = (double(sMontage.Matrix(iMatrixDisp,iMatrixChan) ~= 0) * reshape(double(DataMat.ChannelFlag(iChannels) == -1), [], 1) > 0);
-                ChannelFlag(isChanBad) = -1;
-            else
-                DataMat.F(iChannels,:) = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
-                ChannelFlag = DataMat.ChannelFlag;
-            end
-
             % Get output study
             sStudyOut = bst_get('Study', iStudyOut);
-            % Edit data structure
-            DataMat.Comment     = [DataMat.Comment ' | ' strMontage];
-            DataMat.ChannelFlag = ChannelFlag;
-            DataMat = bst_history('add', DataMat, 'montage', ['Applied montage: ' sMontage.Name]);
-            % New filename
-            [fPath, fBase, fExt] = bst_fileparts(sInputs(iInput).FileName);
-            NewDataFile = bst_fullfile(bst_fileparts(file_fullpath(sStudyOut.FileName)), [fBase '_montage.mat']);
-            NewDataFile = file_unique(NewDataFile);
-            % Save new data file
-            bst_save(NewDataFile, DataMat, 'v6');
-            % Add file to database
-            db_add_data(iStudyOut, NewDataFile, DataMat);
-            % Add file to list of returned files
-            OutputFiles{end+1} = NewDataFile;
+
+            % Apply montage
+            if isRaw
+            else
+                if isCreateChan
+                    DataMat.F = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
+                    % Compute channel flag
+                    ChannelFlag = ones(size(DataMat.F,1),1);
+                    isChanBad = (double(sMontage.Matrix(iMatrixDisp,iMatrixChan) ~= 0) * reshape(double(DataMat.ChannelFlag(iChannels) == -1), [], 1) > 0);
+                    ChannelFlag(isChanBad) = -1;
+                else
+                    DataMat.F(iChannels,:) = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
+                    ChannelFlag = DataMat.ChannelFlag;
+                end
+                % Edit data structure
+                DataMat.Comment     = [DataMat.Comment ' | ' strMontage];
+                DataMat.ChannelFlag = ChannelFlag;
+                DataMat = bst_history('add', DataMat, 'montage', ['Applied montage: ' sMontage.Name]);
+                % New filename
+                [fPath, fBase, fExt] = bst_fileparts(sInputs(iInput).FileName);
+                NewDataFile = bst_fullfile(bst_fileparts(file_fullpath(sStudyOut.FileName)), [fBase '_montage.mat']);
+                NewDataFile = file_unique(NewDataFile);
+                % Save new data file
+                bst_save(NewDataFile, DataMat, 'v6');
+                % Add file to database
+                db_add_data(iStudyOut, NewDataFile, DataMat);
+                % Add file to list of returned files
+                OutputFiles{end+1} = NewDataFile;
+            end
             
             % Copy video links
             if ~isequal(iStudyIn, iStudyOut) && ~isempty(sStudyIn.Image) && isempty(sStudyOut.Image)

--- a/toolbox/process/functions/process_montage_apply.m
+++ b/toolbox/process/functions/process_montage_apply.m
@@ -140,17 +140,6 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 bst_report('Error', sProcess, sInputs, ['The montage "' sMontage.Name '" changes the names of the channels, it requires the creation of new folders.']);
                 return;
             end
-            % Apply montage
-            if isCreateChan
-                DataMat.F = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
-                % Compute channel flag
-                ChannelFlag = ones(size(DataMat.F,1),1);
-                isChanBad = (double(sMontage.Matrix(iMatrixDisp,iMatrixChan) ~= 0) * reshape(double(DataMat.ChannelFlag(iChannels) == -1), [], 1) > 0);
-                ChannelFlag(isChanBad) = -1;
-            else
-                DataMat.F(iChannels,:) = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
-                ChannelFlag = DataMat.ChannelFlag;
-            end
 
             % Get output study
             if isCreateChan
@@ -249,6 +238,18 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 end
             else
                 iStudyOut = sInputs(iInput).iStudy;
+            end
+            
+            % Apply montage
+            if isCreateChan
+                DataMat.F = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
+                % Compute channel flag
+                ChannelFlag = ones(size(DataMat.F,1),1);
+                isChanBad = (double(sMontage.Matrix(iMatrixDisp,iMatrixChan) ~= 0) * reshape(double(DataMat.ChannelFlag(iChannels) == -1), [], 1) > 0);
+                ChannelFlag(isChanBad) = -1;
+            else
+                DataMat.F(iChannels,:) = panel_montage('ApplyMontage', sMontage, DataMat.F(iChannels,:), sInputs(iInput).FileName, iMatrixDisp, iMatrixChan);
+                ChannelFlag = DataMat.ChannelFlag;
             end
 
             % Get output study


### PR DESCRIPTION
Expand existing process **Standardize > Apply montage** to support `raw` files

For `raw` data, there is the option to apply CTF compensation (only in CTF MEG devices) and SSP/ICA projectors before applying the montages.

If SSP/ICA projectors are not applied, they are removed from the output channel file, as the channels are with montages they are not the same. Although they could, however, in that case montages should not be the way to go, but filtering or projectors themselves. 

FYI @yashvakilna, @jcmosher, @Edouard2laire, @ShahlaBakian

