### PR TITLE
Allow overlay on volume of choice

### DIFF
--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1102,14 +1102,14 @@ switch (lower(action))
                                 jMenuOverlay3d = gui_component('Menu', jMenuDisplay, [], 'Overlay on... (3D)', IconLoader.ICON_ANATOMY, [], []);
                                 for iVol = 1:length(iVols)
                                     volFile = sSubject.Anatomy(iVols(iVol)).FileName;
-                                    volIcon = 'ICON_ANATOMY';
+                                    volIconOver = 'ICON_ANATOMY';
                                     if ~isempty(strfind(volFile, '_volct'))
-                                        volIcon = 'ICON_VOLCT';
+                                        volIconOver = 'ICON_VOLCT';
                                     elseif ~isempty(strfind(volFile, '_volpet'))
-                                        volIcon = 'ICON_VOLPET';
+                                        volIconOver = 'ICON_VOLPET';
                                     end
-                                    gui_component('MenuItem', jMenuOverlayVr, [], sSubject.Anatomy(iVols(iVol)).Comment, IconLoader.(volIcon), [], @(h,ev)view_mri(sSubject.Anatomy(iVols(iVol)).FileName, filenameRelative));
-                                    gui_component('MenuItem', jMenuOverlay3d, [], sSubject.Anatomy(iVols(iVol)).Comment, IconLoader.(volIcon), [], @(h,ev)view_mri_3d(sSubject.Anatomy(iVols(iVol)).FileName, filenameRelative));
+                                    gui_component('MenuItem', jMenuOverlayVr, [], sSubject.Anatomy(iVols(iVol)).Comment, IconLoader.(volIconOver), [], @(h,ev)view_mri(sSubject.Anatomy(iVols(iVol)).FileName, filenameRelative));
+                                    gui_component('MenuItem', jMenuOverlay3d, [], sSubject.Anatomy(iVols(iVol)).Comment, IconLoader.(volIconOver), [], @(h,ev)view_mri_3d(sSubject.Anatomy(iVols(iVol)).FileName, filenameRelative));
                                 end
                             end
                             AddSeparator(jMenuDisplay);


### PR DESCRIPTION
Based on our discussion in Slack, this PR allows user to choose on which volume they want to overlay rather than just overlaying on the default MRI.
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/77e70a2f-0ddd-4fb0-98f5-cf868eaa1fcb" />

If there is just one other volume other than the default MRI then it shows the option to overlay on default MRI.
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/2696dc27-f39a-44a1-b806-fad9d6c109a5" />

@tmedani 