### PR TITLE
Fix downsize for some surface

### DIFF
--- a/toolbox/anatomy/tess_downsize.m
+++ b/toolbox/anatomy/tess_downsize.m
@@ -101,7 +101,7 @@ if isempty(Method)
 
     % Identify textured surfaces (color info is present) and show available methods for them
     VarInfo = whos('-file',file_fullpath(TessFile), 'Color');
-    if all(VarInfo.size ~= 0)
+    if ~isempty(VarInfo) && all(VarInfo.size ~= 0)
         methods_str = methods_str(1); % Inhomogeneous mesh
     end
     % Ask method


### PR DESCRIPTION
For some surface,      VarInfo = whos('-file',file_fullpath(TessFile), 'Color'); is an empty structure making it not possible to downsample currently : 



```
Error using  ~= 
Not enough input arguments.

Error in tess_downsize (line 104)
    if all(VarInfo.size ~= 0)

Error in tree_callbacks>@(h,ev)tess_downsize(filenameFull,[],[]) (line 1227)
                        gui_component('MenuItem', jPopup, [], 'Less vertices...', IconLoader.ICON_DOWNSAMPLE, [], @(h,ev)tess_downsize(filenameFull, [], []));
 
```

Bug introduced in https://github.com/brainstorm-tools/brainstorm3/commit/6c646d2248c877a481dcf1e7308ff5287992a676#diff-06a50b4ab8b307f561df9657e84204144ccafe391b867f3a8eea5e4ceb1c5e55 


Edit: Actually, I am not sure I quite like the syntax : 

```matab    
 VarInfo = whos('-file',file_fullpath(TessFile), 'Color');
     if ~isempty(VarInfo) && all(VarInfo.size ~= 0)
         methods_str = methods_str(1); % Inhomogeneous mesh
     end


```  

and would more write something like (seems more consistent with the rest of the codebase)

```matlab

sTess = in_tess_bst(TessFile)
if isfield(sTess,  'Color')  && ~isempty(sTess.Color) 
    methods_str = methods_str(1); % Inhomogeneous mesh
end

``` 


This would allow to remove the other call to whos on line62 (VarInfo = whos('-file',file_fullpath(TessFile),'Vertices');)