### PR TITLE
Bugfix `Digitize panel 2024`: `Digitize.iPoint` should point to end of list

### DIFF
--- a/toolbox/sensors/panel_digitize_2024.m
+++ b/toolbox/sensors/panel_digitize_2024.m
@@ -831,7 +831,6 @@ function EEGAutoDetectElectrodes()
     % Enable Random button
     ctrl.jButtonRandomHeadPts.setEnabled(1);
     bst_progress('stop');
-
 end
 
 %% ===== MANUAL COLLECT CALLBACK ======

--- a/toolbox/sensors/panel_digitize_2024.m
+++ b/toolbox/sensors/panel_digitize_2024.m
@@ -803,7 +803,7 @@ function EEGAutoDetectElectrodes()
     [sSurf, capImg2d, capCenters2d, capRadii2d] = channel_detect_eegcap_auto('FindElectrodesEegCap', sSurf);
 
     % Get current montage
-    curMontage = GetCurrentMontage();
+    [curMontage, nEEG] = GetCurrentMontage();
 
     % Get acquired EEG points
     iEeg = and(cellfun(@(x) ~isempty(regexp(x, 'EEG', 'match')), {Digitize.Points.Type}), ~cellfun(@isempty, {Digitize.Points.Loc}));
@@ -822,6 +822,8 @@ function EEGAutoDetectElectrodes()
         PlotCoordinate();
     end
 
+    % All EEG points collected, global should point to end of list
+    Digitize.iPoint = nEEG + (numel(Digitize.Options.Fids) * Digitize.Options.nFidSets);
     UpdateList();
     % Change delete button label and callback such that we can delete the last point
     java_setcb(ctrl.jButtonDeletePoint, 'ActionPerformedCallback', @(h,ev)bst_call(@DeletePoint_Callback));

--- a/toolbox/sensors/panel_digitize_2024.m
+++ b/toolbox/sensors/panel_digitize_2024.m
@@ -1068,7 +1068,7 @@ function PlotCoordinate(isAdd)
             % Overwrite empty channel created by template.
             iP = 1;
         else
-            if Digitize.isEditPts
+            if Digitize.isEditPts || ~isAdd
                 iP = find(strcmpi({GlobalData.DataSet(Digitize.iDS).Channel.Name}, Digitize.Points(Digitize.iPoint).Label), 1);
             else
                 iP = numel(GlobalData.DataSet(Digitize.iDS).Channel) + 1;
@@ -1085,7 +1085,6 @@ function PlotCoordinate(isAdd)
                     % Keep point in list, but remove location 
                     GlobalData.DataSet(Digitize.iDS).Channel(iP).Loc = [];
                 else  % Remove last point
-                    iP = iP - 1;
                     GlobalData.DataSet(Digitize.iDS).Channel(iP) = [];
                 end
             end


### PR DESCRIPTION
After automatically getting all the EEG points, the `Digitize.iPoint` should point to end of list.

Introduced in https://github.com/brainstorm-tools/brainstorm3/commit/6c646d2248c877a481dcf1e7308ff5287992a676

**Steps to reproduce:**
This was particularly observed when collecting `Random` points for the `WearableSensing DSI-24` EEG headset **(only in the 2024 panel)**.
1. Get all the EEG electrodes by running `Auto` (3D model available in the [tutorial](https://neuroimage.usc.edu/brainstorm/Tutorials/TutDigitize3dScanner#Example_dataset) dataset).
2. Click `File -> Save in database and exit`. The channel file shows the correct (22) electrodes.
3. Repeat step-1.
4. Click on `Random` to collect the 150 headshape points. 
5. Click `File -> Save in database and exit`. Channel file just shows 3 electrodes.
<img width="500" height="90" alt="Screenshot 2026-03-24 150159" src="https://github.com/user-attachments/assets/75e8de36-5cbd-4669-be24-933c1020f461" />

