### PR TITLE
[Matlab2024b] remove usage of legend with nargout == 2

### DIFF
--- a/toolbox/gui/figure_spectrum.m
+++ b/toolbox/gui/figure_spectrum.m
@@ -1613,15 +1613,15 @@ function PlotHandles = PlotAxesButterfly(hAxes, PlotHandles, TfInfo, TsInfo, X, 
     % Plotting the names of the channels
     if ~isempty(LinesLabels) && TsInfo.ShowLegend && ((length(LinesLabels) > 1) || ~isempty(LinesLabels{1}))
         if (length(LinesLabels) == 1) && (length(PlotHandles.hLines) > 1)
-            [hLegend, hLegendObjects] = legend(PlotHandles.hLines(1), strrep(LinesLabels{1}, '_', '-'));
+            legend(PlotHandles.hLines(1), strrep(LinesLabels{1}, '_', '-'));
         elseif (length(PlotHandles.hLines) == length(LinesLabels))
-            [hLegend, hLegendObjects] = legend(PlotHandles.hLines, strrep(LinesLabels(:), '_', '-'));
+            legend(PlotHandles.hLines, strrep(LinesLabels(:), '_', '-'));
         else
             disp('BST> Error: Number of legend entries do not match the number of lines. Ignoring...');
-            [hLegend, hLegendObjects] = legend('off');
+            legend('off');
         end
     else
-        [hLegend, hLegendObjects] = legend('off');
+        legend('off');
     end
 end
 

--- a/toolbox/gui/figure_timeseries.m
+++ b/toolbox/gui/figure_timeseries.m
@@ -3381,13 +3381,13 @@ function PlotHandles = PlotAxes(iDS, hAxes, PlotHandles, TimeVector, F, TsInfo, 
             GroupNames{i} = GlobalData.DataSet(iDS).Channel(strcmpi(ChanName, {GlobalData.DataSet(iDS).Channel.Name})).Group;
         end
         % Create legend
-        [hLegend, hLegendObjects] = legend(PlotHandles.hLines(iLinesGroup), strrep(GroupNames, '_', '-'));
+        legend(PlotHandles.hLines(iLinesGroup), strrep(GroupNames, '_', '-'));
     % Plotting the names of the channels
     elseif strcmpi(TsInfo.DisplayMode, 'butterfly') && ~isFastUpdate && ~isempty(LinesLabels) && TsInfo.ShowLegend && ((length(LinesLabels) > 1) || ~isempty(LinesLabels{1}))
         if (length(LinesLabels) == 1) && (length(PlotHandles.hLines) > 1)
-            [hLegend, hLegendObjects] = legend(PlotHandles.hLines(1), strrep(LinesLabels{1}, '_', '-'));
+            legend(PlotHandles.hLines(1), strrep(LinesLabels{1}, '_', '-'));
         elseif (length(PlotHandles.hLines) == length(LinesLabels))
-            [hLegend, hLegendObjects] = legend(PlotHandles.hLines, strrep(LinesLabels(:), '_', '-'));
+            legend(PlotHandles.hLines, strrep(LinesLabels(:), '_', '-'));
         else
             disp('BST> Error: Number of legend entries do not match the number of lines. Ignoring...');
         end


### PR DESCRIPTION
Hello, 

Starting from Matlab2024b, matlab is issuing a warning when using the function legend with 2 outpou, as this will be removed in future matlab release. 

Since the outputs were not used it was easy to remove them from the code. 

see https://www.mathworks.com/help/matlab/ref/legend.html

