### PR TITLE
Bst support container

### DIFF
--- a/toolbox/containers/bst_check_container.m
+++ b/toolbox/containers/bst_check_container.m
@@ -23,6 +23,7 @@ function [runtime, image, imageLocal] = bst_check_container(image)
 % NOTES:
 %   - This function may display GUI dialogs and download container images
 %   - No container is executed by this function
+%   current duneuro image: 'ghcr.io/maltehoel/duneuro_in_docker_testing:wip';   [for testing]   
 %
 % TUTORIAL:
 %   https://neuroimage.usc.edu/brainstorm/Tutorials/bstContainers


### PR DESCRIPTION
This PR introduces an initial and experimental interface to explore the use
of containerized external tools from Brainstorm.

Main contributions:
- Add a generic utility function (bst_check_container) to detect and validate
  container runtimes (Docker, Podman, Apptainer/Singularity)
- Provide runtime usability checks (eg. Docker daemon running)
- Add Brainstorm GUI dialogs to guide users when installation or action is required
- Support automatic detection and optional download of container images
- Introduce a dedicated toolbox folder (toolbox/containers) for container-related utilities
- Add preliminary user documentation describing how containers can be used with Brainstorm

This work is intended as a first step and proof-of-concept toward integrating
containers as a supported mechanism to run external tools (eg. duneuro) from
Brainstorm, without requiring users to manually install complex dependencies.

The current implementation is deliberately minimal and meant to enable
discussion, testing, and refinement. In particular, the long-term integration
of container-based tools may be better handled through the Brainstorm Plugin
Manager, rather than via standalone utilities, and this PR is meant to help
inform that design choice.

No existing behavior is modified, and no containers are executed directly
by this current change.
