### PR TITLE
Missing EEG Channel Names When Importing FIF/BIDS Files from NeuroMag

### DIFF
--- a/toolbox/process/functions/process_import_bids.m
+++ b/toolbox/process/functions/process_import_bids.m
@@ -861,26 +861,6 @@ function [RawFiles, Messages, OrigFiles] = ImportBidsDataset(BidsDir, OPTIONS)
                 newFiles = import_raw(allMeegFiles{iFile}, FileFormat, iSubject, ImportOptions, DateOfStudy);
                 RawFiles = [RawFiles{:}, newFiles];
                 OrigFiles = [OrigFiles{:}, repmat(allMeegFiles(iFile), length(newFiles), 1)];
-                % Add electrodes positions if available
-                if ~isempty(allMeegElecFiles{iFile}) && ~isempty(allMeegElecFormats{iFile})
-                    % Subject T1 coordinates (space-ScanRAS)
-                    if ~isempty(strfind(allMeegElecFormats{iFile}, '-SCANRAS-'))
-                        % If using the vox2ras transformation: also removes the SPM coregistrations computed in Brainstorm
-                        % after importing the files, as these transformation were not available in the BIDS dataset
-                        isVox2ras = 2;
-                    % Or MNI coordinates (space-IXI549Space or other MNI space)
-                    else
-                        isVox2ras = 0;
-                    end
-                    % Import electrode positions
-                    % Note: this does not work if channel names different in data and metadata - see note in the function header
-                    bst_process('CallProcess', 'process_channel_addloc', newFiles, [], ...
-                        'channelfile', {allMeegElecFiles{iFile}, allMeegElecFormats{iFile}}, ...
-                        'fixunits',    0, ...
-                        'vox2ras',     isVox2ras, ...
-                        'mrifile',     {allMeegElecAnatRef{iFile}, 'BST'}, ...
-                        'fiducials',   allMeegElecFiducials{iFile});
-                end
                 % Get base file name
                 iLast = find(allMeegFiles{iFile} == '_', 1, 'last');
                 if isempty(iLast)
@@ -991,6 +971,27 @@ function [RawFiles, Messages, OrigFiles] = ImportBidsDataset(BidsDir, OPTIONS)
                     end                   
                 end
 
+                % Add electrodes positions if available
+                if ~isempty(allMeegElecFiles{iFile}) && ~isempty(allMeegElecFormats{iFile})
+                    % Subject T1 coordinates (space-ScanRAS)
+                    if ~isempty(strfind(allMeegElecFormats{iFile}, '-SCANRAS-'))
+                        % If using the vox2ras transformation: also removes the SPM coregistrations computed in Brainstorm
+                        % after importing the files, as these transformation were not available in the BIDS dataset
+                        isVox2ras = 2;
+                    % Or MNI coordinates (space-IXI549Space or other MNI space)
+                    else
+                        isVox2ras = 0;
+                    end
+                    % Import electrode positions
+                    % Note: this does not work if channel names different in data and metadata - see note in the function header
+                    bst_process('CallProcess', 'process_channel_addloc', newFiles, [], ...
+                        'channelfile', {allMeegElecFiles{iFile}, allMeegElecFormats{iFile}}, ...
+                        'fixunits',    0, ...
+                        'vox2ras',     isVox2ras, ...
+                        'mrifile',     {allMeegElecAnatRef{iFile}, 'BST'}, ...
+                        'fiducials',   allMeegElecFiducials{iFile});
+                end
+                
                 % === MEG.JSON ===
                 % Get _meg.json next to the recordings file
                 MegFile = [baseName, '_meg.json'];

--- a/toolbox/process/functions/process_import_bids.m
+++ b/toolbox/process/functions/process_import_bids.m
@@ -911,12 +911,19 @@ function [RawFiles, Messages, OrigFiles] = ImportBidsDataset(BidsDir, OPTIONS)
                             isModifiedData = 0;
                             % Loop to find matching channels
                             for iChanBids = 1:size(ChanInfo,1)
-                                % Look for corresponding channel in Brainstorm channel file
-                                iChanBst = find(strcmpi(ChanInfo{iChanBids,1}, {ChannelMat.Channel.Name}));
-                                if isempty(iChanBst)
-                                    iChanBst = find(strcmpi(strrep(ChanInfo{iChanBids,1}, ' ', ''), {ChannelMat.Channel.Name}));
+                                % Update EEG channel names for FIF files
+                                if strcmpi(FileFormat, 'FIF') && strcmpi(ChanInfo{iChanBids, 2}, 'EEG')
+                                    ChannelMat.Channel(iChanBids).Name = ChanInfo{iChanBids, 1};
+                                    iChanBst = iChanBids;
+                                    isModifiedChan = 1;
+                                else
+                                    % Look for corresponding channel in Brainstorm channel file
+                                    iChanBst = find(strcmpi(ChanInfo{iChanBids,1}, {ChannelMat.Channel.Name}));
                                     if isempty(iChanBst)
-                                        continue;
+                                        iChanBst = find(strcmpi(strrep(ChanInfo{iChanBids,1}, ' ', ''), {ChannelMat.Channel.Name}));
+                                        if isempty(iChanBst)
+                                            continue;
+                                        end
                                     end
                                 end
                                 % Copy type


### PR DESCRIPTION
This PR addresses issue https://github.com/brainstorm-tools/brainstorm3/issues/802

When importing FIF files through `process_import_bids`, for non-MEG (here EEG) channels, two post processing steps are required:

1. Renaming the `EEGxxx` channel names to the proper ones as provided in the `_channels.tsv` file
2. Update the locations for the EEG channels from `_electrodes.tsv`. The reason we do this is because the locations in the FIF file may have error but `_electrodes.tsv` will have the most accurate locations. 

@yashvakilna @tmedani 