### PR TITLE
[bugfix] Better error message when aligning multiple MRI without available MNI transformation

### DIFF
--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -3030,6 +3030,12 @@ function ApplyCoordsToAllFigures(hSrcFig, cs)
     srcHandles = bst_figures('GetFigureHandles', hSrcFig);
     % Get slices locations
     XYZ = GetLocation(cs, srcMri, srcHandles);
+    if isempty(XYZ) 
+        bst_error('Error: The MNI transformation is not available for this subject. To align multiple MRI within the same subject, use ''*'' instead.'); 
+        return; 
+    end 
+ 
+
     % Go through all figures, set new location
     for ii = 1:length(hAllFig)
         destMri = panel_surface('GetSurfaceMri', hAllFig(ii));


### PR DESCRIPTION

Fix the following error : 

```

Index exceeds array bounds.

Error in figure_mri>SetLocation (line 1303)
    XYZ(1) = bst_saturate(XYZ(1), [1, size(sMri.Cube,1)]);
                          ^^^^^^
Error in figure_mri>ApplyCoordsToAllFigures (line 3037)
        SetLocation(cs, destMri, destHandles, XYZ);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in figure_mri>FigureKeyPress_Callback (line 587)
            ApplyCoordsToAllFigures(hFig, 'mni');
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
Error while evaluating Figure KeyPressFcn.

```

This error occurs when pressing '=' in an MRI figure without having the MNI transformation computed. 