### PR TITLE
restaure progress bar after installing fieldtrip

### DIFF
--- a/toolbox/io/in_data_edf_ft.m
+++ b/toolbox/io/in_data_edf_ft.m
@@ -31,7 +31,15 @@ if ~exist('edf2fieldtrip', 'file')
     if ~isInstalled
         error(errMsg);
     end
+    
+    % Start progress bar
+    isProgress = ~bst_progress('isVisible');
+    if isProgress
+        bst_progress('start', 'Open raw EEG/MEG recordings', 'Initializing...');
+    end
+
 end
+
 
 % Temporary FieldTrip file
 [~, filename] = bst_fileparts(DataFile);
@@ -42,3 +50,5 @@ data = edf2fieldtrip(DataFile);
 save(tmpfilename, 'data');
 % Import in Brainstorm
 [DataMat, ChannelMat] = in_data_fieldtrip(tmpfilename);
+end
+


### PR DESCRIPTION
If you try to load a file while fieldtrip is not installed, the progress bar is wrong after the installation and stay as 'installing fieldtrip' during the file loading. 


