### PR TITLE
[Plugin] Add `mexmaca64` files for MVGC

### DIFF
--- a/toolbox/core/bst_plugin.m
+++ b/toolbox/core/bst_plugin.m
@@ -529,7 +529,7 @@ function PlugDesc = GetSupported(SelPlug, UserDefVerbose)
     PlugDesc(end).TestFile       = 'mvgc_makemex.m';
     PlugDesc(end).ReadmeFile     = 'README.md';
     PlugDesc(end).CompiledStatus = 2;
-    PlugDesc(end).LoadFolders    = {''};
+    PlugDesc(end).LoadFolders    = {'utils'};
     PlugDesc(end).DeleteFiles    = {'testing', 'maintainer'};
     PlugDesc(end).LoadedFcn      = 'cd(fullfile(PlugDesc.Path)); startup;';
 


### PR DESCRIPTION
Looking for startup.m is not a good idea (i dont think its a good idea to have it in the toolbox either) as it is the default script that is executed when starting matlab: https://www.mathworks.com/help/matlab/ref/startup.html


Edit: btw, we might want to execute mvgc_makemex during installation to generate the mex if they are missing (case for ARM computer  -- i tested, the compilation works)


Note: i also opened a PR here: https://github.com/lcbarnett/MVGC1/pull/2

