### PR TITLE
Fix reload last pipeline

### DIFF
--- a/toolbox/process/bst_report.m
+++ b/toolbox/process/bst_report.m
@@ -1407,8 +1407,8 @@ function Recall(target)
         return
     end
     % Get the start and process entries
-    iStart   = strcmpi(Reports(:,1), 'start');
-    iProcess = strcmpi(Reports(:,1), 'process');
+    iStart   = find(strcmpi(Reports(:,1), 'start'));
+    iProcess = find(strcmpi(Reports(:,1), 'process'));
     if isempty(iStart) || isempty(iProcess)
         return;
     end


### PR DESCRIPTION
This fix a bug introduced by https://github.com/brainstorm-tools/brainstorm3/commit/d0aac8311fcbd70bf99eece9cd2e49a84be5e144

in line 1410, 
    FileNames = GetFilesList(Reports{iStart(1),3}, 0);


Report is 
![image](https://github.com/user-attachments/assets/c60c7bfe-7d69-4c04-903f-5ce8b151c532)


and without the fix, iStart is [ 0, 1, 0, 0] instead of [2] so  iStart(1) is using the first entry which is the login of the version instead of the first called process. 



