### PR TITLE
GetTimeIndices with empty TimeRange

### DIFF
--- a/toolbox/gui/panel_time.m
+++ b/toolbox/gui/panel_time.m
@@ -493,6 +493,13 @@ end
 
 %% ===== GET TIME INDICES =====
 function iTime = GetTimeIndices(TimeVector, TimeRange) %#ok<DEFNU>
+    
+    % If TimeRange is empty, return the entire time vector
+    if isempty(TimeRange)
+        iTime = 1:length(TimeVector);
+        return;
+    end
+    
     % If the two segments are not overlapping: empty time range
     if (TimeRange(2) < TimeVector(1)) || (TimeRange(1) > TimeVector(end)) || (TimeRange(1) > TimeRange(2)) || (length(TimeRange) ~= 2)
         iTime = [];


### PR DESCRIPTION
Context: 

When creating a process that takes a timewindow**, we will often make something like this: 
```matlab
        TimeRange = sProcess.options.range_of_interest.Value{1};
        iTime = panel_time('GetTimeIndices', sData.Time, TimeRange);
```

However, this does not work as if the user selects "All File"; then TimeRange is empty, forcing us to do something like: 

```matlab
        TimeRange = sProcess.options.range_of_interest.Value{1};
        if isempty(TimeRange)
            iTime = 1:length(sData.Time);
        else
            iTime = panel_time('GetTimeIndices', sData.Time, TimeRange);
        end
```

Or this is kind of ugly. This PR hides the if/else inside GetTimeIndices. 




** 
```matlab
    sProcess.options.range_of_interest.Comment = 'Time window for correlation: ';
    sProcess.options.range_of_interest.Type    = 'timewindow';
    sProcess.options.range_of_interest.Value   =  []; 
```
