### PR TITLE
[process] Add possibility to use cluster_confirm when there is no cluster

### DIFF
--- a/toolbox/process/panel_process_select.m
+++ b/toolbox/process/panel_process_select.m
@@ -1217,7 +1217,7 @@ function [bstPanel, panelName] = CreatePanel(sFiles, sFiles2, FileTimeVector)
                     jList = GetClusterList(sProcess, optNames{iOpt});
                     % If no clusters
                     if isempty(jList) && strcmp(option.Type, 'cluster')
-                        gui_component('label', jPanelOpt, [], '<HTML>Error: No clusters available in channel file.');
+                        gui_component('label', jPanelOpt, [], '<html><p style="color:red;">Error: No clusters available in channel file.</p></html>');
                     else
                         % Confirm selection
                         if strcmpi(option.Type, 'cluster_confirm')
@@ -1229,10 +1229,10 @@ function [bstPanel, panelName] = CreatePanel(sFiles, sFiles2, FileTimeVector)
                             jCheckCluster = gui_component('checkbox', jPanelOpt, [], strCheck);
                             
                             if ~isempty(jList)
-                            jCheckCluster.setSelected(1)
-                            jList.setEnabled(1);
+                                jCheckCluster.setSelected(1)
+                                jList.setEnabled(1);
                                 java_setcb(jCheckCluster, 'ActionPerformedCallback', @(h,ev)Cluster_ValueChangedCallback(iProcess, optNames{iOpt}, jList, jCheckCluster, []));
-                        else
+                            else
                                 jList = GetEmptyClusterList(sProcess, optNames{iOpt});
                                 jCheckCluster.setSelected(0)
                                 jCheckCluster.setEnabled(0);
@@ -1256,7 +1256,7 @@ function [bstPanel, panelName] = CreatePanel(sFiles, sFiles2, FileTimeVector)
                     [AtlasList, iAtlasList] = GetAtlasList(sProcess, optNames{iOpt});
                     % If no scouts are available
                     if isempty(AtlasList)
-                        gui_component('label', jPanelOpt, [], '<HTML>No scouts available.');
+                        gui_component('label', jPanelOpt, [], '<html><p style="color:red;">Error: No scouts available.</p></html>');
                     else
                         % Create list
                         jList = java_create('javax.swing.JList');


### PR DESCRIPTION
Hello, 

The goal of this PR is to be able to use process with cluster_confirm option even when no cluster are present in the file. (option of using cluster being unavailable). I also changed the color of the error to red, when using cluster, so it's a bit more visible.

A similar thing could probably be done for scout_confirm, but it's more rare to have no scout. :) 



**Before:**

<img width="484" height="522" alt="image" src="https://github.com/user-attachments/assets/273c471a-0b8e-48d2-81f1-ef249943d72e" />


**After:**

_Cluster confirm:_
<img width="484" height="624" alt="image" src="https://github.com/user-attachments/assets/a67c256f-0ab6-4ca1-8c43-48715c61d104" />

_Cluster:_ 
<img width="484" height="522" alt="image" src="https://github.com/user-attachments/assets/4129637b-a2f2-4aca-bc27-66a21980092a" />
