### PR TITLE
[rename events]continue renaming even if event is not found

### DIFF
--- a/toolbox/process/functions/process_evt_rename.m
+++ b/toolbox/process/functions/process_evt_rename.m
@@ -130,7 +130,7 @@ function [events, isModified] = Compute(sInput, events, src, dest)
         iEvt = find(strcmpi({events.label}, src{i}));
         if isempty(iEvt)
             bst_report('Warning', 'process_evt_rename', sInput, ['Event "' src{i} '" does not exist.']);
-            return;
+            continue;
         end
         % Rename event
         events(iEvt).label = dest{i};


### PR DESCRIPTION
So i have this dataset where there is at least 3 different name for a specific event, so i tried using this code at the begening of my script to rename them automatically 

```matlab

    bst_process('CallProcess', 'process_evt_rename', sFile, [], ...
        'src',   'PreTapping, PostTapping, Tapping', ...
        'dest',  'tapping, tapping, tapping');

```

However, this doesnt work if the name is Tapping as the code returns after checking 'PreTapping. 
