### PR TITLE
IO: Fix SNIRF badly formatted optode labels

### DIFF
--- a/toolbox/io/in_data_snirf.m
+++ b/toolbox/io/in_data_snirf.m
@@ -132,7 +132,7 @@ function jnirs = detectAndFixError(jnirs)
         jnirs.nirs.probe.detectorLabels = {};
     end
 
-    % Convert cell array to string array 
+    % Convert to string array
     if iscell(jnirs.nirs.probe.sourceLabels)
         jnirs.nirs.probe.sourceLabels = convertCharsToStrings(jnirs.nirs.probe.sourceLabels);
     elseif ischar(jnirs.nirs.probe.sourceLabels)
@@ -140,14 +140,12 @@ function jnirs = detectAndFixError(jnirs)
         jnirs.nirs.probe.sourceLabels = strsplit(convertCharsToStrings(jnirs.nirs.probe.sourceLabels), ' ');
         jnirs.nirs.probe.sourceLabels = jnirs.nirs.probe.sourceLabels(jnirs.nirs.probe.sourceLabels ~= "");
     end
-
     if iscell(jnirs.nirs.probe.detectorLabels)
         jnirs.nirs.probe.detectorLabels = convertCharsToStrings(jnirs.nirs.probe.detectorLabels);
     elseif ischar(jnirs.nirs.probe.detectorLabels)
         jnirs.nirs.probe.detectorLabels(end+1, :) = ' ';
         jnirs.nirs.probe.detectorLabels = strsplit(convertCharsToStrings(jnirs.nirs.probe.detectorLabels), ' ');
         jnirs.nirs.probe.detectorLabels = jnirs.nirs.probe.detectorLabels( jnirs.nirs.probe.detectorLabels ~= "");
-
     end
 
     % Events. Convert cell array to struct array


### PR DESCRIPTION
Fix snirf reading for the following file: https://drive.google.com/file/d/1MPZreFUTrGsQtotEShNcz4P4TRBGSgRB/view?usp=share_link



