### PR TITLE
Corr with flat signals

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -1078,9 +1078,8 @@ for iFile = 1 : length(FilesA)
             bst_report('Error', OPTIONS.ProcessName, [], ['Invalid method "' OPTIONS.Method '".']);
             CleanExit; return;
     end
-    % Replace any NaN values with zeros
+    % Replace Inf values with zeros
     if isnumeric(R)
-        R(isnan(R)) = 0;
         R(isinf(R)) = 0;
     end
     

--- a/toolbox/connectivity/bst_corrn.m
+++ b/toolbox/connectivity/bst_corrn.m
@@ -48,12 +48,18 @@ else
     Xc = X;
     Yc = Y;
 end
+% Identify flat signals
+iFlatX = all(X == X(:,1), 2);
+iFlatY = all(Y == Y(:,1), 2);
 % Normalize the rows of all the signals 
 % (to avoid rounding errors in case of values with radically different values)
 Xc = normr(Xc);
 Yc = normr(Yc);
 % Correlation coefficients
 R = Xc * Yc';
+% Set correlation coefficient with flat signals to NaN
+R(iFlatX, :) = NaN;
+R(:, iFlatY) = NaN;
 % % Set the diagonal to zero
 % if isequal(X,Y)
 %     R = R - diag(diag(R));

--- a/toolbox/core/bst_memory.m
+++ b/toolbox/core/bst_memory.m
@@ -1570,6 +1570,11 @@ function [iDS, iTimefreq, iResults] = LoadTimefreqFile(TimefreqFile, isTimeCheck
     if any(TimefreqFile == '$')
         TimefreqFile = TimefreqFile(1:find(TimefreqFile == '$',1)-1);
     end
+    % Is connectivity timefreq?
+    isConnect = 0;
+    if regexp(TimefreqFile, '_connect[n|1]', 'once')
+        isConnect = 1;
+    end
     % Get file information
     [sStudy, iTf, ChannelFile, FileType, sItem] = GetFileInfo(TimefreqFile);
     TimefreqMat = in_bst_timefreq(TimefreqFile, 0, 'DataType');
@@ -1768,7 +1773,7 @@ function [iDS, iTimefreq, iResults] = LoadTimefreqFile(TimefreqFile, isTimeCheck
     % ===== REMOVE NAN =====
     % Replace NaN values with 0, and add them to the mask
     iNan = find(isnan(TimefreqMat.TF));
-    if ~isempty(iNan)
+    if ~isempty(iNan) && ~isConnect
         disp(sprintf('BST> Error: There are %d abnormal NaN values in this file, check the computation process.', length(iNan)));
         TimefreqMat.TF(iNan) = 0;
     end

--- a/toolbox/gui/figure_connect.m
+++ b/toolbox/gui/figure_connect.m
@@ -1033,8 +1033,10 @@ function [DataPair, isStat] = LoadConnectivityData(hFig, Options)
     end
 
     % Zero-out the diagonal because its useless
-    M = M - diag(diag(M));
-    
+    M(logical(eye(size(M)))) = 0;
+    % Replace NaN values with Inf to test for symmetry
+    ixNan = isnan(M);
+    M(ixNan) = Inf;
     % If the matrix is symetric and Not directional
     if (isequal(M, M') && ~IsDirectionalData(hFig))
         % We don't need the upper half
@@ -1042,6 +1044,8 @@ function [DataPair, isStat] = LoadConnectivityData(hFig, Options)
             M(i, i:end) = 0;
         end
     end
+    % Restore NaNs
+    M(ixNan) = NaN;
     
     % === THRESHOLD ===
     if ~isStat && ((size(M, 1) * size(M, 2)) > MaximumNumberOfData)


### PR DESCRIPTION
This PR updates the code in `bst_corrn` to allow to return `NaN` if correlation is computed with flat signals. This is inline with the Matlab function `corr`

It also updates `bst_connectiity` to be able to save `NaN` in the connectivity matrix.

This addresses the issue reported in #774 