### PR TITLE
Mesh stats for surfaces

### DIFF
--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -39,9 +39,9 @@ function MeshStat = tess_meshstats(tessFile)
 
 % Install/load iso2mesh plugin
 isInteractive = 1;
-[isInstalled, errInstall] = bst_plugin('Install', 'iso2mesh', isInteractive);
+[isInstalled, errMsg] = bst_plugin('Install', 'iso2mesh', isInteractive);
 if ~isInstalled
-    error('Plugin "iso2mesh" not available.');
+    error(['Could not install or load plugin: iso2mesh' 10 errMsg]);
 end
 
 % Get data in database

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -224,7 +224,7 @@ if isDisplay
     histogram(voli,nbins);
     switch meshType
         case 'surface_triangle'
-            xlabel(sprintf('%s (%s):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f [Enclosed Volume=%1.2f mm3]', measureType, measureUnit, MeshStat.FullModel.([measureFieldName 'Mean']), MeshStat.FullModel.([measureFieldName 'Std']),...
+            xlabel(sprintf('%s (%s):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f/n[Enclosed Volume=%1.2f mm3]', measureType, measureUnit, MeshStat.FullModel.([measureFieldName 'Mean']), MeshStat.FullModel.([measureFieldName 'Std']),...
                 MeshStat.FullModel.([measureFieldName 'Min']), MeshStat.FullModel.([measureFieldName 'Max']), MeshStat.FullModel.([measureFieldName 'Sum']), MeshStat.FullModel.VolumeClosedSurface))
 
         case 'volume_tetrahedron'

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -1,14 +1,15 @@
-function MeshStat = tess_meshstats(FemFile)
-% FEM_MESHSTATS: Computes and display FEM mesh volume (tetrahedral only).
+function MeshStat = tess_meshstats(tessFile)
+% FEM_MESHSTATS: Computes and display mesh stats.
 %
 % INPUTS:
-%    - FemFile : Relative file path to a Braistorm tetrahedral FEM mesh
+%    - SurfaceFile : Relative or Full file path to a Braistorm surface file (including FEM mesh)
 % OUTPUTS: 
-%    - MeshStat : Mtlab structure that contains all FEM mesh stqtistics (edge length, elem volum and mesh quality)
+%    - MeshStat : Matlab structure that contains all mesh stqtistics (edge length, elem volum/Face surface and mesh quality)
 %
 % DEPENDENCIES:
 %    This function require the iso2mesh toolbox
-
+%    This function is an extended version of fem_meshstats to include
+%    surface meshes
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
@@ -28,6 +29,7 @@ function MeshStat = tess_meshstats(FemFile)
 % =============================================================================@
 %
 % Authors: Takfarinas Medani, Francois Tadel, 2023
+%          Takfarinas Medani, 2025
 
 % Install/load iso2mesh plugin
 isInteractive = 1;
@@ -37,91 +39,102 @@ if ~isInstalled
 end
 
 % Get data in database
-bst_progress('start', 'Mesh volume', 'Loading file...');
-FemFullFile = file_fullpath(FemFile);
-femmat = load(FemFullFile);
-% Check type of mesh: accept only tetrahedral
-if (size(femmat.Elements,2) ~= 4)
-    error('This menu is available for tetrahedral meshes only.');
+bst_progress('start', 'Mesh Stats', 'Loading file...');
+FullFile = file_fullpath(tessFile);
+tessData = load(FullFile);
+
+% Check if the data is Surface Mesh or FEM tetrahedral mesh
+if isfield(tessData, 'Faces')
+    meshType = 1; % 'Surface Triangle';
+    tessData.Elements =  tessData.Faces; % adapting the variable
+elseif isfield(tessData, 'Elements')
+    meshType = 2; % 'Volume Tetrahedral';
+    TissueID = unique(tessData.Tissue);
+    % Check type of mesh: accept only tetrahedral
+    if (size(tessData.Elements,2) ~= 4)
+        error('This option is available for FEM tetrahedral meshes only.');
+    end
 end
+
 % Display results in figures if no variable in output
 isDisplay = (nargout == 0);
 hFig = [];
 
 % Convert to millimeter for convenience
-femmat.Vertices = 1000 .* femmat.Vertices;
+tessData.Vertices = 1000 .* tessData.Vertices;
 
-% Loop over the tissues
-TissueID = unique(femmat.Tissue);
-for iTissue = 1:length(TissueID)
-    iTissueID = find(femmat.Tissue == TissueID(iTissue));
+if (meshType == 2) && (length(TissueID) > 1) % This loop is only for FEM mesh with multiple tissues
+    % Loop over the tissues
+    for iTissue = 1:length(TissueID)
+        iTissueID = find(tessData.Tissue == TissueID(iTissue));
 
-    % 1. Edges length
-    bst_progress('text', sprintf('Computing edges length...  [%d/%d]', iTissue, length(TissueID)));
-    Edges = meshedge(femmat.Elements(iTissueID,:));
-    n1 = femmat.Vertices(Edges(:,1),:);
-    n2 = femmat.Vertices(Edges(:,2),:);
-    EdgeLength = sqrt((n1(:,1)- n2(:,1)).^2 + (n1(:,2)- n2(:,2)).^2 + (n1(:,3)- n2(:,3)).^2);
-    
-    tstat.EdgeLengthMax = max(EdgeLength);
-    tstat.EdgeLengthMin = min(EdgeLength);
-    tstat.EdgeLengthStd = std(EdgeLength);
-    tstat.EdgeLengthMean = mean(EdgeLength);
-    tstat.EdgeLengthRMS = rms(EdgeLength);
+        % 1. Edges length
+        bst_progress('text', sprintf('Computing edges length...  [%d/%d]', iTissue, length(TissueID)));
+        Edges = meshedge(tessData.Elements(iTissueID,:));
+        n1 = tessData.Vertices(Edges(:,1),:);
+        n2 = tessData.Vertices(Edges(:,2),:);
+        EdgeLength = sqrt((n1(:,1)- n2(:,1)).^2 + (n1(:,2)- n2(:,2)).^2 + (n1(:,3)- n2(:,3)).^2);
 
-    % 2. Mesh quality: Joe-Liu mesh quality metric (0-1)
-    %  quality: a vector of the same length as size(elem,1), with
-    %            each element being the Joe-Liu mesh quality metric (0-1) of
-    %            the corresponding element. A value close to 1 represents
-    %            higher mesh quality (1 means equilateral tetrahedron);
-    %            a value close to 0 means nearly degenerated element.
-    bst_progress('text', sprintf('Computing mesh quality...  [%d/%d]', iTissue, length(TissueID)));
-    quality = 100 .*meshquality(femmat.Vertices, femmat.Elements(iTissueID,:));
-    tstat.MeshQualityMax = max(quality);
-    tstat.MeshQualityMin = min(quality);
-    tstat.MeshQualityStd = std(quality);
-    tstat.MeshQualityMean = mean(quality);
+        tstat.EdgeLengthMax = max(EdgeLength);
+        tstat.EdgeLengthMin = min(EdgeLength);
+        tstat.EdgeLengthStd = std(EdgeLength);
+        tstat.EdgeLengthMean = mean(EdgeLength);
+        tstat.EdgeLengthRMS = rms(EdgeLength);
 
-    % 3. Volume of elem
-    bst_progress('text', sprintf('Computing volume of elements...  [%d/%d]', iTissue, length(TissueID)));
-    voli = elemvolume(femmat.Vertices, femmat.Elements(iTissueID,:));
-    tstat.MeshVolumeMax = max(voli);
-    tstat.MeshVolumeMin = min(voli);
-    tstat.MeshVolumeStd = std(voli);
-    tstat.MeshVolumeMean = mean(voli);
-    tstat.MeshVolumeSum = sum(voli);
+        % 2. Mesh quality: Joe-Liu mesh quality metric (0-1)
+        %  quality: a vector of the same length as size(elem,1), with
+        %            each element being the Joe-Liu mesh quality metric (0-1) of
+        %            the corresponding element. A value close to 1 represents
+        %            higher mesh quality (1 means equilateral tetrahedron);
+        %            a value close to 0 means nearly degenerated element.
+        bst_progress('text', sprintf('Computing mesh quality...  [%d/%d]', iTissue, length(TissueID)));
+        quality = 100 .*meshquality(tessData.Vertices, tessData.Elements(iTissueID,:));
+        tstat.MeshQualityMax = max(quality);
+        tstat.MeshQualityMin = min(quality);
+        tstat.MeshQualityStd = std(quality);
+        tstat.MeshQualityMean = mean(quality);
 
-    MeshStat.(femmat.TissueLabels{iTissue}) = tstat;
+        % 3. Volume of elem
+        bst_progress('text', sprintf('Computing volume of elements...  [%d/%d]', iTissue, length(TissueID)));
+        voli = elemvolume(tessData.Vertices, tessData.Elements(iTissueID,:));
+        tstat.MeshVolumeMax = max(voli);
+        tstat.MeshVolumeMin = min(voli);
+        tstat.MeshVolumeStd = std(voli);
+        tstat.MeshVolumeMean = mean(voli);
+        tstat.MeshVolumeSum = sum(voli);
 
-    % Visualization
-    if isDisplay
-        bst_progress('text', sprintf('Visualisation... [%d/%d]', iTissue, length(TissueID)));
-        hFig(end+1) = figure('Name', ['Mesh stat: ' femmat.TissueLabels{iTissue}], 'NumberTitle', 'off');
-        
-        nbins = 30;
-        subplot(3,1,1)
-        histogram(EdgeLength,nbins);
-        xlabel(sprintf('Edge length (mm):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f', tstat.EdgeLengthMean, tstat.EdgeLengthStd, tstat.EdgeLengthMin, tstat.EdgeLengthMax))
-        drawnow
+        MeshStat.(tessData.TissueLabels{iTissue}) = tstat;
 
-        subplot(3,1,2)
-        histogram(quality,nbins);
-        xlabel(sprintf('Mesh quality (%%):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f', tstat.MeshQualityMean, tstat.MeshQualityStd, tstat.MeshQualityMin, tstat.MeshQualityMax))
-        drawnow
+        % Visualization
+        if isDisplay
+            bst_progress('text', sprintf('Visualisation... [%d/%d]', iTissue, length(TissueID)));
+            hFig(end+1) = figure('Name', ['Mesh stat: ' tessData.TissueLabels{iTissue}], 'NumberTitle', 'off');
 
-        subplot(3,1,3)
-        histogram(voli,nbins);
-        xlabel(sprintf('Element volume (mm3):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f', tstat.MeshVolumeMean, tstat.MeshVolumeStd, tstat.MeshVolumeMin, tstat.MeshVolumeMax, tstat.MeshVolumeSum))
-        drawnow
+            nbins = 30;
+            subplot(3,1,1)
+            histogram(EdgeLength,nbins);
+            xlabel(sprintf('Edge length (mm):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f', tstat.EdgeLengthMean, tstat.EdgeLengthStd, tstat.EdgeLengthMin, tstat.EdgeLengthMax))
+            drawnow
+
+            subplot(3,1,2)
+            histogram(quality,nbins);
+            xlabel(sprintf('Mesh quality (%%):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f', tstat.MeshQualityMean, tstat.MeshQualityStd, tstat.MeshQualityMin, tstat.MeshQualityMax))
+            drawnow
+
+            subplot(3,1,3)
+            histogram(voli,nbins);
+            xlabel(sprintf('Element volume (mm3):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f', tstat.MeshVolumeMean, tstat.MeshVolumeStd, tstat.MeshVolumeMin, tstat.MeshVolumeMax, tstat.MeshVolumeSum))
+            drawnow
+        end
     end
 end
 
 % For all the full Model
 % 1. Edges length
 bst_progress('text', 'Computing edges length...');
-Edges = meshedge(femmat.Elements);
-n1 = femmat.Vertices(Edges(:,1),:);
-n2 = femmat.Vertices(Edges(:,2),:);
+Edges = meshedge(tessData.Elements);
+n1 = tessData.Vertices(Edges(:,1),:);
+n2 = tessData.Vertices(Edges(:,2),:);
 EdgeLength = sqrt((n1(:,1)- n2(:,1)).^2 + (n1(:,2)- n2(:,2)).^2 + (n1(:,3)- n2(:,3)).^2);
 
 MeshStat.FullModel.EdgeLengthMax = max(EdgeLength);
@@ -132,21 +145,46 @@ MeshStat.FullModel.EdgeLengthRMS = rms(EdgeLength);
 
 % 2. Mesh quality: Joe-Liu mesh quality metric (0-100)
 bst_progress('text', 'Computing mesh quality...');
-quality = 100 .* meshquality(femmat.Vertices, femmat.Elements);
+quality = 100 .* meshquality(tessData.Vertices, tessData.Elements);
 MeshStat.FullModel.MeshQualityMax = max(quality);
 MeshStat.FullModel.MeshQualityMin = min(quality);
 MeshStat.FullModel.MeshQualityStd = std(quality);
 MeshStat.FullModel.MeshQualityMean = mean(quality);
 
-% 3. Volume of elem
-bst_progress('text', 'Computing volume of elements...');
-voli = elemvolume(femmat.Vertices, femmat.Elements);
-MeshStat.FullModel.MeshVolumeMax = max(voli);
-MeshStat.FullModel.MeshVolumeMin = min(voli);
-MeshStat.FullModel.MeshVolumeStd = std(voli);
-MeshStat.FullModel.MeshVolumeMean = mean(voli);
-MeshStat.FullModel.MeshVolumeSum = sum(voli);
+% 3. Volume/Area of elem/face
+if  meshType == 1
+    bst_progress('text', 'Computing area of faces...');
+    fieldName = 'MeshArea';
+    measureUnit = 'mm2';
+    measureType = 'Triangle Face Area';
+elseif  meshType == 2
+    bst_progress('text', 'Computing volume of elements...');
+    fieldName = 'MeshVolume';
+    measureUnit = 'mm3';
+    measureType = 'Tetra Element Volume';
+end
+voli = elemvolume(tessData.Vertices, tessData.Elements); % can be either volume or area
+MeshStat.FullModel.([fieldName 'Max']) = max(voli);
+MeshStat.FullModel.([fieldName 'Min']) = min(voli);
+MeshStat.FullModel.([fieldName 'Std']) = std(voli);
+MeshStat.FullModel.([fieldName 'Mean']) = mean(voli);
+MeshStat.FullModel.([fieldName 'Sum']) = sum(voli);
 
+if (meshType == 1)
+    % 4. Add the volume of the closed surface fromed by the triangle faces
+    % Method 1: %  divergence theorem
+    volume = 0;
+    for iElem = 1:size(tessData.Elements, 1)
+        v1 = tessData.Vertices(tessData.Elements(iElem,1), :);
+        v2 = tessData.Vertices(tessData.Elements(iElem,2), :);
+        v3 = tessData.Vertices(tessData.Elements(iElem,3), :);
+        volume = volume + dot(v1, cross(v2, v3)); 
+    end
+    volume = abs(volume) / 6 ;
+    MeshStat.FullModel.VolumeClosedSurface = volume;
+    % % Method 2: %  based on iso2mesh (require generating FEM mesh and the sum elem vol => not recommended )
+    % volume = surfvolume(tessData.Vertices,tessData.Elements);
+end
 % Visualization
 if isDisplay
     bst_progress('text', 'Visualisation...');
@@ -165,10 +203,17 @@ if isDisplay
     
     subplot(3,1,3)
     histogram(voli,nbins);
-    xlabel(sprintf('Element volume (mm3):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f', MeshStat.FullModel.MeshVolumeMean, MeshStat.FullModel.MeshVolumeStd, MeshStat.FullModel.MeshVolumeMin, MeshStat.FullModel.MeshVolumeMax, MeshStat.FullModel.MeshVolumeSum))
+    if  meshType == 1
+        xlabel(sprintf('%s (%s):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f | [Enclosed Volume=%1.2f mm3]', measureType, measureUnit, MeshStat.FullModel.([fieldName 'Mean']), MeshStat.FullModel.([fieldName 'Std']),...
+            MeshStat.FullModel.([fieldName 'Min']), MeshStat.FullModel.([fieldName 'Max']), MeshStat.FullModel.([fieldName 'Sum']), MeshStat.FullModel.VolumeClosedSurface))
 
-    % Close all the figures at once
-    set(hFig, 'DeleteFcn', @(h,ev)delete(setdiff(hFig,h)));
+    elseif  meshType == 2
+        xlabel(sprintf('%s (%s):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f', measureType, measureUnit, MeshStat.FullModel.([fieldName 'Mean']), MeshStat.FullModel.([fieldName 'Std']),...
+            MeshStat.FullModel.([fieldName 'Min']), MeshStat.FullModel.([fieldName 'Max']), MeshStat.FullModel.([fieldName 'Sum'])))
+
+    end
+% Close all the figures at once
+set(hFig, 'DeleteFcn', @(h,ev)delete(setdiff(hFig,h)));
 end
 
 bst_progress('stop');

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -1,4 +1,4 @@
-function MeshStat = fem_meshstats(FemFile)
+function MeshStat = tess_meshstats(FemFile)
 % FEM_MESHSTATS: Computes and display FEM mesh volume (tetrahedral only).
 %
 % INPUTS:

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -60,7 +60,7 @@ if isfield(tessData, 'Faces')
     end
     meshType = 'surface_triangle';
     tessData.Elements = tessData.Faces; % adapting the variable
-    measureType = 'Triangle Face Area';
+    measureType = 'Triangle area';
     measureFieldName   = 'MeshArea';
     measureUnit = 'mm2';
 
@@ -71,7 +71,7 @@ elseif isfield(tessData, 'Elements')
     end
     meshType = 'volume_tetrahedron';
     TissueID = unique(tessData.Tissue);
-    measureType = 'Tetra Element Volume';
+    measureType = 'Tetrahedron volume';
     measureFieldName  = 'MeshVolume';
     measureUnit = 'mm3';
 end
@@ -146,7 +146,7 @@ if strcmpi(meshType, 'volume_tetrahedron') && (length(TissueID) > 1)
 
             subplot(3,1,3)
             histogram(voli,nbins);
-            xlabel(sprintf('Element volume (mm3):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f', tstat.MeshVolumeMean, tstat.MeshVolumeStd, tstat.MeshVolumeMin, tstat.MeshVolumeMax, tstat.MeshVolumeSum))
+            xlabel(sprintf('Tetrahedron volume (mm3):   mean=%1.2f | std=%1.2f | min=%1.2f | max=%1.2f | sum=%1.2f', tstat.MeshVolumeMean, tstat.MeshVolumeStd, tstat.MeshVolumeMin, tstat.MeshVolumeMax, tstat.MeshVolumeSum))
             drawnow
         end
     end

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -56,7 +56,7 @@ MeshQualityUnit = '%';
 if isfield(tessData, 'Faces')
     % Check type of mesh: accept only tetrahedral
     if (size(tessData.Vertices, 2) ~= 3)
-        error('This option is available for surface triangular meshes only.');
+        error('This option is available only for surface triangular meshes.');
     end
     meshType = 'surface_triangle';
     tessData.Elements = tessData.Faces; % adapting the variable
@@ -67,7 +67,7 @@ if isfield(tessData, 'Faces')
 elseif isfield(tessData, 'Elements')
     % Check type of mesh: accept only tetrahedral
     if (size(tessData.Elements,2) ~= 4)
-        error('This option is available for FEM tetrahedral meshes only.');
+        error('This option is available only for FEM tetrahedral meshes.');
     end
     meshType = 'volume_tetrahedron';
     TissueID = unique(tessData.Tissue);

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -183,19 +183,11 @@ MeshStat.FullModel.([fieldName 'Std']) = std(voli);
 MeshStat.FullModel.([fieldName 'Mean']) = mean(voli);
 MeshStat.FullModel.([fieldName 'Sum']) = sum(voli);
 
-if (meshType == 1)
-    % 4. Add the volume of the closed surface fromed by the triangle faces
-    % Method 1: %  divergence theorem
-    volume = 0;
-    for iElem = 1:size(tessData.Elements, 1)
-        v1 = tessData.Vertices(tessData.Elements(iElem,1), :);
-        v2 = tessData.Vertices(tessData.Elements(iElem,2), :);
-        v3 = tessData.Vertices(tessData.Elements(iElem,3), :);
-        volume = volume + dot(v1, cross(v2, v3)); 
-    end
-    volume = abs(volume) / 6 ;
-    MeshStat.FullModel.VolumeClosedSurface = volume;
-    % % Method 2: %  based on iso2mesh (require generating FEM mesh and the sum elem vol => not recommended )
+if strcmpi(meshType, 'surface_triangle')
+    % 4. Add the volume of the closed surface formed by the triangle faces
+    % Method 1: Divergence theorem
+    MeshStat.FullModel.VolumeClosedSurface = stlVolumeNormals(tessData.Vertices', tessData.Faces');
+    % % Method 2: Based on iso2mesh (require generating FEM mesh and the sum elem vol => not recommended )
     % volume = surfvolume(tessData.Vertices,tessData.Elements);
 end
 % Visualization

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -1,15 +1,21 @@
 function MeshStat = tess_meshstats(tessFile)
-% FEM_MESHSTATS: Computes and display mesh stats.
+% TESS_MESHSTATS: Compute and display statistics for:
+%  - Surface triangular meshes, and
+%  - Volume tetrahedral meshes
 %
 % INPUTS:
-%    - SurfaceFile : Relative or Full file path to a Braistorm surface file (including FEM mesh)
+%    - SurfaceFile : Relative or Full file path to a Braistorm surface file, either:
+%                    - triangular: head, skull, cortex, etc. Or
+%                    - tetrahedral: FEM mesh
+%
 % OUTPUTS: 
-%    - MeshStat : Matlab structure that contains all mesh stqtistics (edge length, elem volum/Face surface and mesh quality)
+%    - MeshStat : Matlab structure that contains all mesh statistics:
+%                 (edge length, elem volum/Face surface and mesh quality)
 %
 % DEPENDENCIES:
-%    This function require the iso2mesh toolbox
-%    This function is an extended version of fem_meshstats to include
-%    surface meshes
+%    This function requires the iso2mesh toolbox
+%    This function replaces fem_meshstats, extends support to triangular meshes
+%
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm

--- a/toolbox/anatomy/tess_meshstats.m
+++ b/toolbox/anatomy/tess_meshstats.m
@@ -45,7 +45,7 @@ if ~isInstalled
 end
 
 % Get data in database
-bst_progress('start', 'Mesh Stats', 'Loading file...');
+bst_progress('start', 'Mesh statistics', 'Loading file...');
 FullFile = file_fullpath(tessFile);
 tessData = load(FullFile);
 
@@ -118,7 +118,7 @@ if strcmpi(meshType, 'volume_tetrahedron') && (length(TissueID) > 1)
         % Visualization
         if isDisplay
             bst_progress('text', sprintf('Visualisation... [%d/%d]', iTissue, length(TissueID)));
-            hFig(end+1) = figure('Name', ['Mesh stat: ' tessData.TissueLabels{iTissue}], 'NumberTitle', 'off');
+            hFig(end+1) = figure('Name', ['Mesh statistics: ' tessData.TissueLabels{iTissue}], 'NumberTitle', 'off');
 
             nbins = 30;
             subplot(3,1,1)
@@ -205,7 +205,7 @@ if isDisplay
     if strcmpi(meshType, 'volume_tetrahedron')
         strAllTissues = ': all tissues combined';
     end
-    hFig(end+1) = figure('Name', ['Mesh stat' strAllTissues], 'NumberTitle', 'off');
+    hFig(end+1) = figure('Name', ['Mesh statistics' strAllTissues], 'NumberTitle', 'off');
     
     nbins = 30;
     subplot(3,1,1)

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1264,6 +1264,7 @@ switch (lower(action))
                         gui_component('MenuItem', jPopup, [], 'Remove interpolations', IconLoader.ICON_RECYCLE, [], @(h,ev)SurfaceClean_Callback(filenameFull, 0));
                         gui_component('MenuItem', jPopup, [], 'Clean surface',         IconLoader.ICON_RECYCLE, [], @(h,ev)SurfaceClean_Callback(filenameFull, 1));
                         gui_component('MenuItem', jPopup, [], 'Smooth surface', IconLoader.ICON_RECYCLE, [], @(h,ev)tess_smooth_select(filenameFull));
+                        gui_component('MenuItem', jPopup, [], 'Compute mesh statistics', IconLoader.ICON_HISTOGRAM, [], @(h,ev)tess_meshstats(filenameFull));
                         AddSeparator(jPopup);
                         gui_component('MenuItem', jPopup, [], 'Import texture', IconLoader.ICON_RESULTS, [], @(h,ev)import_sources([], filenameFull));
                     end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1297,7 +1297,7 @@ switch (lower(action))
                     gui_component('MenuItem', jPopup, [], 'Extract surfaces', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@import_femlayers, iSubject, filenameFull, 'BSTFEM', 1));
                     gui_component('MenuItem', jPopup, [], 'Merge layers', IconLoader.ICON_FEM, [], @(h,ev)panel_femname('Edit', filenameFull));
                     gui_component('MenuItem', jPopup, [], 'Convert tetra/hexa', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@process_fem_mesh, 'SwitchHexaTetra', filenameRelative));
-                    gui_component('MenuItem', jPopup, [], 'Compute mesh statistics', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@fem_meshstats, filenameRelative));
+                    gui_component('MenuItem', jPopup, [], 'Compute mesh statistics', IconLoader.ICON_HISTOGRAM, [], @(h,ev)bst_call(@tess_meshstats, filenameRelative));
                     AddSeparator(jPopup);
                     gui_component('MenuItem', jPopup, [], 'Resect neck', IconLoader.ICON_FEM, [], @(h,ev)bst_call(@fem_resect, filenameFull));
                     AddSeparator(jPopup);


### PR DESCRIPTION
This PR introduces a new function, [tess_meshstats](https://github.com/brainstorm-tools/brainstorm3/compare/master...tmedani:meshStatsForSurfaces?expand=1#diff-739e720488d81bcdceeb20b6c4b075eeffe647f6d5d941d98881b12112a8ab03), adapted from [fem_meshstats](https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/anatomy/fem_meshstats.m), to support surface meshes. This new function provides comprehensive geometric statistics for surface models, enabling easier comparison between meshes, particularly useful after post-processing steps such as smoothing or decimation.

Key Changes

Added: tess_meshstats function for computing surface mesh statistics.

Replaces previous function calls across all relevant menu options.

Supports use cases like mesh comparison and quality control after surface editing.