### PR TITLE
[bst_plugin usage] use bst_websave when bst_webread fail

### DIFF
--- a/toolbox/core/bst_userstat.m
+++ b/toolbox/core/bst_userstat.m
@@ -181,6 +181,14 @@ if ~isempty(PlugName)
     str =  bst_webread(url);
 
     if isempty(str)
+        err = bst_websave(fullfile(bst_get('BrainstormTmpDir'), sprintf('stat_%s.txt',PlugName)), url);
+
+        if isempty(err)
+            str = fileread(fullfile(bst_get('BrainstormTmpDir'), sprintf('stat_%s.txt',PlugName)));
+        end
+    end
+
+    if isempty(str)
         bst_progress('stop');
         return;
     end


### PR DESCRIPTION
For some reason, on my computer bst_webread fail to recover the plugins stats, but bst_websave works. 

<img width="812" height="340" alt="image" src="https://github.com/user-attachments/assets/56278a27-c951-4209-8a9c-6849fbc81293" />


Getting close to the 1000th download of nirstorm :) 