### PR TITLE
Bugfix: For `linefit`, update only the current selected 3D figure

### DIFF
--- a/toolbox/gui/panel_ieeg.m
+++ b/toolbox/gui/panel_ieeg.m
@@ -3229,7 +3229,10 @@ end
 % perform line fitting between contacts
 function LineFit(plotLoc, Tag)
     % Get axes handle
-    hFig = bst_figures('GetFiguresByType', '3DViz');
+    hFig = bst_figures('GetCurrentFigure', '3D');
+    if isempty(hFig)
+        return;
+    end
     hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
     hCoord = findobj(hAxes, '-depth', 1, 'Tag', Tag);
     if ~isempty(hCoord)


### PR DESCRIPTION
Introduced in 2ea6b5c

**Error:** When multiple 3D figures are open, on selecting the electrode(s) in iEEG panel and clicking `Contacts > Show/Hide line fit through contacts`, the following error occurs as it tries to update all the figures.

![Screenshot 2025-05-06 151652](https://github.com/user-attachments/assets/5b1c5faa-4f88-44d9-8620-edb5e98eda6e)

It makes more sense to just update the current selected 3D figure. This PR addresses that.