### PR TITLE
Supress  `javacomponent` warnings >=R2025a

### DIFF
--- a/toolbox/anatomy/mri_editMask.m
+++ b/toolbox/anatomy/mri_editMask.m
@@ -161,8 +161,12 @@ function figureEditMask_OpeningFcn(hObject, eventdata, handles, varargin)
     
     % === Replace Matlab slider by Java slider ===
     % Disable the Java-related warnings after 2019b
-    if (bst_get('MatlabVersion') >= 907)
+    % MATLAB >= 2019b and MATLAB <= 2024b
+    if (bst_get('MatlabVersion') >= 907 && bst_get('MatlabVersion') <= 2402)
         warning('off', 'MATLAB:ui:javacomponent:FunctionToBeRemoved');
+    % MATLAB >= 2025a
+    elseif (bst_get('MatlabVersion') >= 2501)
+        warning('off', 'MATLAB:ui:javacomponent:BridgeForWebFigures');
     end
 %     sliderPos = get(handles.sliderPreview, 'Position');
 %     hParent = get(handles.sliderPreview, 'Parent');

--- a/toolbox/gui/figure_mri.m
+++ b/toolbox/gui/figure_mri.m
@@ -65,8 +65,12 @@ function [hFig, Handles] = CreateFigure(FigureId) %#ok<DEFNU>
         rendererName = 'opengl';
     end
     % Disable the Java-related warnings after 2019b
-    if (bst_get('MatlabVersion') >= 907)
+    % MATLAB >= 2019b and MATLAB <= 2024b
+    if (bst_get('MatlabVersion') >= 907 && bst_get('MatlabVersion') <= 2402)
         warning('off', 'MATLAB:ui:javacomponent:FunctionToBeRemoved');
+    % MATLAB >= 2025a
+    elseif (bst_get('MatlabVersion') >= 2501)
+        warning('off', 'MATLAB:ui:javacomponent:BridgeForWebFigures');
     end
     
     % ===== FIGURE =====

--- a/toolbox/process/functions/process_bandpass.m
+++ b/toolbox/process/functions/process_bandpass.m
@@ -349,8 +349,12 @@ else
     figure(hFig);
 end
 % Disable the Java-related warnings after 2019b
-if (bst_get('MatlabVersion') >= 907)
+% MATLAB >= 2019b and MATLAB <= 2024b
+if (bst_get('MatlabVersion') >= 907 && bst_get('MatlabVersion') <= 2402)
     warning('off', 'MATLAB:ui:javacomponent:FunctionToBeRemoved');
+% MATLAB >= 2025a
+elseif (bst_get('MatlabVersion') >= 2501)
+    warning('off', 'MATLAB:ui:javacomponent:BridgeForWebFigures');
 end
 
 % Plot frequency response


### PR DESCRIPTION
Based on the issue described in https://github.com/brainstorm-tools/brainstorm3/issues/820, this PR aims to suppress those messages.

<img width="2372" height="394" alt="Screenshot 2025-09-29 174455" src="https://github.com/user-attachments/assets/5d3f4d25-fd8c-41b7-ac39-a819af07aa75" />


MATLAB 2025a onwards the MATLAB desktop and graphics system uses JavaScript and HTML instead of Java (check blog https://blogs.mathworks.com/matlab/2025/05/16/whats-with-all-the-big-changes-in-r2025a/). The warning now falls under the category `MATLAB:ui:javacomponent:BridgeForWebFigures` as compared to `MATLAB:ui:javacomponent:FunctionToBeRemoved` prior to R2025a.