### PR TITLE
[align sensors] Select study when applying transformation to other study

### DIFF
--- a/toolbox/sensors/channel_align_manual.m
+++ b/toolbox/sensors/channel_align_manual.m
@@ -997,6 +997,7 @@ function CopyToOtherFolders(ChannelMatSrc, iStudySrc, Transf, iChannels)
     end
     % Apply transformation
     if ~isempty(ChannelFiles)
+        StudyNames = regexprep(StudyNames, '^@raw', '[RAW] ');
         isFileSelected = java_dialog('checkbox', 'Select the folders for the channel files to apply the same transformation:', ...
                                      'Align sensors', [], StudyNames, ones(length(StudyNames), 1));
         if ~any(isFileSelected)


### PR DESCRIPTION
When doing the co-registration and brainstorm, ask me if i want to apply co-registration to other sensors in the database, i am always scared as it doesn't tell me what file will be modified. (especially when having multiple sessions within the same subject). 

So now brainstorm ask which file should be modified so the user can check.