### PR TITLE
Bugfix: `ContactNumber` check only needed for SEEG in `SetElectrodeLoc`

### DIFF
--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3256,7 +3256,7 @@ function SetElectrodeLoc(iLoc, jButton)
     elseif (length(sSelElec) > 1)
         bst_error('Multiple electrodes selected.', 'Set electrode position', 0);
         return;
-    elseif isempty(sSelElec.ContactNumber) ||  sSelElec.ContactNumber < 2
+    elseif strcmpi(sSelElec.Type, 'SEEG') && (isempty(sSelElec.ContactNumber) ||  sSelElec.ContactNumber < 2)
         bst_error(['Update the number of contacts to construct the electrode "' sSelElec.Name '".'], 'Set electrode position', 0);
         return;
     elseif (size(sSelElec.Loc, 2) < iLoc-1)


### PR DESCRIPTION
Introduced in 3017616

**The error**
While doing this section https://neuroimage.usc.edu/brainstorm/Tutorials/ECoG#ECoG_grid:_G where the ECoG `ContactNumber` can be a grid, trying to set the contact location gives the error below:
![Screenshot 2025-05-01 182233](https://github.com/user-attachments/assets/bee78384-2baf-4247-bf89-9f5416b05d76)

This PR fixes this issue.

**Why this check ?**
This check is just needed for SEEG when user removes all but 1 contact (a feature only available for SEEG as of now) and would want to `Set skull entry` to reconstruct the electrode with the correct number of contacts
