### PR TITLE
Load map without std field

### DIFF
--- a/toolbox/process/functions/process_extract_scout.m
+++ b/toolbox/process/functions/process_extract_scout.m
@@ -747,6 +747,9 @@ function [sResults, matSourceValues, matDataValues, fileComment] = LoadFile(sPro
     if ~isfield(sResults, 'SurfaceFile')
         sResults.SurfaceFile = [];
     end
+    if ~isfield(sResults, 'Std')
+        sResults.Std = [];
+    end
     if ~isfield(sResults, 'DisplayUnits')
         sResults.DisplayUnits = [];
     end


### PR DESCRIPTION
When testing the correlation fix in #806, i encounted this error: 

![image](https://github.com/user-attachments/assets/8671844e-cb9d-46f1-846e-55a5db72eac7)


This PR is here to fix it :)
