### PR TITLE
Process: verify that folder exist before using `cd`

### DIFF
--- a/toolbox/process/panel_process_select.m
+++ b/toolbox/process/panel_process_select.m
@@ -3063,7 +3063,7 @@ function ParseProcessFolder(isForced) %#ok<DEFNU>
             end
         end
         % Restore previous dir
-        if isChangeDir
+        if isChangeDir && exist(curDir, "dir")
             cd(curDir);
         end
         % Report error and skip process

--- a/toolbox/process/panel_process_select.m
+++ b/toolbox/process/panel_process_select.m
@@ -3063,7 +3063,7 @@ function ParseProcessFolder(isForced) %#ok<DEFNU>
             end
         end
         % Restore previous dir
-        if isChangeDir && exist(curDir, "dir")
+        if isChangeDir && exist(curDir, 'dir')
             cd(curDir);
         end
         % Report error and skip process


### PR DESCRIPTION
This is a minor fix.  I had the error after deleting a plugin manually (without going from the brainstorm interface): 

``` 
BST> Invalid Plug-in function: "/Users/edelaire1/.brainstorm/plugins/brainentropy/best-brainstorm-master/processes/process_inverse_mem.m"
     Unable to open file
Error using cd
Unable to change current folder to '/Users/edelaire1/.brainstorm/plugins/nirs-dpf' (Name is
nonexistent or not a folder).

Error in panel_process_select>ParseProcessFolder (line 3067)
            cd(curDir);

Error in panel_process_select (line 32)
eval(macro_method);

Error in bst_startup (line 496)
panel_process_select('ParseProcessFolder', 1);

Error in brainstorm (line 134)
        bst_startup(BrainstormHomeDir, 1, BrainstormDbDir, TemplateName);
```

