### PR TITLE
Resample: also resample the std field if present

### DIFF
--- a/toolbox/process/functions/process_resample.m
+++ b/toolbox/process/functions/process_resample.m
@@ -86,8 +86,14 @@ function sInput = Run(sProcess, sInput, method) %#ok<DEFNU>
             'This method is based on a fft-based low-pass filter, followed by a spline interpolation.' 10 ...
             'Make sure you remove the DC offset before resampling; EEGLAB function does not work well when the signals are not centered.']);
     end
+
     % Resample
+    oldTimeVector = sInput.TimeVector;
     [sInput.A, sInput.TimeVector] = Compute(sInput.A, sInput.TimeVector, NewFreq, method);
+    if isfield(sInput, 'Std') && ~isempty(sInput.Std)
+        sInput.Std = Compute(sInput.Std, oldTimeVector, NewFreq, method);
+    end
+
     % Update file
     sInput.CommentTag = sprintf('resample(%dHz)', round(NewFreq));
     sInput.HistoryComment = sprintf('Resample from %0.2f Hz to %0.2f Hz (%s)', OldFreq, NewFreq, method);


### PR DESCRIPTION
This PR is here to keep the standard deviation after resampling,



For contexte, we have estimated the average nirs response to a task using averaging (sampled at 10Hz). Now we want to compare with the fMRI response sample at 1Hz. This PR allow us to compare the two after resampling


