### PR TITLE
[mvgc] Add an error when var_to_autocov fails

### DIFF
--- a/toolbox/connectivity/bst_connectivity.m
+++ b/toolbox/connectivity/bst_connectivity.m
@@ -1698,4 +1698,3 @@ function Files = GetFileNames(Files)
         end
     end
 end
-


### PR DESCRIPTION
Prevent brainstorm from saving an empty result from MVGC when var_to_autocov fails

<img width="779" height="322" alt="image" src="https://github.com/user-attachments/assets/0e5b1fe8-2c0e-4e5b-b4ad-c6220425715f" />
