### PR TITLE
Improve iEEG editing features (`Group electrodes` and `Add/Remove contacts`)

### DIFF
--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1601,7 +1601,9 @@ function DisplayFigurePopup(hFig)
     else
         TfFile = [];
     end
-
+    % Check if IsoSurface exists in the figure
+    isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
+    
     % Create popup menu
     jPopup = java_create('javax.swing.JPopupMenu');
     
@@ -1816,7 +1818,6 @@ function DisplayFigurePopup(hFig)
             jMenuChannels.addSeparator();
             gui_component('MenuItem', jMenuChannels, [], 'Configure display', IconLoader.ICON_CHANNEL, [], @(h,ev)SetElectrodesConfig(hFig));
             % For iEEG: Add/Remove contact(s) (TODO: support for ECoG)
-            isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
             sSelElec = panel_ieeg('GetSelectedElectrodes');
             if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG')
                 if isIsoSurf
@@ -2022,7 +2023,6 @@ function DisplayFigurePopup(hFig)
         % ==== MENU: TOGGLE BETWEEN CENTROID/SURFACE POINT SELECTION ====
         if gui_brainstorm('isTabVisible', 'iEEG')
             isSelectingCoordinates = getappdata(hFig, 'isSelectingCoordinates');
-            isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
             if isIsoSurf && isSelectingCoordinates
                 jItem = gui_component('checkboxmenuitem', jPopup, [], 'Select surface centroid', [], [], @(h,ev)panel_coordinates('SetCentroidSelection', ev.getSource.isSelected()));
                 isSelectingCentroid = getappdata(hFig, 'isSelectingCentroid');

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1807,14 +1807,6 @@ function DisplayFigurePopup(hFig)
             end
         % 3DElectrodes
         elseif ~isempty(hElectrodeGrid)
-            % For iEEG: Remove contact(s) (TODO: support for ECoG)
-            if gui_brainstorm('isTabVisible', 'iEEG')
-                if ~isempty(SelChan) && ~isempty(Modality) && ismember(Modality, {'SEEG'})
-                    jItem = gui_component('MenuItem', jMenuChannels, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)panel_ieeg('RemoveContactHelper'));
-                    jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
-                    jMenuChannels.addSeparator();
-                end
-            end
             % Menu "View sensor labels"
             isLabels = ~isempty(GlobalData.DataSet(iDS).Figure(iFig).Handles.hSensorLabels);
             jItem = gui_component('CheckBoxMenuItem', jMenuChannels, [], 'Display labels', IconLoader.ICON_CHANNEL_LABEL, [], @(h,ev)ViewSensors(hFig, [], ~isLabels));
@@ -1823,6 +1815,18 @@ function DisplayFigurePopup(hFig)
             % Configure 3D electrode display
             jMenuChannels.addSeparator();
             gui_component('MenuItem', jMenuChannels, [], 'Configure display', IconLoader.ICON_CHANNEL, [], @(h,ev)SetElectrodesConfig(hFig));
+            % For iEEG: Add/Remove contact(s) (TODO: support for ECoG)
+            isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match')));
+            sSelElec = panel_ieeg('GetSelectedElectrodes');
+            if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG')
+                if isIsoSurf
+                    gui_component('MenuItem', jMenuChannels, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)panel_ieeg('AddContact'));
+                end
+                if ~isempty(SelChan)
+                    jItem = gui_component('MenuItem', jMenuChannels, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)panel_ieeg('RemoveContactHelper'));
+                    jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
+                end
+            end
         % Other figures
         else
             % Menu "View sensors"

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1293,7 +1293,7 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                     % For iEEG: Remove contact(s) (TODO: support for ECoG)
                     if gui_brainstorm('isTabVisible', 'iEEG')
                         if ~isempty(SelChan) && ~isempty(FigureId.Modality) && ismember(FigureId.Modality, {'SEEG'})
-                            panel_ieeg('RemoveContact');
+                            panel_ieeg('RemoveContactHelper');
                         end
                     end
                 % ESCAPE: RESET SELECTION
@@ -1810,7 +1810,7 @@ function DisplayFigurePopup(hFig)
             % For iEEG: Remove contact(s) (TODO: support for ECoG)
             if gui_brainstorm('isTabVisible', 'iEEG')
                 if ~isempty(SelChan) && ~isempty(Modality) && ismember(Modality, {'SEEG'})
-                    jItem = gui_component('MenuItem', jMenuChannels, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)panel_ieeg('RemoveContact'));
+                    jItem = gui_component('MenuItem', jMenuChannels, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)panel_ieeg('RemoveContactHelper'));
                     jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
                     jMenuChannels.addSeparator();
                 end

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1264,8 +1264,9 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                             view_timefreq(TfInfo.FileName, 'SingleSensor', SelChan{1});
                         end
                     end
-                % DELETE: SET CHANNELS AS BAD
+                % DELETE
                 case {'delete', 'backspace'}
+                    % Set channels as bad
                     isMulti2dLayout = (isfield(GlobalData.DataSet(iDS).Figure(iFig).Handles, 'hLines') && (length(GlobalData.DataSet(iDS).Figure(iFig).Handles.hLines) >= 2));
                     if ~isAlignFig && ~isempty(SelChan) && ~isSensorsOnly && ~isempty(GlobalData.DataSet(iDS).DataFile) && ...
                             (length(GlobalData.DataSet(iDS).Figure(iFig).SelectedChannels) ~= length(iSelChan)) && ~isMulti2dLayout
@@ -1282,6 +1283,12 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                         panel_channel_editor('UpdateChannelFlag', GlobalData.DataSet(iDS).DataFile, newChannelFlag);
                         % Reset selection
                         bst_figures('SetSelectedRows', []);
+                    end
+                    % For iEEG: Remove contact(s) (TODO: support for ECoG)
+                    if gui_brainstorm('isTabVisible', 'iEEG')
+                        if ~isempty(SelChan) && ~isempty(FigureId.Modality) && ismember(FigureId.Modality, {'SEEG'})
+                            panel_ieeg('RemoveContact');
+                        end
                     end
                 % ESCAPE: RESET SELECTION
                 case 'escape'
@@ -1794,6 +1801,14 @@ function DisplayFigurePopup(hFig)
             end
         % 3DElectrodes
         elseif ~isempty(hElectrodeGrid)
+            % For iEEG: Remove contact(s) (TODO: support for ECoG)
+            if gui_brainstorm('isTabVisible', 'iEEG')
+                if ~isempty(SelChan) && ~isempty(Modality) && ismember(Modality, {'SEEG'})
+                    jItem = gui_component('MenuItem', jMenuChannels, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)panel_ieeg('RemoveContact'));
+                    jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
+                    jMenuChannels.addSeparator();
+                end
+            end
             % Menu "View sensor labels"
             isLabels = ~isempty(GlobalData.DataSet(iDS).Figure(iFig).Handles.hSensorLabels);
             jItem = gui_component('CheckBoxMenuItem', jMenuChannels, [], 'Display labels', IconLoader.ICON_CHANNEL_LABEL, [], @(h,ev)ViewSensors(hFig, [], ~isLabels));

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1225,6 +1225,15 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                     if ismember('control', keyEvent.Modifier)
                         bst_figures('ViewResults', hFig); 
                     end
+                    % For iEEG: Add contact
+                    if gui_brainstorm('isTabVisible', 'iEEG')
+                        TessInfo = getappdata(hFig, 'Surface');
+                        isIsoSurf = any(~cellfun(@isempty, regexp({TessInfo.SurfaceFile}, 'tess_isosurface', 'match'))); 
+                        sSelElec = panel_ieeg('GetSelectedElectrodes');
+                        if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG') && isIsoSurf
+                            panel_ieeg('AddContact');
+                        end
+                    end
                 % CTRL+T : Default topography
                 case 't'
                     if ismember('control', keyEvent.Modifier) 
@@ -1821,7 +1830,8 @@ function DisplayFigurePopup(hFig)
             sSelElec = panel_ieeg('GetSelectedElectrodes');
             if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG')
                 if isIsoSurf
-                    gui_component('MenuItem', jMenuChannels, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)panel_ieeg('AddContact'));
+                    jItem = gui_component('MenuItem', jMenuChannels, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)panel_ieeg('AddContact'));
+                    jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, 0));
                 end
                 if ~isempty(SelChan)
                     jItem = gui_component('MenuItem', jMenuChannels, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)panel_ieeg('RemoveContactHelper'));

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -830,12 +830,18 @@ function FigureMouseUpCallback(hFig, varargin)
                     else
                         bst_figures('ToggleSelectedRow', SelChan);
                     end
-                    % If there are intra electrodes defined, and if the channels are SEEG/ECOG: try to select the electrode in panel_ieeg
-                    if ~isempty(GlobalData.DataSet(iDS).IntraElectrodes) && all(~cellfun(@isempty, {GlobalData.DataSet(iDS).Channel(iSelChan).Group}))
+                    % Get current selected channels in the figure
+                    SelChanCur = GetFigSelectedRows(hFig);
+                    % If there are channels selected, they have intra electrodes defined, and if the channels are SEEG/ECOG: try to select the electrode in panel_ieeg
+                    if ~isempty(SelChanCur) && ~isempty(GlobalData.DataSet(iDS).IntraElectrodes) && all(~cellfun(@isempty, {GlobalData.DataSet(iDS).Channel(iSelChan).Group}))
                         selGroup = unique({GlobalData.DataSet(iDS).Channel(iSelChan).Group});
                         % Highlight the electrode and contacts
                         panel_ieeg('SetSelectedElectrodes', selGroup);
                         panel_ieeg('SetSelectedContacts', SelChan);
+                    else % Else if no selected channels: Reset electrode selection in panel_ieeg
+                        % Remove highlight for contacts and electrode
+                        panel_ieeg('SetSelectedContacts', 0);
+                        panel_ieeg('SetSelectedElectrodes', 0);
                     end
                 end
             end

--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -625,6 +625,13 @@ function FigureKeyPress_Callback(hFig, keyEvent)
                     if ismember('control', keyEvent.Modifier)
                         SetElectrodePosition(hFig);
                     end
+                    % For iEEG: Add contact (TODO: support for ECoG)
+                    if gui_brainstorm('isTabVisible', 'iEEG')
+                        sSelElec = panel_ieeg('GetSelectedElectrodes');
+                        if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG')
+                            panel_ieeg('AddContact');
+                        end
+                    end
                 % CTRL+E : Set electrode labels visible
                 case 'e'
                     if ismember('control', keyEvent.Modifier)
@@ -1063,7 +1070,8 @@ function DisplayFigurePopup(hFig)
             % For iEEG: Add contact (TODO: support for ECoG) 
             sSelElec = panel_ieeg('GetSelectedElectrodes');
             if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG')
-                gui_component('MenuItem', jMenuElec, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)panel_ieeg('AddContact')); 
+                jItem = gui_component('MenuItem', jMenuElec, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)panel_ieeg('AddContact'));
+                jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, 0));
             end
         elseif isequal(GlobalData.DataSet(iDS).Figure(iFig).Id.Modality, 'SEEG')
             gui_component('MenuItem', jMenuElec, [], 'SEEG contacts', IconLoader.ICON_CHANNEL, [], @(h,ev)panel_ieeg('LoadElectrodes', hFig, GlobalData.DataSet(iDS).ChannelFile, 'SEEG'));

--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -1060,6 +1060,11 @@ function DisplayFigurePopup(hFig)
             % Set position
             jItem = gui_component('MenuItem', jMenuElec, [], 'Set electrode position',  IconLoader.ICON_CHANNEL, [], @(h,ev)SetElectrodePosition(hFig));      
             jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, KeyEvent.CTRL_MASK));
+            % For iEEG: Add contact (TODO: support for ECoG) 
+            sSelElec = panel_ieeg('GetSelectedElectrodes');
+            if ~isempty(sSelElec) && strcmpi(sSelElec(end).Type, 'SEEG')
+                gui_component('MenuItem', jMenuElec, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)panel_ieeg('AddContact')); 
+            end
         elseif isequal(GlobalData.DataSet(iDS).Figure(iFig).Id.Modality, 'SEEG')
             gui_component('MenuItem', jMenuElec, [], 'SEEG contacts', IconLoader.ICON_CHANNEL, [], @(h,ev)panel_ieeg('LoadElectrodes', hFig, GlobalData.DataSet(iDS).ChannelFile, 'SEEG'));
         elseif isequal(GlobalData.DataSet(iDS).Figure(iFig).Id.Modality, 'ECOG')

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -112,7 +112,8 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
                 jListCont.setLayoutOrientation(jListCont.HORIZONTAL_WRAP);
                 jListCont.setVisibleRowCount(-1);
                 java_setcb(jListCont, ...
-                    'ValueChangedCallback', @(h,ev)bst_call(@ContListChanged_Callback,h,ev));
+                    'ValueChangedCallback', @(h,ev)bst_call(@ContListChanged_Callback,h,ev), ...
+                    'KeyTypedCallback',     @(h,ev)bst_call(@ContListKeyTyped_Callback,h,ev));
                 jPanelScrollContList = JScrollPane();
                 jPanelScrollContList.getLayout.getViewport.setView(jListCont);
                 jPanelScrollContList.setBorder([]);
@@ -346,6 +347,21 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         sContacts = GetSelectedContacts();
         bst_figures('SetSelectedRows', {sContacts.Name});
         SetMriCrosshair(sContacts);
+    end
+
+    %% ===== CONTACT LIST KEY TYPED CALLBACK =====
+    function ContListKeyTyped_Callback(h, ev)
+        switch(uint8(ev.getKeyChar()))
+            % DELETE
+            case {ev.VK_DELETE, ev.VK_BACK_SPACE}
+                sSelElec = GetSelectedElectrodes();
+                % Remove contact(s) (TODO: support for ECoG)
+                if strcmpi(sSelElec(1).Type, 'SEEG')
+                    RemoveContact();
+                end
+            case ev.VK_ESCAPE
+                SetSelectedContacts(0);
+        end
     end
 end
                    
@@ -959,6 +975,11 @@ function ShowContactsMenu(jButton)
         java_dialog('warning', 'No electrode selected.', 'Align contacts');
         return
     end
+    % Menu: Remove contact(s) (TODO: support for ECoG)
+    if length(sSelElec)==1 && sSelElec.ContactNumber>=1 && strcmpi(sSelElec.Type, 'SEEG')
+        gui_component('MenuItem', jMenu, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)bst_call(@RemoveContact));
+        jMenu.addSeparator();
+    end
     % Menu: Default positions
     gui_component('MenuItem', jMenu, [], 'Use default positions', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)bst_call(@AlignContacts, iDS, iFig, 'default'));
     % Menu: Export select atlas
@@ -1482,6 +1503,115 @@ function RemoveElectrode()
     UpdateFigures();
 end
 
+%% ===== REMOVE CONTACT(S) =====
+function RemoveContact()
+    global GlobalData;
+    % Get selected electrode
+    [sSelElec, iSelElec, iDSall, iFigall] = GetSelectedElectrodes();
+    if isempty(iDSall)
+        return;
+    end
+    % Check if this is an new implantation folder
+    ChannelFile = GlobalData.DataSet(iDSall(1)).ChannelFile;
+    [~, folderName] = bst_fileparts(bst_fileparts(ChannelFile));
+    isImplantation = ~isempty(strfind(folderName, 'Implantation'));
+    % Get selected contact
+    sSelCont = GetSelectedContacts();
+    if isempty(sSelCont)
+        java_dialog('warning', 'No contact selected.', 'Remove contact');
+        return
+    end
+    % Confirmation text
+    if (length(sSelCont) == 1)
+        strConfirm = ['Delete contact "' sSelCont.Name '"?'];
+    else
+        strConfirm = ['Delete ' num2str(length(sSelCont)) ' contacts in electrode "' sSelElec.Name '"?'];
+    end
+    % Ask for confirmation
+    if ~java_dialog('confirm', strConfirm)
+        return;
+    end
+    % Reset selected contacts
+    SetSelectedContacts(0);
+    % Loop on datasets
+    for iDS = unique(iDSall)
+        % If implantation scheme proceed with deleting the selected contacts
+        if isImplantation
+            % Loop on contacts to delete
+            for iCont = 1:length(sSelCont)
+                % Get contact details from channel file
+                iChan = find(strcmpi({GlobalData.DataSet(iDS).Channel.Name}, sSelCont(iCont).Name));
+                if isempty(iChan)
+                    continue;
+                end
+                % Loop on figures for this dataset
+                for iFig = iFigall(iDSall == iDS)
+                    % If incorrect figure type
+                    if ~ismember(GlobalData.DataSet(iDS).Figure(iFig).Id.Type, {'MriViewer', '3DViz', 'Topography'})
+                        continue;
+                    end
+                    % Get indices in the figure handles
+                    [~, iHandles] = intersect(GlobalData.DataSet(iDS).Figure(iFig).SelectedChannels, iChan);
+                    % Delete graphic handles
+                    if ~isempty(iHandles) && isfield(GlobalData.DataSet(iDS).Figure(iFig).Handles, 'hPointEEG') && (max(iHandles) <= size(GlobalData.DataSet(iDS).Figure(iFig).Handles.hPointEEG,1))
+                        delete(GlobalData.DataSet(iDS).Figure(iFig).Handles.hPointEEG(iHandles,:));
+                        GlobalData.DataSet(iDS).Figure(iFig).Handles.hPointEEG(iHandles,:) = [];
+                    end
+                    if ~isempty(iHandles) && isfield(GlobalData.DataSet(iDS).Figure(iFig).Handles, 'hTextEEG') && (max(iHandles) <= size(GlobalData.DataSet(iDS).Figure(iFig).Handles.hTextEEG,1))
+                        delete(GlobalData.DataSet(iDS).Figure(iFig).Handles.hTextEEG(iHandles,:));
+                        GlobalData.DataSet(iDS).Figure(iFig).Handles.hTextEEG(iHandles,:) = [];
+                    end
+                    if ~isempty(iHandles) && isfield(GlobalData.DataSet(iDS).Figure(iFig).Handles, 'LocEEG') && (max(iHandles) <= size(GlobalData.DataSet(iDS).Figure(iFig).Handles.LocEEG,1))
+                        GlobalData.DataSet(iDS).Figure(iFig).Handles.LocEEG(iHandles,:) = [];
+                    end
+                    % Delete all previously created objects
+                    hFig = GlobalData.DataSet(iDS).Figure(iFig).hFigure;
+                    delete(findobj(hFig, 'Tag', 'ElectrodeGrid'));
+                    delete(findobj(hFig, 'Tag', 'ElectrodeSelect'));
+                    delete(findobj(hFig, 'Tag', 'ElectrodeDepth'));
+                    delete(findobj(hFig, 'Tag', 'ElectrodeWire'));
+                    delete(findobj(hFig, 'Tag', 'ElectrodeLabel'));
+                    % Update list of displayed channels
+                    iSelChan = setdiff(GlobalData.DataSet(iDS).Figure(iFig).SelectedChannels, iChan);
+                    remChan = {GlobalData.DataSet(iDS).Channel(setdiff(1:length(GlobalData.DataSet(iDS).Channel), iChan)).Name};
+                    selChan = {GlobalData.DataSet(iDS).Channel(iSelChan).Name};
+                    [~, I] = intersect(remChan, selChan);
+                    GlobalData.DataSet(iDS).Figure(iFig).SelectedChannels = I(:)';
+                end
+                % Update figure modality
+                UpdateFigureModality(iDS, iFig);
+                % Remove channels
+                GlobalData.DataSet(iDS).Channel(iChan) = [];
+            end
+            % === Update intraelectrode structure in channel ===
+            % Get the updated contacts
+            sContacts = GetContacts(sSelElec.Name);
+            % Update electrode contact number
+            sSelElec.ContactNumber = size(sContacts, 2);
+            % Assign electrode tip and skull entry
+            sSelElec.Loc = [];
+            if sSelElec.ContactNumber >= 1
+                sSelElec.Loc(:,1) = sContacts(1).Loc;
+            end
+            if sSelElec.ContactNumber > 1
+                sSelElec.Loc(:,2) = sContacts(end).Loc;
+            end
+            % Set the changed electrode properties
+            SetElectrodes(iSelElec, sSelElec);
+            % === Update contact names in channel ===
+            [~, iChan] = ismember({sContacts.Name}, {GlobalData.DataSet(iDS).Channel.Name});
+            newContNames  = {};
+            for iCont = 1:sSelElec.ContactNumber
+                newContNames{end+1} = sprintf('%s%d', sSelElec.Name, iCont);
+            end
+            [GlobalData.DataSet(iDS).Channel(iChan).Name] = newContNames{:};
+        end
+    end
+    % Mark channel file as modified (only the first one)
+    GlobalData.DataSet(iDSall(1)).isChannelModified = 1;
+    % Update figure
+    UpdateFigures();
+end
 
 %% ===== GET ELECTRODE MODELS =====
 function sModels = GetElectrodeModels()

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -994,6 +994,8 @@ end
 
 %% ===== SHOW CONTACTS MENU =====
 function ShowContactsMenu(jButton)
+    import java.awt.event.KeyEvent;
+    import javax.swing.KeyStroke;
     import org.brainstorm.icon.*;
     % Create popup menu
     jMenu = java_create('javax.swing.JPopupMenu');
@@ -1005,8 +1007,9 @@ function ShowContactsMenu(jButton)
     end
     % Menu: Add/Remove contact(s)
     if strcmpi(sSelElec(end).Type, 'SEEG')
-        gui_component('MenuItem', jMenu, [], 'Add new contact', IconLoader.ICON_PLUS, [], @(h,ev)bst_call(@AddContact));
-        gui_component('MenuItem', jMenu, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)bst_call(@RemoveContactHelper));
+        gui_component('MenuItem', jMenu, [], 'Add contact', IconLoader.ICON_PLUS, [], @(h,ev)bst_call(@AddContact));
+        jItem = gui_component('MenuItem', jMenu, [], 'Remove selected contact(s)', IconLoader.ICON_MINUS, [], @(h,ev)bst_call(@RemoveContactHelper));
+        jItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
         jMenu.addSeparator();
     end
     % Menu: Default positions

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -1528,7 +1528,7 @@ function RemoveContact()
     if (length(sSelCont) == 1)
         strConfirm = ['Delete contact "' sSelCont.Name '"?'];
     else
-        strConfirm = ['Delete ' num2str(length(sSelCont)) ' contacts in electrode "' sSelElec.Name '"?'];
+        strConfirm = ['Delete ' num2str(length(sSelCont)) ' contacts in electrode "' sSelElec(end).Name '"?'];
     end
     % Ask for confirmation
     if ~java_dialog('confirm', strConfirm)
@@ -1588,24 +1588,24 @@ function RemoveContact()
             end
             % === Update intraelectrode structure in channel ===
             % Get the updated contacts
-            sContacts = GetContacts(sSelElec.Name);
+            sContacts = GetContacts(sSelElec(end).Name);
             % Update electrode contact number
-            sSelElec.ContactNumber = size(sContacts, 2);
+            sSelElec(end).ContactNumber = size(sContacts, 2);
             % Assign electrode tip and skull entry
-            sSelElec.Loc = [];
-            if sSelElec.ContactNumber >= 1
-                sSelElec.Loc(:,1) = sContacts(1).Loc;
+            sSelElec(end).Loc = [];
+            if sSelElec(end).ContactNumber >= 1
+                sSelElec(end).Loc(:,1) = sContacts(1).Loc;
             end
-            if sSelElec.ContactNumber > 1
-                sSelElec.Loc(:,2) = sContacts(end).Loc;
+            if sSelElec(end).ContactNumber > 1
+                sSelElec(end).Loc(:,2) = sContacts(end).Loc;
             end
             % Set the changed electrode properties
             SetElectrodes(iSelElec, sSelElec);
             % === Update contact names in channel ===
             [~, iChan] = ismember({sContacts.Name}, {GlobalData.DataSet(iDS).Channel.Name});
             newContNames  = {};
-            for iCont = 1:sSelElec.ContactNumber
-                newContNames{end+1} = sprintf('%s%d', sSelElec.Name, iCont);
+            for iCont = 1:sSelElec(end).ContactNumber
+                newContNames{end+1} = sprintf('%s%d', sSelElec(end).Name, iCont);
             end
             [GlobalData.DataSet(iDS).Channel(iChan).Name] = newContNames{:};
         end

--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -833,6 +833,9 @@ function sSelContacts = GetSelectedContacts()
     end
     % Get all contacts
     sSelElec  = GetSelectedElectrodes();
+    if isempty(sSelElec)
+        return
+    end
     sContacts = GetContacts(sSelElec(end).Name);
     if isempty(sContacts)
         return


### PR DESCRIPTION
This PR adds some new features that will enable iEEG **(currently focused only on SEEG)** editing as under:
- [x] **Group electrodes (SEEG only)**
   - **Testing:**
     - Option-1: Select electrodes in panel iEEG > right click on the electrodes > `Group Electrodes` 
     - Option-2: Select electrodes in panel iEEG > press `Ctrl+G`
![Screenshot 2025-04-21 174535](https://github.com/user-attachments/assets/d1b75d41-b536-4307-a357-207369f77a5c)
   - This feature will be more useful in case of automated detection using GARDEL where there could be some bad detections of contacts being grouped into different electrodes even though they should be part of just one.
   
- [x] **Add contacts (SEEG only)**
   - **Testing:**
     - Option-1: Open 3DViz from SEEG channel > Add IsoSurface > Select electrode in panel iEEG > Turn on `Select Surface Point` > Select a location on the IsoSurface > click `Contacts` (menu) > `Add contact` in iEEG panel
     - Option-2: Open 3DViz of SEEG channel > Add IsoSurface > Select electrode in panel iEEG > Turn on `Select Surface Point` > Select a location on the IsoSurface > Right click (`Channels > Add contact`)
     - Option-3: Open MRI Viewer from SEEG channel > Select electrode in panel iEEG > Set crosshair at a location in MRI Viewer > click `Contacts` (menu) > `Add contact` in iEEG panel
     - Option-4: Open MRI Viewer from SEEG channel > Select electrode in panel iEEG > Set crosshair at a location in MRI Viewer > Right click (`Electrodes> Add contact`)  
     
- [x] **Remove contacts (SEEG only)**
   - **Testing:**
     - Option-1: Select contact(s) in panel iEEG > press `Delete` or `Backspace`
     - Option-2: Select contact(s) in panel iEEG > click `Contacts` (menu) > `Remove selected contacts`
     - Option-3: Select the contact in 3D figure >  press `Delete` or `Backspace`
     - Option-4: Select the contact in 3D figure > right click (`Channels > Remove contact`)

- Panel iEEG
![Screenshot 2025-04-21 184412](https://github.com/user-attachments/assets/577a041a-5849-4c08-960d-d63c651efda3)
- 3D figure
![Screenshot 2025-04-21 184513](https://github.com/user-attachments/assets/1c31146d-e39f-47c2-832a-3730bcd748ac)
 - MRI Viewer
![Screenshot 2025-04-21 184557](https://github.com/user-attachments/assets/0a88b401-be98-46ec-b282-7b0a40121c0e)


- **Addresses # 11 and # 12 in #732** 
>Delete and add contacts while maintaining the ordering

>Regrouping contacts correctly for wrong grouping of contacts for a electrode

Some points for discussion @tmedani @rcassani:
1. I have not added the remove contacts feature from MRI viewer.  Do you think it is worth having something like a drop-down list approach we have for `Set electrode position` ?
![Screenshot 2025-04-21 175358](https://github.com/user-attachments/assets/3420bd5b-63da-4497-92f0-9dca3062777e)