### PR TITLE
Load brainentropy instead of install

### DIFF
--- a/toolbox/process/functions/process_inverse_2018.m
+++ b/toolbox/process/functions/process_inverse_2018.m
@@ -259,7 +259,7 @@ function [OutputFiles, errMessage] = Compute(iStudies, iDatas, OPTIONS)
                 return
             end
             % Install/load brainentropy plugin
-            [isInstalled, errMessage] = bst_plugin('Install', 'brainentropy', 1);
+            [isInstalled, errMessage] = bst_plugin('Load', 'brainentropy', 1);
             if ~isInstalled
                 return;
             end


### PR DESCRIPTION
Currently, every time we try to do a localization, a pop-up asks if we want to update brainentropy. This removes the unnecessary pop-up.
