### PR TITLE
Headmodel: Allow to display NIRS volume head model

### DIFF
--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1460,7 +1460,13 @@ switch (lower(action))
                         iNIRS      = good_channel(ChannelMat.Channel, [], 'NIRS');
                         Groups     = unique({ChannelMat.Channel(iNIRS).Group});
                         for iGroup = 1:length(Groups)
-                            gui_component('MenuItem', jPopup, [], sprintf('View NIRS (%s) leadfield sensitivity', Groups{iGroup}), IconLoader.ICON_ANATOMY, [], @(h,ev)bst_call(@view_leadfield_sensitivity, filenameRelative, 'NIRS', 'Surface', Groups{iGroup}));
+                            if strcmpi(sStudy.HeadModel(iHeadModel).HeadModelType, 'volume')
+                                gui_component('MenuItem', jPopup, [], sprintf('View NIRS (%s) leadfield sensitivity (isosurface)', Groups{iGroup}), IconLoader.ICON_ANATOMY, [], @(h,ev)bst_call(@view_leadfield_sensitivity, filenameRelative, 'NIRS', 'Isosurface',  Groups{iGroup}));
+                                gui_component('MenuItem', jPopup, [], sprintf('View NIRS (%s) leadfield sensitivity (MRI 3D)', Groups{iGroup}), IconLoader.ICON_ANATOMY, [], @(h,ev)bst_call(@view_leadfield_sensitivity, filenameRelative, 'NIRS', 'Mri3D',  Groups{iGroup}));
+                                gui_component('MenuItem', jPopup, [], sprintf('View NIRS (%s) leadfield sensitivity (MRI Viewer)', Groups{iGroup}), IconLoader.ICON_ANATOMY, [], @(h,ev)bst_call(@view_leadfield_sensitivity, filenameRelative, 'NIRS', 'MriViewer', Groups{iGroup}));
+                            elseif strcmpi(sStudy.HeadModel(iHeadModel).HeadModelType, 'surface')
+                                gui_component('MenuItem', jPopup, [], sprintf('View NIRS (%s) leadfield sensitivity', Groups{iGroup}), IconLoader.ICON_ANATOMY, [], @(h,ev)bst_call(@view_leadfield_sensitivity, filenameRelative, 'NIRS', 'Surface', Groups{iGroup}));
+                            end
                         end
                     end
                 end


### PR DESCRIPTION
I recently started playing with volumetric nirs head models: https://github.com/Edouard2laire/nirs-dpf/blob/main/process/process_compute_head_model_volume.m 


This PR allows to visualize the resulting head model in Brainstorm. It's actually very nice that the visualization automatically works well without adjustment. 


For example here, using the isosurface that show the 'famous' banana shape: 
<img width="1103" height="861" alt="image" src="https://github.com/user-attachments/assets/25cc05c1-8987-45e7-858a-ce9aeecdfe71" />

