### PR TITLE
Bugfix: Panel Digitize

### DIFF
--- a/toolbox/sensors/panel_digitize.m
+++ b/toolbox/sensors/panel_digitize.m
@@ -124,17 +124,16 @@ function Start(varargin) %#ok<DEFNU>
     end
     
     % ===== PATIENT ID =====
+    % Get Digitize options
+    DigitizeOptions = bst_get('DigitizeOptions');
     if isempty(sSubject)
-        % Get Digitize options
-        DigitizeOptions = bst_get('DigitizeOptions');
         % Ask for subject id
         PatientId = java_dialog('input', 'Please, enter subject ID:', Digitize.Type, [], DigitizeOptions.PatientId);
         if isempty(PatientId)
             return;
         end
         % Save the new default patient id
-        DigitizeOptions.PatientId = PatientId;
-        bst_set('DigitizeOptions', DigitizeOptions);
+        DigitizeOptions.PatientId = PatientId;      
     
         % ===== GET SUBJECT =====
         if strcmpi(Digitize.Type, '3DScanner')
@@ -145,8 +144,11 @@ function Start(varargin) %#ok<DEFNU>
     
         [sSubject, iSubject] = bst_get('Subject', SubjectName);
     else
+        DigitizeOptions.PatientId = strrep(sSubject.Name, [Digitize.Type '_'], '');
         SubjectName = sSubject.Name;
     end
+    % Set Digitize options
+    bst_set('DigitizeOptions', DigitizeOptions);
 
     % Save the new SubjectName
     Digitize.SubjectName = SubjectName;

--- a/toolbox/sensors/panel_digitize.m
+++ b/toolbox/sensors/panel_digitize.m
@@ -866,6 +866,9 @@ function SwitchToNewMode(mode)
                 SetSelectedButton(8);
                 Digitize.Mode = 8;
             end
+            if strcmpi(Digitize.Type, '3DScanner')
+                ctrl.jButtonRandomHeadPts.setEnabled(0);
+            end
         % Shape
         case 8
             ctrl.jButtonExtraStart.setEnabled(1);
@@ -2145,6 +2148,8 @@ function BytesAvailable_Callback(h, ev)
             % Find the index for the current point
             % ADD A CONDITION HERE THAT EDITS EXISTING EEG POINTS
             if Digitize.isEditPts
+                % Reset global variable required for updating
+                Digitize.isEditPts = 0;
                 [~, iSelCoord] = GetSelectedCoord(); 
                 iPoint = iSelCoord - 3;
             else
@@ -2162,19 +2167,14 @@ function BytesAvailable_Callback(h, ev)
             [curMontage, nEEG] = GetCurrentMontage();
             Digitize.Points.Label{iPoint} = curMontage.Labels{iPoint};
             PlotCoordinate(Digitize.Points.EEG(iPoint,:), Digitize.Points.Label{iPoint}, 'EEG', iPoint)
-            
-            if Digitize.isEditPts
-                Digitize.isEditPts = 0;
+            % Update text field counter to the next point in the list
+            nextPoint = max(size(Digitize.Points.EEG,1)+1, 1);
+            if nextPoint > nEEG
+                % All EEG points have been collected, switch to next mode
+                ctrl.jTextFieldEEG.setText(java.lang.String.valueOf(int16(nEEG)));
+                SwitchToNewMode(8);
             else
-                % Update text field counter to the next point in the list
-                nextPoint = max(size(Digitize.Points.EEG,1)+1, 1);
-                if nextPoint > nEEG
-                    % All EEG points have been collected, switch to next mode
-                    ctrl.jTextFieldEEG.setText(java.lang.String.valueOf(int16(nEEG)));
-                    SwitchToNewMode(8);
-                else
-                    ctrl.jTextFieldEEG.setText(java.lang.String.valueOf(int16(nextPoint)));
-                end
+                ctrl.jTextFieldEEG.setText(java.lang.String.valueOf(int16(nextPoint)));
             end
         % === EXTRA ===
         case 8

--- a/toolbox/sensors/panel_digitize_2024.m
+++ b/toolbox/sensors/panel_digitize_2024.m
@@ -120,6 +120,7 @@ function Start(varargin)
     
         [sSubject, iSubject] = bst_get('Subject', Digitize.SubjectName);
     else
+        Digitize.Options.PatientId = strrep(sSubject.Name, [Digitize.Type '_'], '');
         Digitize.SubjectName = sSubject.Name;
     end
 

--- a/toolbox/sensors/panel_digitize_2024.m
+++ b/toolbox/sensors/panel_digitize_2024.m
@@ -946,7 +946,11 @@ function DeletePoint_Callback()
 
     % Remove last point from figure. It must still be in the list.
     PlotCoordinate(false); % isAdd = false: remove last point instead of adding one
-
+    
+    % Disable 'Random' button
+    if strcmpi(Digitize.Points(Digitize.iPoint).Type, 'EEG')
+        ctrl.jButtonRandomHeadPts.setEnabled(0);
+    end
     % Decrement head shape point count
     if strcmpi(Digitize.Points(Digitize.iPoint).Type, 'EXTRA')
         nShapePts = str2num(ctrl.jTextFieldExtra.getText());
@@ -1669,14 +1673,20 @@ function BytesAvailable_Callback(h, ev) %#ok<INUSD>
         % Update the coordinate list
         UpdateList();
     end
-    % Enable 'Auto' button IFF all landmark fiducials have been acquired
-    if strcmpi(Digitize.Type, '3DScanner') && ~strcmpi(Digitize.Points(Digitize.iPoint).Type, 'EXTRA')
-        eegCapLandmarkLabels = channel_detect_eegcap_auto('GetEegCapLandmarkLabels', Digitize.Options.Montages(Digitize.Options.iMontage).Name);
-        if ~isempty(eegCapLandmarkLabels)
-            acqPoints = Digitize.Points(~cellfun(@isempty, {Digitize.Points.Loc}));
-            if all(ismember([eegCapLandmarkLabels], {acqPoints.Label}))
-                ctrl.jButtonEEGAutoDetectElectrodes.setEnabled(1);
+    if strcmpi(Digitize.Type, '3DScanner')
+        % Enable 'Auto' button IFF all landmark fiducials have been acquired
+        if ~strcmpi(Digitize.Points(Digitize.iPoint).Type, 'EXTRA')
+            eegCapLandmarkLabels = channel_detect_eegcap_auto('GetEegCapLandmarkLabels', Digitize.Options.Montages(Digitize.Options.iMontage).Name);
+            if ~isempty(eegCapLandmarkLabels)
+                acqPoints = Digitize.Points(~cellfun(@isempty, {Digitize.Points.Loc}));
+                if all(ismember([eegCapLandmarkLabels], {acqPoints.Label}))
+                    ctrl.jButtonEEGAutoDetectElectrodes.setEnabled(1);
+                end
             end
+        end
+        % Enable 'Random' button IFF all the EEG points have been collected/corrected
+        if Digitize.iPoint == numel(Digitize.Points)
+            ctrl.jButtonRandomHeadPts.setEnabled(1);
         end
     end
 end

--- a/toolbox/sensors/panel_digitize_2024.m
+++ b/toolbox/sensors/panel_digitize_2024.m
@@ -823,6 +823,9 @@ function EEGAutoDetectElectrodes()
     end
 
     UpdateList();
+    % Change delete button label and callback such that we can delete the last point
+    java_setcb(ctrl.jButtonDeletePoint, 'ActionPerformedCallback', @(h,ev)bst_call(@DeletePoint_Callback));
+    ctrl.jButtonDeletePoint.setText('Delete last point');
     % Enable Random button
     ctrl.jButtonRandomHeadPts.setEnabled(1);
     bst_progress('stop');


### PR DESCRIPTION
**Both panels:**
- [x] For 3D scanner, while manually collecting/correcting EEG points, enable `Random` button IFF all EEG points have been already collected/corrected. Check c177d50 2fc8adb
- [x] Right click on `texture > Digitize (3D scanner)`, get the correct subject ID from the subject name. Check 4b78658

**2024 panel:** 
- [x] For 3D scanner, after `Auto` detection, change delete button label and callback such that we can delete the last point. Check 3e0a5ae