### PR TITLE
Toggle between centroid and surface point selection (for IsoSurface)

### DIFF
--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1999,7 +1999,7 @@ function DisplayFigurePopup(hFig)
             isSelectingCoordinates = getappdata(hFig, 'isSelectingCoordinates');
             isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
             if isIsoSurf && isSelectingCoordinates
-                jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select centroid', [], [], @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
+                jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select surface centroid', [], [], @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
                 isSelectingCentroid = getappdata(hFig, 'isSelectingCentroid');
                 jItem.setSelected(isSelectingCentroid);
                 jPopup.addSeparator();

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1997,8 +1997,8 @@ function DisplayFigurePopup(hFig)
         % ==== MENU: TOGGLE BETWEEN CENTROID/SURFACE POINT SELECTION ====
         if gui_brainstorm('isTabVisible', 'iEEG')
             isSelectingCoordinates = getappdata(hFig, 'isSelectingCoordinates');
-            iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {TessInfo.SurfaceFile})); 
-            if ~isempty(iIsoSurf) && isSelectingCoordinates
+            isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
+            if isIsoSurf && isSelectingCoordinates
                 jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select centroid', [], [], @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
                 isSelectingCentroid = getappdata(hFig, 'isSelectingCentroid');
                 jItem.setSelected(isSelectingCentroid);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -2001,7 +2001,7 @@ function DisplayFigurePopup(hFig)
             ctrl = bst_get('PanelControls', 'iEEG');
             if ctrl.jButtonSelect.isSelected()
                 jPopup.addSeparator();
-                jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select Centroid', [], [], @(h,ev)panel_coordinates('SetSurfacePointSelector', ev.getSource.isSelected()));
+                jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select centroid', [], [], @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
                 isSelectingCentroid = getappdata(hFig, 'isSelectingCentroid');
                 jItem.setSelected(isSelectingCentroid);
                 jPopup.addSeparator();

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -616,7 +616,7 @@ function FigureMouseUpCallback(hFig, varargin)
             % Selecting from Coordinates or iEEG panels
             if gui_brainstorm('isTabVisible', 'Coordinates') || gui_brainstorm('isTabVisible', 'iEEG')
                 if gui_brainstorm('isTabVisible', 'iEEG')
-                    % For IsoSurface allow toggle between centroid/surface point selection                    
+                    % Allow toggle between centroid/surface point selection
                     if isSelectingCentroid
                         panel_coordinates('SelectPoint', hFig, 0, 1);
                     else

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -616,10 +616,8 @@ function FigureMouseUpCallback(hFig, varargin)
             % Selecting from Coordinates or iEEG panels
             if gui_brainstorm('isTabVisible', 'Coordinates') || gui_brainstorm('isTabVisible', 'iEEG')
                 if gui_brainstorm('isTabVisible', 'iEEG')
-                    % For IsoSurface allow toggle bewteen centroid/surface point selection
-                    TessInfo = getappdata(hFig, 'Surface');
-                    iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {TessInfo.SurfaceFile}));
-                    if ~isempty(iIsoSurf) && isSelectingCentroid
+                    % For IsoSurface allow toggle between centroid/surface point selection                    
+                    if isSelectingCentroid
                         panel_coordinates('SelectPoint', hFig, 0, 1);
                     else
                         panel_coordinates('SelectPoint', hFig);
@@ -1998,9 +1996,9 @@ function DisplayFigurePopup(hFig)
         jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, KeyEvent.CTRL_MASK));
         % ==== MENU: TOGGLE BETWEEN CENTROID/SURFACE POINT SELECTION ====
         if gui_brainstorm('isTabVisible', 'iEEG')
-            ctrl = bst_get('PanelControls', 'iEEG');
-            if ctrl.jButtonSelect.isSelected()
-                jPopup.addSeparator();
+            isSelectingCoordinates = getappdata(hFig, 'isSelectingCoordinates');
+            iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {TessInfo.SurfaceFile})); 
+            if ~isempty(iIsoSurf) && isSelectingCoordinates
                 jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select centroid', [], [], @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
                 isSelectingCentroid = getappdata(hFig, 'isSelectingCentroid');
                 jItem.setSelected(isSelectingCentroid);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -616,15 +616,11 @@ function FigureMouseUpCallback(hFig, varargin)
             % Selecting from Coordinates or iEEG panels
             if gui_brainstorm('isTabVisible', 'Coordinates') || gui_brainstorm('isTabVisible', 'iEEG')
                 if gui_brainstorm('isTabVisible', 'iEEG')
-                    % For SEEG, making sure centroid calculation for plotting contacts is active
-                    [iTess, TessInfo, hFig, sSurf] = panel_surface('GetSurface', hFig, [], 'Other');
-                    if ~isempty(sSurf)
-                        iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {sSurf.FileName}));
-                        if ~isempty(iIsoSurf) && isSelectingCentroid
-                            panel_coordinates('SelectPoint', hFig, 0, 1);
-                        else
-                            panel_coordinates('SelectPoint', hFig);
-                        end
+                    % For IsoSurface allow toggle bewteen centroid/surface point selection
+                    TessInfo = getappdata(hFig, 'Surface');
+                    iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {TessInfo.SurfaceFile}));
+                    if ~isempty(iIsoSurf) && isSelectingCentroid
+                        panel_coordinates('SelectPoint', hFig, 0, 1);
                     else
                         panel_coordinates('SelectPoint', hFig);
                     end

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -125,6 +125,7 @@ function hFig = CreateFigure(FigureId) %#ok<DEFNU>
     setappdata(hFig, 'HeadModelFile', []);
     setappdata(hFig, 'isSelectingCorticalSpot', 0);
     setappdata(hFig, 'isSelectingCoordinates',  0);
+    setappdata(hFig, 'isSelectingCentroid',  0);
     setappdata(hFig, 'hasMoved',    0);
     setappdata(hFig, 'isPlotEditToolbar',   0);
     setappdata(hFig, 'isSensorsOnly', 0);
@@ -545,6 +546,7 @@ function FigureMouseUpCallback(hFig, varargin)
     hAxes       = findobj(hFig, '-depth', 1, 'tag', 'Axes3D');
     isSelectingCorticalSpot = getappdata(hFig, 'isSelectingCorticalSpot');
     isSelectingCoordinates  = getappdata(hFig, 'isSelectingCoordinates');
+    isSelectingCentroid     = getappdata(hFig, 'isSelectingCentroid');
     TfInfo = getappdata(hFig, 'Timefreq');
     
     % Remove mouse appdata (to stop movements first)
@@ -618,7 +620,7 @@ function FigureMouseUpCallback(hFig, varargin)
                     [iTess, TessInfo, hFig, sSurf] = panel_surface('GetSurface', hFig, [], 'Other');
                     if ~isempty(sSurf)
                         iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {sSurf.FileName}));
-                        if ~isempty(iIsoSurf)
+                        if ~isempty(iIsoSurf) && isSelectingCentroid
                             panel_coordinates('SelectPoint', hFig, 0, 1);
                         else
                             panel_coordinates('SelectPoint', hFig);
@@ -1998,6 +2000,17 @@ function DisplayFigurePopup(hFig)
         jItem = gui_component('checkboxmenuitem', jPopup, [], 'Get coordinates...', IconLoader.ICON_SCOUT_NEW, [], @GetCoordinates);
         jItem.setSelected(panel_coordinates('GetSelectionState'));
         jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, KeyEvent.CTRL_MASK));
+        % ==== MENU: TOGGLE BETWEEN CENTROID/SURFACE POINT SELECTION ====
+        if gui_brainstorm('isTabVisible', 'iEEG')
+            ctrl = bst_get('PanelControls', 'iEEG');
+            if ctrl.jButtonSelect.isSelected()
+                jPopup.addSeparator();
+                jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select Centroid', [], [], @(h,ev)panel_coordinates('SetSurfacePointSelector', ev.getSource.isSelected()));
+                isSelectingCentroid = getappdata(hFig, 'isSelectingCentroid');
+                jItem.setSelected(isSelectingCentroid);
+                jPopup.addSeparator();
+            end
+        end
     end
     
     % ==== MENU: SNAPSHOT ====

--- a/toolbox/gui/panel_coordinates.m
+++ b/toolbox/gui/panel_coordinates.m
@@ -292,6 +292,7 @@ function SetSelectionState(isSelected)
             TessInfo = getappdata(hFig, 'Surface');
             if ~isempty(TessInfo)
                 setappdata(hFig, 'isSelectingCoordinates', 1);
+                setappdata(hFig, 'isSelectingCentroid', 0);
                 set(hFig, 'Pointer', 'cross');
             end
         end
@@ -304,6 +305,7 @@ function SetSelectionState(isSelected)
         % Exit 3DViz figures from SelectingCorticalSpot mode
         for hFig = hFigures
             set(hFig, 'Pointer', 'arrow');
+            setappdata(hFig, 'isSelectingCentroid', 0);
             setappdata(hFig, 'isSelectingCoordinates', 0);      
         end
     end
@@ -517,6 +519,14 @@ function [TessInfo, iTess, pout, vout, vi, hPatch] = ClickPointInSurface(hFig, S
             iTess = i;
             break;
         end
+    end
+end
+
+%% ===== SET SURFACE POINT SELECTOR (CENTROID/SURFACE) =====
+function SetSurfacePointSelector(isCentroid)
+    hFigures = bst_figures('GetFiguresByType', '3DViz');
+    for hFig = hFigures 
+        setappdata(hFig, 'isSelectingCentroid', isCentroid);
     end
 end
 

--- a/toolbox/gui/panel_coordinates.m
+++ b/toolbox/gui/panel_coordinates.m
@@ -309,6 +309,10 @@ function SetSelectionState(isSelected)
             setappdata(hFig, 'isSelectingCoordinates', 0);      
         end
     end
+    % Update iEEG panel
+    if ~isempty(ctrl2)
+        panel_ieeg('UpdatePanel');
+    end
 end
 
 

--- a/toolbox/gui/panel_coordinates.m
+++ b/toolbox/gui/panel_coordinates.m
@@ -524,9 +524,14 @@ end
 
 %% ===== SET CENTROID SELECTION =====
 function SetCentroidSelection(isSelected)
-    hFigures = bst_figures('GetFiguresByType', '3DViz');
-    for hFig = hFigures 
-        setappdata(hFig, 'isSelectingCentroid', isSelected);
+    hFig = bst_figures('GetCurrentFigure', '3D');
+    if isempty(hFig)
+        return;
+    end
+    setappdata(hFig, 'isSelectingCentroid', isSelected);
+    ctrl = bst_get('PanelControls', 'iEEG');
+    if ~isempty(ctrl)
+        ctrl.jButtonCentroid.setSelected(isSelected);
     end
 end
 

--- a/toolbox/gui/panel_coordinates.m
+++ b/toolbox/gui/panel_coordinates.m
@@ -522,11 +522,11 @@ function [TessInfo, iTess, pout, vout, vi, hPatch] = ClickPointInSurface(hFig, S
     end
 end
 
-%% ===== SET SURFACE POINT SELECTOR (CENTROID/SURFACE) =====
-function SetSurfacePointSelector(isCentroid)
+%% ===== SET CENTROID SELECTION =====
+function SetCentroidSelection(isSelected)
     hFigures = bst_figures('GetFiguresByType', '3DViz');
     for hFig = hFigures 
-        setappdata(hFig, 'isSelectingCentroid', isCentroid);
+        setappdata(hFig, 'isSelectingCentroid', isSelected);
     end
 end
 

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -376,8 +376,8 @@ function UpdatePanel()
         ctrl.jButtonCentroid.setEnabled(0);
         % Enable centroid select button only when IsoSurface present
         TessInfo = getappdata(hFigall, 'Surface');
-        iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {TessInfo.SurfaceFile}));            
-        if ~isempty(iIsoSurf)
+        isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
+        if isIsoSurf
             isSelectingCoordinates = getappdata(hFigall, 'isSelectingCoordinates');
             ctrl.jButtonCentroid.setEnabled(isSelectingCoordinates);
             isSelectingCentroid    = getappdata(hFigall, 'isSelectingCentroid');

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -54,7 +54,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_PLUS, TB_DIM}, 'Add new electrode', @(h,ev)bst_call(@AddElectrode));
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_MINUS, TB_DIM}, 'Remove selected electrodes', @(h,ev)bst_call(@RemoveElectrode));
         % Button "Select vertex"
-        jButtonSelect = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SCOUT_NEW, 'Select surface point', @(h,ev)panel_coordinates('SetSelectionState', ev.getSource.isSelected()));
+        jButtonSelect = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SCOUT_NEW, 'Select surface point', @(h,ev)ShowSurfPointSelectMenu(ev.getSource()));
         % Set color
         jToolbar.addSeparator();
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_COLOR_SELECTION, TB_DIM}, 'Select color for selected electrodes', @(h,ev)bst_call(@EditElectrodeColor));
@@ -755,6 +755,17 @@ function UpdateElecProperties(isUpdateModelList)
     ctrl.jButtonShow.setSelected(isSelected);
     % Save selected electrodes
     ctrl.jLabelSelectElec.setText(num2str(iSelElec));
+end
+
+%% ===== SHOW SURFACE POINT SELECTION MENU =====
+function ShowSurfPointSelectMenu(jButton)
+    panel_coordinates('SetSelectionState', jButton.isSelected());
+    if jButton.isSelected()
+        jMenu = java_create('javax.swing.JPopupMenu');
+        % MENU: TOGGLE BETWEEN CENTROID/SURFACE POINT SELECTION
+        gui_component('checkbox', jMenu, [], 'Select Centroid', '', [], @(h,ev)panel_coordinates('SetSurfacePointSelector', ev.getSource.isSelected()));
+        gui_brainstorm('ShowPopup', jMenu, jButton);
+    end
 end
 
 %% ===== SET CROSSHAIR POSITION ON MRI =====

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -56,8 +56,8 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         % Button "Select vertex"
         jToolbar.addSeparator();
         jButtonSelect = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SCOUT_NEW, 'Select surface point', @(h,ev)panel_coordinates('SetSelectionState', ev.getSource.isSelected()));
-        % Button "Select centroid"
-        jButtonCentroid = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_RESET, 'Select centroid', @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
+        % Button "Select surface centroid"
+        jButtonCentroid = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SURFACE, 'Select surface centroid', @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
         % Set color
         jToolbar.addSeparator();
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_COLOR_SELECTION, TB_DIM}, 'Select color for selected electrodes', @(h,ev)bst_call(@EditElectrodeColor));
@@ -381,7 +381,7 @@ function UpdatePanel()
             isSelectingCoordinates = getappdata(hFigall, 'isSelectingCoordinates');
             ctrl.jButtonCentroid.setEnabled(isSelectingCoordinates);
             isSelectingCentroid    = getappdata(hFigall, 'isSelectingCentroid');
-            ctrl.jButtonCentroid.setSelected(isSelectingCentroid);              
+            ctrl.jButtonCentroid.setSelected(isSelectingCentroid);
         end
     % Else: no figure associated with the panel, or not loaded channel file : disable all controls
     else

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -57,7 +57,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         jToolbar.addSeparator();
         jButtonSelect = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SCOUT_NEW, 'Select surface point', @(h,ev)panel_coordinates('SetSelectionState', ev.getSource.isSelected()));
         % Button "Select surface centroid"
-        jButtonCentroid = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SURFACE, 'Select surface centroid', @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
+        jButtonCentroid = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_GOOD, 'Select surface centroid', @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
         % Set color
         jToolbar.addSeparator();
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_COLOR_SELECTION, TB_DIM}, 'Select color for selected electrodes', @(h,ev)bst_call(@EditElectrodeColor));

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -382,6 +382,8 @@ function UpdatePanel()
             ctrl.jButtonCentroid.setEnabled(isSelectingCoordinates);
             isSelectingCentroid    = getappdata(hFigall, 'isSelectingCentroid');
             ctrl.jButtonCentroid.setSelected(isSelectingCentroid);
+        else
+            panel_coordinates('SetCentroidSelection', 0);
         end
     % Else: no figure associated with the panel, or not loaded channel file : disable all controls
     else

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -43,7 +43,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
     jPanelNew = gui_component('Panel');
     jPanelTop = gui_component('Panel');
     jPanelNew.add(jPanelTop, BorderLayout.NORTH);
-    TB_DIM = java_scaled('dimension',25,25);
+    TB_DIM = java_scaled('dimension',20,25);
     
     % ===== TOOLBAR =====
     jMenuBar = gui_component('MenuBar', jPanelTop, BorderLayout.NORTH);
@@ -54,7 +54,10 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_PLUS, TB_DIM}, 'Add new electrode', @(h,ev)bst_call(@AddElectrode));
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_MINUS, TB_DIM}, 'Remove selected electrodes', @(h,ev)bst_call(@RemoveElectrode));
         % Button "Select vertex"
-        jButtonSelect = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SCOUT_NEW, 'Select surface point', @(h,ev)ShowSurfPointSelectMenu(ev.getSource()));
+        jToolbar.addSeparator();
+        jButtonSelect = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_SCOUT_NEW, 'Select surface point', @(h,ev)panel_coordinates('SetSelectionState', ev.getSource.isSelected()));
+        % Button "Select centroid"
+        jButtonCentroid = gui_component('ToolbarToggle', jToolbar, [], '', IconLoader.ICON_RESET, 'Select centroid', @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
         % Set color
         jToolbar.addSeparator();
         gui_component('ToolbarButton', jToolbar,[],[], {IconLoader.ICON_COLOR_SELECTION, TB_DIM}, 'Select color for selected electrodes', @(h,ev)bst_call(@EditElectrodeColor));
@@ -215,6 +218,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
                                   'jToolbar',            jToolbar, ...
                                   'jPanelElecOptions',   jPanelElecOptions, ...
                                   'jButtonSelect',       jButtonSelect, ...
+                                  'jButtonCentroid',     jButtonCentroid, ...
                                   'jButtonShow',         jButtonShow, ...
                                   'jRadioDispDepth',     jRadioDispDepth, ...
                                   'jRadioDispSphere',    jRadioDispSphere, ...
@@ -757,16 +761,6 @@ function UpdateElecProperties(isUpdateModelList)
     ctrl.jLabelSelectElec.setText(num2str(iSelElec));
 end
 
-%% ===== SHOW SURFACE POINT SELECTION MENU =====
-function ShowSurfPointSelectMenu(jButton)
-    panel_coordinates('SetSelectionState', jButton.isSelected());
-    if jButton.isSelected()
-        jMenu = java_create('javax.swing.JPopupMenu');
-        % MENU: TOGGLE BETWEEN CENTROID/SURFACE POINT SELECTION
-        gui_component('checkbox', jMenu, [], 'Select Centroid', '', [], @(h,ev)panel_coordinates('SetSurfacePointSelector', ev.getSource.isSelected()));
-        gui_brainstorm('ShowPopup', jMenu, jButton);
-    end
-end
 
 %% ===== SET CROSSHAIR POSITION ON MRI =====
 function SetMriCrosshair(sSelContacts) %#ok<DEFNU>

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -373,6 +373,16 @@ function UpdatePanel()
         gui_enable([ctrl.jPanelElecList, ctrl.jToolbar], 1);
         ctrl.jListElec.setBackground(java.awt.Color(1,1,1));
         ctrl.jListCont.setBackground(java.awt.Color(1,1,1));
+        ctrl.jButtonCentroid.setEnabled(0);
+        % Enable centroid select button only when IsoSurface present
+        TessInfo = getappdata(hFigall, 'Surface');
+        iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, 'tess_isosurface', 'match')), {TessInfo.SurfaceFile}));            
+        if ~isempty(iIsoSurf)
+            isSelectingCoordinates = getappdata(hFigall, 'isSelectingCoordinates');
+            ctrl.jButtonCentroid.setEnabled(isSelectingCoordinates);
+            isSelectingCentroid    = getappdata(hFigall, 'isSelectingCentroid');
+            ctrl.jButtonCentroid.setSelected(isSelectingCentroid);              
+        end
     % Else: no figure associated with the panel, or not loaded channel file : disable all controls
     else
         gui_enable([ctrl.jPanelElecList, ctrl.jToolbar], 0);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -915,6 +915,7 @@ function ButtonRemoveSurfaceCallback(varargin)
     if isempty(iSurface)
         return
     end
+    % Check if surface being removed is an IsoSurface
     isRemoveIsoSurface = ~isempty(regexp(TessInfo(iSurface).SurfaceFile, 'tess_isosurface', 'match'));
     % Remove surface 
     RemoveSurface(hFig, iSurface);

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -891,9 +891,13 @@ function ButtonAddSurfaceCallback(surfaceType)
         % Update colormap
         figure_3d('ColormapChangedCallback', iDS, iFig);
     end
-    % Reload scouts (only if new surface was added)
     if (iTess > length(TessInfo))
+        % Reload scouts (only if new surface was added)
         panel_scout('ReloadScouts', hFig);
+        % Update iEEG panel (only if new IsoSurface was added)
+        if strcmpi(surfaceType, 'IsoSurface') && gui_brainstorm('isTabVisible', 'iEEG')
+             panel_ieeg('UpdatePanel');
+        end
     end
 end
 
@@ -905,15 +909,21 @@ function ButtonRemoveSurfaceCallback(varargin)
     if isempty(hFig)
         return
     end
-    % Get current surface index
+    % Get current surface and its index
+    TessInfo = getappdata(hFig, 'Surface');
     iSurface = getappdata(hFig, 'iSurface');
     if isempty(iSurface)
         return
     end
-    % Remove surface
+    isRemoveIsoSurface = ~isempty(regexp(TessInfo(iSurface).SurfaceFile, 'tess_isosurface', 'match'));
+    % Remove surface 
     RemoveSurface(hFig, iSurface);
     % Update "Surfaces" panel
     UpdatePanel();
+    % Update iEEG panel if IsoSurface was removed
+    if isRemoveIsoSurface && gui_brainstorm('isTabVisible', 'iEEG')
+        panel_ieeg('UpdatePanel');
+    end
 end
 
 

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -910,19 +910,19 @@ function ButtonRemoveSurfaceCallback(varargin)
         return
     end
     % Get current surface and its index
-    TessInfo = getappdata(hFig, 'Surface');
     iSurface = getappdata(hFig, 'iSurface');
     if isempty(iSurface)
         return
     end
-    % Check if surface being removed is an IsoSurface
-    isRemoveIsoSurface = ~isempty(regexp(TessInfo(iSurface).SurfaceFile, 'tess_isosurface', 'match'));
     % Remove surface 
     RemoveSurface(hFig, iSurface);
     % Update "Surfaces" panel
     UpdatePanel();
     % Update iEEG panel if IsoSurface was removed
-    if isRemoveIsoSurface && gui_brainstorm('isTabVisible', 'iEEG')
+    TessInfo = getappdata(hFig, 'Surface');
+    % Check if no IsoSurface remains
+    isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
+    if ~isIsoSurf && gui_brainstorm('isTabVisible', 'iEEG')
         panel_ieeg('UpdatePanel');
     end
 end


### PR DESCRIPTION
This PR allows users to switch between centroid/surface point selection while selecting a point in the IsoSurface (addresses point # 10 in PR #732).

> Shortcut to switch between center and non-center selection of 3D contacts

Proposed GUI (button) in iEEG panel :
![Screenshot 2025-04-14 185728](https://github.com/user-attachments/assets/8190be50-6a22-4ccf-9a30-7a561c355dc6)


Proposed menu item (checkboxmenuitem) when user right clicking on the 3D figure (shows up only when the `Select` button is pressed in iEEG panel and IsoSurface is loaded):
![Screenshot 2025-04-14 185852](https://github.com/user-attachments/assets/39a9a4b3-1a96-47fd-877d-a31f5dd97ab4)
