### PR TITLE
Add directional sensitivity selection

### DIFF
--- a/toolbox/gui/view_leadfield_sensitivity.m
+++ b/toolbox/gui/view_leadfield_sensitivity.m
@@ -481,7 +481,7 @@ panel_surface('SetSizeThreshold', hFig, 1, 1);
         elseif isAvgRef
             strTitle = [strTarget '  |  Average reference'];
         else
-            strTitle = [strTarget , sprintf('  |  Reference #%d/%d : %s (green)', iRef, length(Channels), Channels(iRef).Name)];
+            strTitle = [strTarget, sprintf('  |  Reference #%d/%d : %s (green)', iRef, length(Channels), Channels(iRef).Name)];
         end
         if (iChannel == 1) && (length(Channels) > 1)
             strTitle = [strTitle, 10 '[Press arrows for next/previous channel (or H for help)]'];


### PR DESCRIPTION
Introduce leadfield sensitivity to be computed for all directions or per-axis (X/Y/Z).
 Add keyboard handling: when viewing the sum of channels (iChannel==0).
- Compute normLF differently based on iSensitivity (full vector norm or sum of absolute components for the chosen axis).
- Update legend text to reflect the selected sensitivity mode and adjust minor ordering of calls.