### PR TITLE
Bugfix: Properly update IsoSurface mesh in database when using `Thresh` slider

### DIFF
--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -167,7 +167,6 @@ if isSave
         % Create IsoFile
         MeshFile = file_unique(bst_fullfile(SurfaceDir, 'tess_isosurface.mat'));
         comment = sprintf('isoSurface (ISO_%d)', isoValue);
-        isAppend = 0;
     else
         % Get old IsoValue
         [~, oldIsoValue] = panel_surface('GetIsosurfaceParams', sSubject.Surface(iIsoSurfForThisCt).FileName);
@@ -179,7 +178,6 @@ if isSave
         % Get Comment and update it
         sMeshTmp = load(MeshFile, 'Comment', 'History');
         comment = strrep(sMeshTmp.Comment, num2str(oldIsoValue), num2str(isoValue));
-        isAppend = 1;
     end
     % Set comment
     sMesh.Comment = comment;
@@ -187,7 +185,7 @@ if isSave
     sMesh = bst_history('add', sMesh, 'threshold_ct', ...
                         sprintf('Thresholded CT: %s threshold = %d minVal = %d maxVal = %d', sMri.FileName, isoValue, isoRange));
     % Save isosurface
-    bst_save(MeshFile, sMesh, 'v7', isAppend);
+    bst_save(MeshFile, sMesh, 'v7');
     % Add isosurface to database
     iSurface = db_add_surface(iSubject, MeshFile, sMesh.Comment);
     % Display mesh with 3D orthogonal slices of the default MRI


### PR DESCRIPTION
Introduced in a93dcd0

While using `Thresh` slider to update IsoSurface, the `append` mode just updates `Faces`, `Vertices`, `Comment` and `History` fields in database for the mesh, but with the new Faces and Vertices, the other dependent fields must also be computed and updated. Wrong `VertConn`, `VertNormals`, `Curvature` and  `SulciMap` can be seen below.
![Screenshot 2025-05-01 113428](https://github.com/user-attachments/assets/6613abfb-9bf8-4293-84ac-a8942f252bdc)

**Where it affects ?**
In centroid selection mode for IsoSurface, on updating the IsoSurface using the slider, due to incorrect `VertConn` the centroid computation is erratic.

After correction:
![Screenshot 2025-05-01 113741](https://github.com/user-attachments/assets/1056a693-76ae-43c1-b188-9b45cb6b0832)