### PR TITLE
Add PET volume processing: SUVR, ROI masking, projection to surface, SPM-petpve plugin

### DIFF
--- a/toolbox/anatomy/mri_interp_vol2tess.m
+++ b/toolbox/anatomy/mri_interp_vol2tess.m
@@ -1,0 +1,193 @@
+function [OutputFile, errorMsg] = mri_interp_vol2tess(MriFileSrc, MriFileRef, Condition, TimeVector, DisplayUnits, ProjFrac)
+% MRI_VOL2TESS: Estimates average voxel intensities along the surface
+% normals from pial surface to white matter surface and projects the result to
+% the pial surface as a texture.
+% 
+% USAGE:  OutputFile = mri_vol2tess(MriFileSrc, MriFileRef, Condition, TimeVector)
+%
+% INPUT:
+%    - MriFileSrc : Source MRI file
+%    - MriFileRef : Reference MRI file
+%    - Condition  : Condition name for the projection
+%    - TimeVector : Time vector for the results
+%    - DisplayUnits: 
+
+% @============================================================================= 
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Authors: Diellor Basha, 2024
+% =============================================================================@
+
+%% ===== INITIALIZATION =====
+errorMsg = '';
+OutputFile = '';
+if nargin < 6, ProjFrac = [0.1 0.8 0.]; end
+if nargin < 5, DisplayUnits = []; end
+if nargin < 4, TimeVector = []; end
+if nargin < 3, Condition = []; end
+
+%% ===== LOAD ANATOMY AND CHECKS =====
+isProgressBar = bst_progress('isVisible');
+if ~isProgressBar
+    bst_progress('start', 'Load anatomy', 'Loading subject surface and MRI...');
+end
+
+% Parse input files and surfaces
+if isstruct(MriFileSrc)
+    sMriSrc = MriFileSrc;
+    sMriRef = MriFileRef;
+else
+    [sSubject, iSubject] = bst_get('MriFile', MriFileSrc);
+    [sStudy, iStudy] = bst_get('StudyWithCondition', bst_fullfile(sSubject.Name, Condition));
+    MriFileRef = sSubject.Anatomy(sSubject.iAnatomy).FileName;
+
+    sMriSrc = in_mri_bst(MriFileSrc);
+    sMriRef = in_mri_bst(MriFileRef);
+end
+
+Comment = sMriSrc.Comment;
+% Volume type
+volType = 'MRI';
+if ~isempty(strfind(Comment, 'CT'))
+    volType = 'CT';
+end
+if ~isempty(strfind(Comment, 'pet'))
+    volType = 'PET';
+end
+
+if isempty(sMriRef) || isempty(sMriSrc)
+    errorMsg = 'MRI files could not be loaded.';
+    return;
+end
+
+if isempty(iStudy)
+    iStudy = db_add_condition(sSubject.Name, Condition);
+    sStudy = bst_get('Study', iStudy);
+end
+
+% Validate MRI dimensions
+refSize = size(sMriRef.Cube(:,:,:,1));
+srcSize = size(sMriSrc.Cube(:,:,:,1));
+if ~isequal(refSize, srcSize)
+    errorMsg = 'Source and reference MRI dimensions do not match.';
+    return;
+end
+
+%% ===== LOAD SURFACES =====
+% Find and load pial, mid, and white "low" resolution surfaces from sSubject.Surface 
+pialFile = '';
+midFile = '';
+whiteFile = '';
+
+% Collect all file names
+allFiles = {sSubject.Surface.FileName};
+
+% Find indices for each surface type
+idxPial  = find(~cellfun('isempty', regexp(allFiles, 'cortex_pial_low\.mat$', 'once')), 1);
+idxMid   = find(~cellfun('isempty', regexp(allFiles, 'cortex_mid_low\.mat$', 'once')), 1);
+idxWhite = find(~cellfun('isempty', regexp(allFiles, 'cortex_white_low\.mat$', 'once')), 1);
+
+% Assign file names if found
+if ~isempty(idxPial)
+    pialFile = allFiles{idxPial};
+else
+    error('Pial surface (cortex_pial_low) not found.');
+end
+if ~isempty(idxMid)
+    midFile = allFiles{idxMid};
+else
+    error('Mid surface (cortex_mid_low) not found.');
+end
+if ~isempty(idxWhite)
+    whiteFile = allFiles{idxWhite};
+else
+    error('White surface (cortex_white_low) not found.');
+end
+
+% Load the surfaces
+sPial  = in_tess_bst(pialFile);
+sMid   = in_tess_bst(midFile);
+sWhite = in_tess_bst(whiteFile);
+
+SurfaceFiles = {pialFile, midFile, whiteFile};
+sSurf = {sPial, sMid, sWhite};
+vol2tess = cell(1, numel(SurfaceFiles)); % Use cell array to handle different vertex counts
+
+cube2vec = double(sMriSrc.Cube(:,:,:,1));
+cube2vec = cube2vec(:);
+
+for nSurf = 1:numel(SurfaceFiles)
+    nVertices = size(sSurf{nSurf}.Vertices, 1);
+    tess2mri_interp = tess_interp_mri(SurfaceFiles{nSurf}, sMriRef);
+    ivol2tess = tess2mri_interp' * cube2vec;
+    vWeights = sum(tess2mri_interp, 1);
+    ivol2tess = ivol2tess ./ vWeights';
+    ivol2tess(~isfinite(ivol2tess)) = 0;
+    vol2tess{nSurf} = ivol2tess;
+end
+
+% If all surfaces have the same number of vertices, you can concatenate:
+if all(cellfun(@(v) numel(v), vol2tess) == numel(vol2tess{1}))
+    vol2tess_mat = cell2mat(vol2tess);
+    map = vol2tess_mat * ProjFrac';
+else
+    error('Surface vertex counts do not match. Cannot combine projections.');
+end
+
+% === STORE AS REGULAR SOURCE FILE ===
+    ResultsMat = db_template('resultsmat');
+    if size(map, 2) > 1
+        ResultsMat.ImageGridAmp  = map;
+    else
+        ResultsMat.ImageGridAmp  = [map, map];
+    end
+    ResultsMat.ImagingKernel = [];
+    FileType = 'results';
+    % Time vector
+    if isempty(TimeVector) || (length(TimeVector) ~= size(ResultsMat.ImageGridAmp,2))
+        ResultsMat.Time = 0:(size(ResultsMat.ImageGridAmp,2)-1);
+    else
+        ResultsMat.Time = TimeVector;
+    end
+% Fix identical time points
+if (length(ResultsMat.Time) == 2) && (ResultsMat.Time(1) == ResultsMat.Time(2))
+    ResultsMat.Time(2) = ResultsMat.Time(2) + 0.001;
+end
+
+% === SAVE NEW FILE ===
+ResultsMat.Comment       = Comment;
+ResultsMat.DataFile      = [];
+ResultsMat.SurfaceFile   = file_win2unix(file_short(pialFile));
+ResultsMat.HeadModelFile = [];
+ResultsMat.nComponents   = 1;
+ResultsMat.DisplayUnits  = DisplayUnits;
+if isequal(DisplayUnits, 's')
+    ResultsMat.ColormapType = 'time';
+end
+ResultsMat.HeadModelType = 'surface';
+% History
+ResultsMat = bst_history('add', ResultsMat, 'project', ['Projected from: ' sMriSrc.Comment]);
+% Create output filename
+OutputFile = bst_process('GetNewFilename', bst_fileparts(sStudy.FileName), [FileType, '_', ResultsMat.HeadModelType, '_', file_standardize(Comment)]);
+% Save new file
+bst_save(OutputFile, ResultsMat, 'v7');
+% Update database
+db_add_data(iStudy, OutputFile, ResultsMat);
+
+% Update tree
+panel_protocols('UpdateNode', 'Study', iStudy);
+% Save database
+db_save();
+
+% Progress bar
+if ~isProgressBar
+    bst_progress('stop');
+end
+%% ====== VISUALIZE RESULT ======= 
+view_surface_data(pialFile, file_short(OutputFile))
+if ~isProgressBar
+    bst_progress('stop');
+end
+
+end

--- a/toolbox/anatomy/mri_mask.m
+++ b/toolbox/anatomy/mri_mask.m
@@ -1,0 +1,196 @@
+function [atlasLabels, MriFileMask, errMsg, fileTag, binMask] = mri_mask(MriFile, AtlasName, maskRegion, doMask, sSubject)
+% MRI_MASK: List atlas regions and optionally mask an MRI volume using a selected atlas and region.
+%
+% USAGE:
+%   atlasLabels = mri_mask([], 'ASEG'); % List all regions in ASEG atlas for current subject
+%   [atlasLabels, MriFileMask] = mri_mask(MriFile, 'ASEG', 'cerebellum', 1);
+%   [atlasLabels, sMriMasked] = mri_mask(sMri, 'ASEG', 'cerebellum', 1, sSubject);
+%
+% INPUTS:
+%   - MriFile   : MRI file to be masked (string) or MRI structure (sMri)
+%   - AtlasName : Name of the atlas (e.g., 'ASEG', 'DKT', etc.)
+%   - maskRegion: (optional) Region name or cell array of region names to mask (e.g., 'cerebellum', {'cortex','wm'})
+%   - doMask    : (optional) 1 to perform masking, 0 (default) to only list labels
+%   - sSubject  : (optional) Subject structure, required if MriFile is a structure
+%
+% OUTPUTS:
+%   - atlasLabels : Cell array of region names in the atlas (bilateral names, see below)
+%   - MriFileMask : Masked MRI file (if doMask==1 and file input), or masked MRI structure (if struct input)
+%   - errMsg      : Error message, if any
+%   - fileTag     : File tag used for output file
+%   - binMask     : Binary mask used for masking (if doMask==1), otherwise []
+%
+% Authors: Diellor Basha, 2025
+
+% Defaults
+if nargin < 3, maskRegion = []; end
+if nargin < 4, doMask = 0; end
+if nargin < 5, sSubject = []; end
+MriFileMask = [];
+errMsg = '';
+fileTag = '';
+binMask = [];
+isSaving = false;
+
+% Progress bar
+isProgress = bst_progress('isVisible');
+if ~isProgress
+    bst_progress('start', 'Masking', 'Loading input volumes...');
+end
+
+% Load MRI and get subject if possible
+if isstruct(MriFile)
+    sMri = MriFile;
+    if isempty(sSubject)
+        errMsg = 'sSubject must be provided when using sMri structure as input.';
+        return;
+    end
+    mriFilePath = '';
+    isSaving = false;
+elseif ischar(MriFile)
+    sMri = in_mri_bst(MriFile);
+    mriFilePath = MriFile;
+    [sSubject, iSubject, iMri] = bst_get('MriFile', MriFile);
+    isSaving = true;
+else
+    bst_progress('stop');
+    error('Invalid call.');
+end
+bst_progress('stop');
+% Get atlas file for the correct subject
+if ~isempty(sSubject)
+    iAtlas = bst_get('AtlasFile', sSubject, AtlasName);
+else
+    % If no subject context, try to get atlas for current subject
+    iAtlas = bst_get('AtlasFile', AtlasName);
+end
+if isempty(iAtlas) || ~isfield(iAtlas, 'FileName') || isempty(iAtlas.FileName)
+    errMsg = ['Atlas "' AtlasName '" not found for the specified subject.'];
+    atlasLabels = {};
+    return;
+end
+
+% Load the atlas structure
+[sAtlas, ~] = bst_memory('LoadMri', iAtlas.FileName);
+if isempty(sAtlas) || ~isfield(sAtlas, 'Labels') || isempty(sAtlas.Labels)
+    errMsg = ['Failed to load atlas file: ' iAtlas.FileName];
+    atlasLabels = {};
+    return;
+end
+
+% Original label names
+labelNames = sAtlas.Labels(:,2);
+
+% Initialize bilateral names array
+bilateralNames = labelNames;
+for i = 1:length(bilateralNames)
+    % Remove trailing ' L' or ' R'
+    bilateralNames{i} = regexprep(bilateralNames{i}, ' [LR]$', '');
+    % Replace any label starting with 'CC_' with 'Corpus-Callosum'
+    if startsWith(bilateralNames{i}, 'CC_')
+        bilateralNames{i} = 'Corpus-Callosum';
+    end
+    % Replace any label containing 'Ventricle' with 'Ventricles'
+    if contains(bilateralNames{i}, 'Ventricle')
+        bilateralNames{i} = 'Ventricles';
+    end
+end
+
+% Add "Brainmask" to the top of the list and exclude "Unknown" from returned labels
+atlasLabels = unique(bilateralNames, 'stable');
+atlasLabels = setdiff(atlasLabels, {'Unknown'}, 'stable');
+atlasLabels = [{'Brainmask'}, atlasLabels(:)'];
+
+% If only listing labels, return here
+if ~doMask || isempty(sMri)
+    return;
+end
+
+% Determine which atlas labels to use for masking
+if isempty(maskRegion)
+    errMsg = 'No mask region specified.';
+    return;
+end
+if ischar(maskRegion)
+    maskRegion = {maskRegion};
+end
+
+% Special handling for "Brainmask"
+if any(strcmpi(maskRegion, 'Brainmask'))
+    % Exclude "Unknown" and "WM-hypointensities"
+    excludeLabels = {'Unknown', 'WM-hypointensities'};
+    labelIdx = find(~ismember(bilateralNames, [{'Brainmask'}, excludeLabels]));
+else
+    % Find label indices matching the requested region(s) (case-insensitive, exact match)
+    labelIdx = [];
+    for i = 1:numel(maskRegion)
+        idx = find(strcmpi(bilateralNames, maskRegion{i}));
+        labelIdx = [labelIdx, idx];
+    end
+    labelIdx = unique(labelIdx);
+end
+
+if isempty(labelIdx)
+    errMsg = ['Region "' strjoin(maskRegion, ', ') '" not found in atlas "' AtlasName '".'];
+    return;
+end
+
+% Get label values for the selected regions
+labelValues = cell2mat(sAtlas.Labels(labelIdx, 1));
+
+% Create binary mask
+binMask = ismember(sAtlas.Cube, labelValues);
+
+% Apply mask to MRI
+sMriMasked = sMri;
+sMriMasked.Cube(~binMask) = 0;
+
+% File tag
+fileTag = sprintf('_masked_%s_%s', lower(AtlasName), lower(strjoin(maskRegion, '_')));
+
+% ===== SAVE NEW FILE =====
+if isSaving
+   bst_progress('text', 'Saving new file...');
+    % Get subject and index
+    [sSubject, iSubject] = bst_get('MriFile', mriFilePath);
+    if isempty(sSubject) || ~isfield(sSubject, 'Anatomy')
+        errMsg = 'Could not find subject for the provided MRI file.';
+        return;
+    end
+    % Insert fileTag before the last underscore-tag (e.g., before _volpet or _volct)
+    [folder, base, ext] = fileparts(file_fullpath(mriFilePath));
+    lastUnderscore = find(base == '_', 1, 'last');
+    if ~isempty(lastUnderscore)
+        newBase = [base(1:lastUnderscore-1), fileTag, base(lastUnderscore:end)];
+    else
+        newBase = [base, fileTag];
+    end
+    MriFileMaskFull = file_unique(fullfile(folder, [newBase, ext]));
+    MriFileMask = file_short(MriFileMaskFull);
+    % Update comment to be unique
+    sMriMasked.Comment = file_unique([sMri.Comment, fileTag], {sSubject.Anatomy.Comment});
+    % Add history entry
+    sMriMasked = bst_history('add', sMriMasked, 'mask', ...
+        sprintf('Masked with "%s" (%s)', AtlasName, strjoin(maskRegion, ', ')));
+    % Save new MRI in Brainstorm format
+    sMriMasked = out_mri_bst(sMriMasked, MriFileMaskFull);
+    % Register new MRI in subject
+    iAnatomy = length(sSubject.Anatomy) + 1;
+    sSubject.Anatomy(iAnatomy) = db_template('Anatomy');
+    sSubject.Anatomy(iAnatomy).FileName = MriFileMask;
+    sSubject.Anatomy(iAnatomy).Comment  = sMriMasked.Comment;
+    % Update subject structure
+    bst_set('Subject', iSubject, sSubject);
+    % Refresh tree
+    panel_protocols('UpdateNode', 'Subject', iSubject);
+    panel_protocols('SelectNode', [], 'anatomy', iSubject, iAnatomy);
+    % Save database
+    db_save();
+    bst_progress('stop');
+    return;
+else
+    % Return output structure if not saving to disk, and output fileTag
+    MriFileMask = sMriMasked;
+    bst_progress('stop');
+    return;
+end

--- a/toolbox/anatomy/mri_rescale.m
+++ b/toolbox/anatomy/mri_rescale.m
@@ -1,0 +1,131 @@
+function [atlasLabels, MriFileRescale, errMsg, fileTag] = mri_rescale(MriFile, AtlasName, roiName, sSubject)
+% MRI_RESCALE: Rescale an MRI volume by the mean value of a specified ROI in an atlas.
+%
+% USAGE:
+%   [atlasLabels, MriFileRescale, errMsg, fileTag] = mri_rescale(MriFile, 'ASEG', 'Cerebellum')
+%   [atlasLabels, sMriRescale, errMsg, fileTag] = mri_rescale(sMri, 'ASEG', 'Cerebellum', sSubject)
+%
+% INPUTS:
+%   - MriFile   : MRI file to be rescaled (string or struct)
+%   - AtlasName : Name of the atlas (e.g., 'ASEG', 'DKT', etc.)
+%   - roiName   : Name of the ROI to use for rescaling (string)
+%   - sSubject  : (optional) Subject structure, required if MriFile is a structure
+%
+% OUTPUTS:
+%   - atlasLabels    : Cell array of region names in the atlas
+%   - MriFileRescale : Path to the rescaled MRI file (string) or structure if input is struct
+%   - errMsg         : Error message, if any
+%   - fileTag        : File tag used for output file
+
+atlasLabels = {};
+MriFileRescale = [];
+errMsg = '';
+fileTag = '';
+
+try
+    % Progress bar
+isProgress = bst_progress('isVisible');
+if ~isProgress
+    bst_progress('start', 'Rescaling', 'Loading input volumes...');
+end
+
+    if isstruct(MriFile)
+        sMri = MriFile;
+        if nargin < 4 || isempty(sSubject)
+            errMsg = 'sSubject must be provided when using sMri structure as input.';
+            return;
+        end
+        mriFilePath = '';
+    elseif ischar(MriFile)
+        sMri = in_mri_bst(MriFile);
+        [sSubject, ~, ~] = bst_get('MriFile', MriFile);
+        mriFilePath = MriFile;
+    else
+        bst_progress('stop');
+        error('Invalid call.');
+    end
+bst_progress('stop');
+    % Mask region
+    [atlasLabels, ~, errMsg, maskFileTag, binMask] = mri_mask(sMri, AtlasName, roiName, 1, sSubject);
+  
+    if ~isempty(errMsg)
+        return;
+    end
+
+    if isempty(sMri) || ~isfield(sMri, 'Cube')
+        errMsg = 'Could not load MRI volume.';
+        return;
+    end
+
+    % Compute mean value in the ROI
+    roiVals = double(sMri.Cube(binMask));
+    if isempty(roiVals) || all(roiVals == 0)
+        errMsg = sprintf('No nonzero voxels found in ROI "%s".', roiName);
+        return;
+    end
+    roiMean = mean(roiVals);
+
+    % Rescale MRI volume
+    sMriRescale = sMri;
+    sMriRescale.Cube = double(sMri.Cube) ./ roiMean;
+
+    % Carry over fileTag and append rescale tag before last underscore
+    rescaleTag = sprintf('_rescaled_%s_%s', lower(AtlasName), lower(roiName));
+    fileTag = [maskFileTag, rescaleTag];
+
+    % Carry over history from mri_mask if present
+    if isfield(sMri, 'History')
+        sMriRescale.History = sMri.History;
+    end
+
+    % Update comment
+    sMriRescale.Comment = [sMri.Comment, rescaleTag];
+
+    % ===== SAVE NEW FILE =====
+    if ~isempty(mriFilePath) && ischar(mriFilePath)
+        bst_progress('text', 'Saving new file...');
+        [sSubject, iSubject] = bst_get('MriFile', mriFilePath);
+        if isempty(sSubject) || ~isfield(sSubject, 'Anatomy')
+            errMsg = 'Could not find subject for the provided MRI file.';
+            return;
+        end
+        % Insert rescaleTag before the last underscore-tag
+        [folder, base, ext] = fileparts(file_fullpath(mriFilePath));
+        lastUnderscore = find(base == '_', 1, 'last');
+        if ~isempty(lastUnderscore)
+            newBase = [base(1:lastUnderscore-1), rescaleTag, base(lastUnderscore:end)];
+        else
+            newBase = [base, rescaleTag];
+        end
+        MriFileRescaleFull = file_unique(fullfile(folder, [newBase, ext]));
+        MriFileRescale = file_short(MriFileRescaleFull);
+        % Update comment to be unique
+        sMriRescale.Comment = file_unique(sMriRescale.Comment, {sSubject.Anatomy.Comment});
+        % Add history entry
+        sMriRescale = bst_history('add', sMriRescale, 'rescale', ...
+            sprintf('Rescaled with "%s" (%s)', AtlasName, roiName));
+        % Save new MRI in Brainstorm format
+        sMriRescale = out_mri_bst(sMriRescale, MriFileRescaleFull);
+        % Register new MRI in subject
+        iAnatomy = length(sSubject.Anatomy) + 1;
+        sSubject.Anatomy(iAnatomy) = db_template('Anatomy');
+        sSubject.Anatomy(iAnatomy).FileName = MriFileRescale;
+        sSubject.Anatomy(iAnatomy).Comment  = sMriRescale.Comment;
+        % Update subject structure
+        bst_set('Subject', iSubject, sSubject);
+        % Refresh tree
+        panel_protocols('UpdateNode', 'Subject', iSubject);
+        panel_protocols('SelectNode', [], 'anatomy', iSubject, iAnatomy);
+        % Save database
+        db_save();
+        bst_progress('stop');
+        return;
+    else
+        % Return output structure if not saving to disk, and output fileTag
+        MriFileRescale = sMriRescale;
+        bst_progress('stop');
+        return;
+    end
+catch ME
+    errMsg = ME.message;
+end

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -116,8 +116,8 @@ function [argout1, argout2, argout3, argout4, argout5] = bst_get( varargin )
 %    - bst_get('SurfaceFileByType',    SurfaceName, SurfaceType) : Find surfaces with given type for subject that also has surface SurfaceName (default only)
 %    - bst_get('SurfaceFileByType',    MriName,     SurfaceType) : Find surfaces with given type for subject that also has MRI MriName  (default only)
 %    - bst_get('SurfaceFileByType',    ...,  ..., isDefaultOnly) : If 0, return all the surfaces of the given type, instead of only the default surface
-%    - bst_get('MriFile',              MriFile)               : Find a MRI in current protocol
-% 
+%    - bst_get('AtlasFile',            AtlasName)               : Find a MRI in current protocol %    - bst_get('MriFile',              MriFile)               : Find a MRI in current protocol
+
 % ====== GUI =================================================================
 %    - bst_get('BstControls')    : Return main Brainstorm GUI structure
 %    - bst_get('BstFrame')       : Return main Brainstorm JFrame
@@ -1313,8 +1313,86 @@ switch contextName
                 return
             end
         end
-        
-        
+
+% ==== ATLAS FILE ====        
+% Usage : atlasNames = bst_get('AtlasFile') % returns cell array of atlas names for current subject
+%         sAtlas = bst_get('AtlasFile', AtlasName) % returns the atlas struct for the given name (case-insensitive)
+%         atlasNames = bst_get('AtlasFile', sSubject/iSubject) % returns atlas names for a specific subject
+%         sAtlas = bst_get('AtlasFile', sSubject/iSubject, AtlasName) % returns the atlas struct for a specific subject and atlas name
+case 'AtlasFile'
+    % No protocol in database
+    if isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
+        return;
+    end
+    % Get list of current protocol subjects
+    ProtocolSubjects = GlobalData.DataBase.ProtocolSubjects(GlobalData.DataBase.iProtocol);
+    if isempty(ProtocolSubjects)
+        return
+    end
+
+    % Parse inputs
+    if (nargin == 3)
+        SubjectOrStruct = varargin{2};
+        AtlasName = varargin{3};
+        % If sSubject struct is supplied, use it directly
+        if isstruct(SubjectOrStruct) && isfield(SubjectOrStruct, 'Anatomy')
+            sSubject = SubjectOrStruct;
+        else
+            % If iSubject is supplied, get subject struct
+            sSubject = bst_get('Subject', SubjectOrStruct, 1);
+        end
+        if isempty(sSubject) || ~isfield(sSubject, 'Anatomy') || isempty(sSubject.Anatomy)
+            argout1 = [];
+            return;
+        end
+        iAtlas = find(contains({sSubject.Anatomy.FileName}, '_volatlas') & ...
+                      strcmpi({sSubject.Anatomy.Comment}, AtlasName));
+        if ~isempty(iAtlas)
+            argout1 = sSubject.Anatomy(iAtlas(1));
+        else
+            argout1 = [];
+        end
+        return;
+    end
+
+    % Get atlas names for a specific subject (sSubject struct or iSubject index)
+    if (nargin == 2)
+        SubjectOrStruct = varargin{2};
+        % If sSubject struct is supplied, use it directly
+        if isstruct(SubjectOrStruct) && isfield(SubjectOrStruct, 'Anatomy')
+            sSubject = SubjectOrStruct;
+        else
+            % If iSubject is supplied, get subject struct
+            sSubject = bst_get('Subject', SubjectOrStruct, 1);
+        end
+        if isempty(sSubject) || ~isfield(sSubject, 'Anatomy') || isempty(sSubject.Anatomy)
+            argout1 = {};
+            return;
+        end
+        iAtlas = find(contains({sSubject.Anatomy.FileName}, '_volatlas'));
+        if isempty(iAtlas)
+            argout1 = {};
+            return;
+        end
+        atlasNames = {sSubject.Anatomy(iAtlas).Comment};
+        argout1 = atlasNames;
+        return;
+    end
+
+    % If no subject specified, use current subject
+    sSubject = bst_get('Subject');
+    if isempty(sSubject) || ~isfield(sSubject, 'Anatomy') || isempty(sSubject.Anatomy)
+        argout1 = {};
+        return;
+    end
+    iAtlas = find(contains({sSubject.Anatomy.FileName}, '_volatlas'));
+    if isempty(iAtlas)
+        argout1 = {};
+        return;
+    end
+    atlasNames = {sSubject.Anatomy(iAtlas).Comment};
+    argout1 = atlasNames;
+    return;
 %% ==== CHANNEL FILE ====
     % Usage: [sStudy, iStudy, iChannel] = bst_get('ChannelFile', ChannelFile)
     case 'ChannelFile'

--- a/toolbox/gui/panel_process_pet.m
+++ b/toolbox/gui/panel_process_pet.m
@@ -1,0 +1,169 @@
+function varargout = panel_process_pet(varargin)
+% PANEL_PROCESS_PET: GUI for PET volume rescaling/masking using atlas ROIs.
+%
+% USAGE: [bstPanelNew, panelName] = panel_process_pet('CreatePanel')
+%
+% This panel allows the user to:
+%   1. Select an atlas (dropdown, populated by bst_get('AtlasFile'))
+%   2. Select an ROI (dropdown, populated by mri_mask([], AtlasName))
+%   3. Optionally rescale or mask a PET volume using the selected ROI
+
+eval(macro_method);
+end
+
+%% ===== CREATE PANEL =====
+function [bstPanelNew, panelName] = CreatePanel(sSubject, iAnatomy, varargin)
+    panelName = 'panel_process_pet';
+    import java.awt.*
+    import javax.swing.*
+
+    % === MAIN LAYOUT ===
+    jPanelMain = gui_river([5, 5], [0, 10, 10, 10]);
+    gui_component('label', jPanelMain, 'br', ...
+        sprintf('<HTML><EM>%s</EM><BR></HTML>', sSubject.Name));
+    % === RESCALE PANEL ===
+    jPanelRescale = gui_river([2, 2], [0, 10, 10, 10], 'SUVR');
+
+    % --- Atlas dropdown ---
+    atlasNames = bst_get('AtlasFile', sSubject);
+    if isempty(atlasNames)
+        atlasNames = {'(No atlas found)'};
+    end
+
+    % --- ROI dropdown ---
+    if ~isempty(atlasNames) && ~strcmp(atlasNames{1}, '(No atlas found)')
+        roiList = mri_mask(sSubject.Anatomy(iAnatomy).FileName, atlasNames{1});
+    else
+        roiList = {'(No ROI found)'};
+    end
+    jLabelROI = gui_component('label', jPanelRescale, 'br', 'Rescale to:');
+    jComboROI = gui_component('combobox', jPanelRescale, 'tab', [], {roiList});
+    % Set "Cerebellum" as default if it exists
+    idxCerebellum = find(strcmpi(roiList, 'Cerebellum'), 1);
+        if ~isempty(idxCerebellum)
+            jComboROI.setSelectedIndex(idxCerebellum - 1); % Java indices start at 0
+        end
+  
+    jLabelAtlas = gui_component('label', jPanelRescale, 'br', 'Atlas:');
+    jComboAtlas = gui_component('combobox', jPanelRescale, 'tab', [], {atlasNames});
+    % --- Callback: When atlas changes, update ROI list ---
+    java_setcb(jComboAtlas, 'ActionPerformedCallback', @(h, ev)AtlasChanged_Callback(jComboAtlas, jComboROI, jComboROIMask, sSubject, iAnatomy));
+
+% ==== MASK PANEL ====
+    jPanelMask = gui_river([2, 2], [0, 10, 10, 10], 'Volume masking');   
+    jCheckMask = gui_component('checkbox', jPanelMask, 'br', 'Apply mask');
+    jLabelROIMask = gui_component('label', jPanelMask, 'br', 'Mask:');
+    jComboROIMask = gui_component('combobox', jPanelMask, 'tab', [], {roiList});
+    jCheckMask.setSelected(false);           % Unchecked by default
+    jComboROIMask.setEnabled(false);         % Disabled by default
+    jLabelROIMask.setEnabled(false);         % Disabled by default
+    java_setcb(jCheckMask, 'ActionPerformedCallback', @(h, ev)SetSelectedAndEnabled(jComboROIMask, jLabelROIMask, jCheckMask.isSelected()));
+
+    % --- Add panel to main layout ---
+    jPanelMain.add('br', jPanelRescale);
+    jPanelMain.add('br', jPanelMask);
+
+    % --- Buttons ---
+    jPanelButtons = gui_river([2 0], [0 5 0 5]);
+    gui_component('button', jPanelButtons, 'br right', 'Cancel', [], [], @(h, ev)ButtonCancel_Callback(panelName));
+    gui_component('button', jPanelButtons, '', 'OK', [], [], @(h, ev)ButtonOK_Callback(panelName));
+    jPanelMain.add('br right', jPanelButtons);
+
+
+    % --- Panel Layout ---
+    jPanelRescale.doLayout();
+
+    % --- Create mutex ---
+    bst_mutex('create', panelName);
+
+    % --- Return panel object ---
+    bstPanelNew = BstPanel(panelName, ...
+        jPanelMain, ...
+        struct('jComboAtlas', jComboAtlas, ...
+               'jComboROI', jComboROI, ...
+               'jComboROIMask', jComboROIMask, ...
+               'jCheckMask', jCheckMask, ...
+               'sSubject', sSubject, ...
+               'iAnatomy', iAnatomy));
+end
+%% ===== CALLBACK: Atlas changed =====
+function AtlasChanged_Callback(jComboAtlas, jComboROI, jComboROIMask, sSubject, iAnatomy)
+    selectedAtlas = char(jComboAtlas.getSelectedItem());
+    if isempty(selectedAtlas) || strcmp(selectedAtlas, '(No atlas found)')
+        roiList = {'(No ROI found)'};
+    else
+        roiList = mri_mask(sSubject.Anatomy(iAnatomy).FileName, selectedAtlas);
+        if isempty(roiList)
+            roiList = {'(No ROI found)'};
+        end
+    end
+    jComboROI.removeAllItems();
+    jComboROIMask.removeAllItems();
+    for i = 1:numel(roiList)
+        jComboROI.addItem(roiList{i});
+        jComboROIMask.addItem(roiList{i});
+    end
+end
+
+%% ===== CANCEL BUTTON =====
+function ButtonCancel_Callback(panelName)
+    gui_hide(panelName);
+end
+
+%% ===== OK BUTTON =====
+function ButtonOK_Callback(panelName)
+    ctrl = bst_get('PanelControls', panelName);
+    atlas    = char(ctrl.jComboAtlas.getSelectedItem());
+    roi      = char(ctrl.jComboROI.getSelectedItem());
+    maskROI  = char(ctrl.jComboROIMask.getSelectedItem());
+    sSubject = ctrl.sSubject;
+    iAnatomy = ctrl.iAnatomy;
+    isMaskChecked = ctrl.jCheckMask.isSelected();
+
+    bst_progress('start', 'PET Processing', 'Processing PET volume...');
+    gui_hide(panelName);
+
+    if ~isempty(sSubject) && ~isempty(iAnatomy) && isfield(sSubject, 'Anatomy') && length(sSubject.Anatomy) >= iAnatomy
+        MriFile = sSubject.Anatomy(iAnatomy).FileName;
+
+        % Prepare options for process_pet
+        if isempty(roi) || strcmp(roi, '(No ROI found)')
+            roi = '';
+        end
+        if isempty(maskROI) || strcmp(maskROI, '(No ROI found)')
+            maskROI = '';
+        end
+
+        % Call process_pet pipeline
+        [MriFileOut, errMsg] = process_pet(MriFile, sSubject, atlas, roi, maskROI, isMaskChecked);
+
+        if ~isempty(errMsg)
+            bst_error(errMsg, 'PET Processing');
+        else
+            disp(['Processed MRI saved as: ' MriFileOut]);
+        end
+    end
+
+    bst_mutex('release', panelName);
+    bst_progress('stop');
+end
+
+%% ===== GET PANEL CONTENTS =====
+function s = GetPanelContents()
+    ctrl = bst_get('PanelControls', 'panel_process_pet');
+    s.atlas = char(ctrl.jComboAtlas.getSelectedItem());
+    s.roi   = char(ctrl.jComboROI.getSelectedItem());
+    s.sSubject = ctrl.sSubject;
+    s.iAnatomy = ctrl.iAnatomy;
+    % Example: get MRI file for masking
+    if ~isempty(s.sSubject) && ~isempty(s.iAnatomy)
+        MriFile = s.sSubject.Anatomy(s.iAnatomy).FileName;
+        % Now you can call mri_mask(MriFile, s.atlas, s.roi, 1);
+    end
+end
+
+%% ===== HELPER: Enable/disable ROI mask controls =====
+function SetSelectedAndEnabled(jCombo, jLabel, isEnabled)
+    jCombo.setEnabled(isEnabled);
+    jLabel.setEnabled(isEnabled);
+end

--- a/toolbox/process_pet.m
+++ b/toolbox/process_pet.m
@@ -1,0 +1,101 @@
+function [MriFileOut, errMsg] = process_pet(MriFile, sSubject, AtlasName, roiName, maskROI, applyMask)
+% PROCESS_PET: Script PET processing pipeline (SUVR rescale and/or masking) with minimal redundant saving.
+%
+% INPUTS:
+%   - MriFile   : Input MRI file path (string)
+%   - sSubject  : Subject structure
+%   - AtlasName : Name of the atlas (e.g., 'ASEG')
+%   - roiName   : Name of the ROI for SUVR rescale (string, can be empty)
+%   - maskROI   : Name of the ROI for masking (string, can be empty)
+%   - applyMask : Logical, true to apply mask, false otherwise
+%
+% OUTPUTS:
+%   - MriFileOut : Output MRI file path (string)
+%   - errMsg     : Error message, if any
+
+MriFileOut = '';
+errMsg = '';
+
+try
+    % Load MRI structure
+    sMri = in_mri_bst(MriFile);
+
+    % --- SUVR Rescale ---
+    if ~isempty(roiName)
+        [~, sMriRescale, errMsgRescale, fileTagRescale] = mri_rescale(sMri, AtlasName, roiName, sSubject);
+        if ~isempty(errMsgRescale)
+            errMsg = errMsgRescale;
+            return;
+        end
+        sMri = sMriRescale;
+        fileTag = fileTagRescale;
+    else
+        fileTag = '';
+    end
+
+    % --- Masking (if requested) ---
+    if applyMask && ~isempty(maskROI)
+        [~, sMriMasked, errMsgMask, fileTagMask] = mri_mask(sMri, AtlasName, maskROI, 1, sSubject);
+        if ~isempty(errMsgMask)
+            errMsg = errMsgMask;
+            return;
+        end
+        sMri = sMriMasked;
+        % Combine tags for output file
+        fileTag = [fileTag, fileTagMask];
+    end
+
+    % --- Save output file manually (like mri_realign) ---
+    % Insert fileTag before last underscore
+    [folder, base, ext] = fileparts(file_fullpath(MriFile));
+    lastUnderscore = find(base == '_', 1, 'last');
+    if ~isempty(lastUnderscore)
+        newBase = [base(1:lastUnderscore-1), fileTag, base(lastUnderscore:end)];
+    else
+        newBase = [base, fileTag];
+    end
+    MriFileOutFull = file_unique(fullfile(folder, [newBase, ext]));
+    MriFileOut = file_short(MriFileOutFull);
+
+    % Update comment to be unique
+    if isfield(sSubject, 'Anatomy')
+        sMri.Comment = file_unique([sMri.Comment, fileTag], {sSubject.Anatomy.Comment});
+    else
+        sMri.Comment = [sMri.Comment, fileTag];
+    end
+
+    % Add history entry
+    if ~isempty(roiName)
+        sMri = bst_history('add', sMri, 'rescale', sprintf('Rescaled with "%s" (%s)', AtlasName, roiName));
+    end
+    if applyMask && ~isempty(maskROI)
+        sMri = bst_history('add', sMri, 'mask', sprintf('Masked with "%s" (%s)', AtlasName, maskROI));
+    end
+
+    % Save new MRI in Brainstorm format
+    sMri = out_mri_bst(sMri, MriFileOutFull);
+
+    % Register new MRI in subject
+    [~, iSubject] = bst_get('Subject', sSubject.Name);
+    iAnatomy = length(sSubject.Anatomy) + 1;
+    sSubject.Anatomy(iAnatomy) = db_template('Anatomy');
+    sSubject.Anatomy(iAnatomy).FileName = MriFileOut;
+    sSubject.Anatomy(iAnatomy).Comment  = sMri.Comment;
+    bst_set('Subject', iSubject, sSubject);
+
+    % Refresh tree and save database
+    panel_protocols('UpdateNode', 'Subject', iSubject);
+    panel_protocols('SelectNode', [], 'anatomy', iSubject, iAnatomy);
+    db_save();
+
+if isfield(sSubject, 'iAnatomy') && ~isempty(sSubject.iAnatomy) && ...
+        isfield(sSubject, 'Anatomy') && length(sSubject.Anatomy) >= sSubject.iAnatomy
+    refMriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
+else
+    refMriFile = sSubject.Anatomy(1).FileName;
+end
+view_mri(refMriFile, MriFileOut);
+
+catch ME
+    errMsg = ME.message;
+end

--- a/toolbox/process_pet.m
+++ b/toolbox/process_pet.m
@@ -1,4 +1,4 @@
-function [MriFileOut, errMsg] = process_pet(MriFile, sSubject, AtlasName, roiName, maskROI, applyMask)
+function [MriFileOut, errMsg, SurfaceFileOut] = process_pet(MriFile, sSubject, AtlasName, roiName, maskROI, applyMask, doProject)
 % PROCESS_PET: Script PET processing pipeline (SUVR rescale and/or masking) with minimal redundant saving.
 %
 % INPUTS:
@@ -8,12 +8,15 @@ function [MriFileOut, errMsg] = process_pet(MriFile, sSubject, AtlasName, roiNam
 %   - roiName   : Name of the ROI for SUVR rescale (string, can be empty)
 %   - maskROI   : Name of the ROI for masking (string, can be empty)
 %   - applyMask : Logical, true to apply mask, false otherwise
+%   - doProject : Logical, true to project PET to surface, false otherwise
 %
 % OUTPUTS:
-%   - MriFileOut : Output MRI file path (string)
-%   - errMsg     : Error message, if any
+%   - MriFileOut    : Output MRI file path (string)
+%   - errMsg        : Error message, if any
+%   - SurfaceFileOut: Output surface file path (string, if projected)
 
 MriFileOut = '';
+SurfaceFileOut = '';
 errMsg = '';
 
 try
@@ -88,13 +91,28 @@ try
     panel_protocols('SelectNode', [], 'anatomy', iSubject, iAnatomy);
     db_save();
 
-if isfield(sSubject, 'iAnatomy') && ~isempty(sSubject.iAnatomy) && ...
-        isfield(sSubject, 'Anatomy') && length(sSubject.Anatomy) >= sSubject.iAnatomy
-    refMriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
-else
-    refMriFile = sSubject.Anatomy(1).FileName;
-end
-view_mri(refMriFile, MriFileOut);
+    % --- Overlay processed PET on subject's default MRI ---
+    if isfield(sSubject, 'iAnatomy') && ~isempty(sSubject.iAnatomy) && ...
+            isfield(sSubject, 'Anatomy') && length(sSubject.Anatomy) >= sSubject.iAnatomy
+        refMriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
+    else
+        refMriFile = sSubject.Anatomy(1).FileName;
+    end
+    view_mri(refMriFile, MriFileOut);
+
+    % --- Project to surface if requested ---
+    if nargin >= 7 && doProject
+        % Use the same reference MRI as above
+        % Use the subject's name as the condition
+        Condition = 'PET';
+        TimeVector = [];
+        DisplayUnits = '';
+        ProjFrac = [0.1 0.4 0.5];
+        [SurfaceFileOut, errProj] = mri_interp_vol2tess(MriFileOut, refMriFile, Condition, TimeVector, DisplayUnits, ProjFrac);
+        if ~isempty(errProj)
+            errMsg = ['PET processed, but projection failed: ', errProj];
+        end
+    end
 
 catch ME
     errMsg = ME.message;

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -3204,15 +3204,20 @@ end
 %% ===== PET PROCESSING =====
 function fcnPetProcessing(jPopup, sSubject, iAnatomy)
     import org.brainstorm.icon.*;
-    % Add menu separator
+       % Add menu separator
     AddSeparator(jPopup);
     % Create sub-menu
     jMenu = gui_component('Menu', jPopup, [], 'PET processing', IconLoader.ICON_VOLPET);
+    gui_component('MenuItem', jMenu, [], 'Process PET volume', IconLoader.ICON_VOLPET, [], @(h,ev)bst_call(@gui_show_dialog, 'PET Pre-processing options', @panel_process_pet, 1, [], sSubject, iAnatomy));
+      AddSeparator(jMenu);
+    gui_component('MenuItem', jMenu, [], 'Project to surface', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)bst_call(@mri_interp_vol2tess, sSubject.Anatomy(iAnatomy).FileName, [], 'PET'));
+
     % === PET IMPORT PROCESSING ===
     if length(iAnatomy) == 1
         PetFile = sSubject.Anatomy(iAnatomy).FileName;
         gui_component('MenuItem', jMenu, [], 'Realign frames', IconLoader.ICON_VOLPET, [], @(h,ev)PetImportProcess_Callback(PetFile));
     end
+
 end
 
 
@@ -3220,12 +3225,13 @@ end
 function PetImportProcess_Callback(PetFile)
     % Get number of frames (4D)
     CubeInfo = whos('-file', file_fullpath(PetFile), 'Cube');
+   if numel(CubeInfo.size)<4
+       disp('BST> PET volume is static (3D), skipping realignment across frames');
+       return
+   else
     nFrames = CubeInfo.size(4);
-    % Nothing to do here
-    if nFrames < 2
-        disp('BST> PET volume is static (3D), skipping realignment across frames');
-        return
-    end
+   end
+    
     % Collect user inputs
     petopts = gui_show_dialog('PET Pre-processing options', @panel_import_pet, 1, [], nFrames, 0);
     if ~isempty(petopts)


### PR DESCRIPTION
PET processing functionalities, extending the previously integrated PET import pipeline.

###  Features:
  - Atlas-based ROI masking, using existing '_volatlas' files in Brainstorm
  - Intensity rescaling (SUVR)
  - Volume-to-surface projection
  - GUI/dialog for collecting user input for PET processing
  - PETPVE plugin as an SPM toolbox

### New functions: 
  - `process_pet.m`: scriptable entry point for PET processing - used to chain together PET processing functions 
  -  `panel_process_pet.m`: GUI for collecting user input for PET processing - works with `process_pet.m`
  - `mri_rescale.m`: rescale intensity values (e.g. SUV/SUVR) using the mean value of a reference regions - works with `panel_process_pet.m` and `mri_mask.m`
  - `mri_mask.m`: bilateral ROI-based volume masking using atlas labels from supported atlases: "aseg", "Desikan-Killiany" and so on. 
  - `mri_interp_vol2tess.m`: interpolates 3D PET volumes onto cortical surfaces

Please let me know if further modularization or code cleanup is needed. Thanks for reviewing!
