### PR TITLE
Use mean instead of min for box tetrahedral size

### DIFF
--- a/toolbox/anatomy/tess_generate_primitive.m
+++ b/toolbox/anatomy/tess_generate_primitive.m
@@ -178,7 +178,7 @@ switch lower(primitiveShape)
         % Processing
         p0 = [r(1), 0, 0];        % coordinates (x,y,z) for one end of the box diagonal
         p1 = [0, r(2), r(3)];     % coordinates (x,y,z) for the other end of the box diagonal
-        tsize = min([p0, p1])/10; % maximum volume of the tetrahedral elements
+        tsize = mean([p0, p1])/10; % maximum volume of the tetrahedral elements
         [vert,face] = meshabox(p0,p1,tsize);
         % Move to the new center
         vert = vert + c0;


### PR DESCRIPTION
Replaces the use of min with mean when calculating the maximum volume of tetrahedral elements for box primitives. This change may result in more consistent element sizing and avoid tsize = 0 (not realistic and leads to an infinite computation in line 184).