### PR TITLE
Bugfix: `TPM.nii` lookup path while skull stripping

### DIFF
--- a/toolbox/anatomy/mri_skullstrip.m
+++ b/toolbox/anatomy/mri_skullstrip.m
@@ -163,7 +163,7 @@ switch lower(Method)
         % Reset matlabbatch to start fresh
         clear matlabbatch;
         % Get the TPM atlas
-        TpmFile = bst_get('SpmTpmAtlas', 'SPM');
+        TpmFile = bst_get('SpmTpmAtlas');
         % Get the SPM tissue segments
         [~, TpmFiles] = mri_normalize_segment(sMriRef, TpmFile);
         % Compute brain mask: union(GM, WM, CSF)


### PR DESCRIPTION
This PR addresses the skull-stripping issue reported on the forum::
https://neuroimage.usc.edu/forums/t/spm12-skull-stripping-tissue-probability-map-error/56326

The problem mainly affects the standalone Brainstorm build when running skull-stripping and SPM12 is not installed in the `plugins` folder. In the current implementation, calling `bst_get('SpmTpmAtlas', 'SPM')` restricts the search to the SPM plugin location. If `TPM.nii` is not found there, the function returns empty, which causes skull stripping to fail.

This change replaces that call with `bst_get('SpmTpmAtlas')`, which searches across all valid Brainstorm-accessible locations for `TPM.nii`. As a result, Brainstorm can resolve the template more robustly in standalone setups and avoid failures when the SPM plugin folder is not present.

I have verified the standalone build at my end.