### PR TITLE
[MEM] Decouple process_inverse_2018 from process_inverse_mem

### DIFF
--- a/toolbox/inverse/panel_inverse_2018.m
+++ b/toolbox/inverse/panel_inverse_2018.m
@@ -606,7 +606,7 @@ function [bstPanelNew, panelName] = CreatePanel(Modalities, isShared, HeadModelT
             Comment = GetMethodComment(InverseMethod, InverseMeasure);
         else
             if ~isempty(jRadioMethodMem) && jRadioMethodMem.isSelected()
-                Comment = 'MEM: ';
+                Comment = 'MEM';
             end
         end
         % Add modality comment

--- a/toolbox/process/functions/process_inverse_2018.m
+++ b/toolbox/process/functions/process_inverse_2018.m
@@ -273,6 +273,13 @@ function [OutputFiles, errMessage] = Compute(iStudies, iDatas, OPTIONS)
             if ~isInstalled
                 return;
             end
+
+            % For new version of BEst (>= 3.2.0), delegate computation to  process_inverse_mem
+            if bst_plugin('CompareVersions',  be_versions() , '3.2.0')  >= 0
+                [OutputFiles, errMessage] = process_inverse_mem('Compute', iStudies, iDatas, OPTIONS);
+                return
+            end
+
             % Default options
             MethodOptions = be_main();
             % Interface to edit options


### PR DESCRIPTION
The goal of this PR is to better separate the code between MEM (process_inverse_MEM and process_inverse_2018). After version 3.2.0, all the computation is done inside process_inverse_MEM.


After version 3.2.0,  all the main code of MEM resides in process_inverse_mem without a call to  process_inverse_2018.

This is helpful so that:
- process_inverse_mem is standalone and easy to read/modify
- It is easier to keep the best package and process_inverse_2018 in sync


