### PR TITLE
[1/3] Fastgraph: Customize SPES blocks (Nihon Kohden)

### DIFF
--- a/toolbox/process/functions/process_customize_spes_nk.m
+++ b/toolbox/process/functions/process_customize_spes_nk.m
@@ -1,0 +1,176 @@
+function varargout = process_customize_spes_nk( varargin )
+% PROCESS_CUSTOMIZE_SPES_NK: Customize SPES blocks imported from 
+% Nihon Kohden recordings. This process can rename stimulation start/stop labels,
+% rename the stimulation trigger event label and optionally create separate 
+% 'ODD' and 'EVEN' events for alternating monophasic stimulation pulses.
+%
+% USAGE:
+%   OutputFiles = process_customize_spes_nk('Run', sProcess, sInputs)
+
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c) University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Chinmay Chinara, 2026
+%          John C. Mosher, 2026
+
+eval(macro_method);
+end
+
+%% ===== GET DESCRIPTION =====
+function sProcess = GetDescription() %#ok<DEFNU>
+% Description the process
+sProcess.Comment     = 'Customize SPES blocks (Nihon Kohden)';
+sProcess.Category    = 'Custom';
+sProcess.SubGroup    = 'Stimulation';
+sProcess.Index       = 901;
+% Definition of the input accepted by this process
+sProcess.InputTypes  = {'data'};
+sProcess.OutputTypes = {'data'};
+sProcess.nInputs     = 1;
+sProcess.nMinFiles   = 1;
+% Update 'Stim Start' label in stimulation block name and events
+sProcess.options.label1.Comment = '<HTML><I><FONT color="#777777">Update ''Stim Start'' label in stimulation block name and events</FONT></I>';
+sProcess.options.label1.Type    = 'label';
+sProcess.options.stimstartlabel.Comment = 'Update ''Stim Start'' label (empty=No change): ';
+sProcess.options.stimstartlabel.Type    = 'text';
+sProcess.options.stimstartlabel.Value   = 'SB';
+% Update 'Stim Stop' label in stimulation block events
+sProcess.options.label2.Comment = '<HTML><I><FONT color="#777777">Update ''Stim Stop'' label in stimulation block events</FONT></I>';
+sProcess.options.label2.Type    = 'label';
+sProcess.options.stimstoplabel.Comment = 'Update ''Stim Stop'' label (empty=No change): ';
+sProcess.options.stimstoplabel.Type    = 'text';
+sProcess.options.stimstoplabel.Value   = 'SE';
+% Stimulation trigger event label
+sProcess.options.stimeventlabel.Comment = 'Stimulation trigger event label: ';
+sProcess.options.stimeventlabel.Type    = 'text';
+sProcess.options.stimeventlabel.Value   = 'DC10';
+% Update stimulation trigger event label
+sProcess.options.newstimeventlabel.Comment = 'Update stimulation trigger event label (empty=No change): ';
+sProcess.options.newstimeventlabel.Type    = 'text';
+sProcess.options.newstimeventlabel.Value   = 'STIM';
+% Add 'ODD' and 'EVEN' events to stimulation blocks
+sProcess.options.label3.Comment = '<HTML><I><FONT color="#777777">Add alternating monophasic stimulation trigger events</FONT></I>';
+sProcess.options.label3.Type    = 'label';
+sProcess.options.addoddevenevents.Comment = 'Add ''ODD'' and ''EVEN'' events';
+sProcess.options.addoddevenevents.Type    = 'checkbox';
+sProcess.options.addoddevenevents.Value   = 1;
+end
+
+%% ===== FORMAT COMMENT =====
+function Comment = FormatComment(sProcess) %#ok<DEFNU>
+    Comment = sProcess.Comment;
+end
+
+%% ===== RUN =====
+function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
+    % Initialize output
+    OutputFiles = {};
+
+    % Get proccess options
+    StimStartLabel    = sProcess.options.stimstartlabel.Value;
+    StimStopLabel     = sProcess.options.stimstoplabel.Value;
+    StimEventLabel    = sProcess.options.stimeventlabel.Value;
+    NewStimEventLabel = sProcess.options.newstimeventlabel.Value;
+    AddOddEvenEvents  = sProcess.options.addoddevenevents.Value;
+     
+    % Check whether the user requested a custom label
+    % If empty, keep the default Nihon Kohden label
+    isUpdateStimStartLabel = ~isempty(StimStartLabel);
+    if ~isUpdateStimStartLabel
+        StimStartLabel = 'Stim Start';
+    end
+    isUpdateStimStopLabel  = ~isempty(StimStopLabel);
+    if ~isUpdateStimStopLabel
+        StimStopLabel = 'Stim Stop';
+    end   
+    
+    % Process each SPES block
+    for iFile = 1:length(sInputs)
+        EventMat =  in_bst_data(sInputs(iFile).FileName, 'Events');
+        
+        % ===== Update 'Stim Start' label (comment and event) =====
+        if isUpdateStimStartLabel           
+            % Update comment
+            newTag = strrep(sInputs(iFile).Comment, 'Stim Start', StimStartLabel);
+            sInputs(iFile) = bst_process('CallProcess', 'process_set_comment', sInputs(iFile), [], ...
+                'tag',           newTag, ...
+                'isindex',       0);
+            % Update event
+            iStimStart = find(strncmp({EventMat.Events.label}, 'Stim Start', 10));
+            srcTag = EventMat.Events(iStimStart).label;
+            destTag = strrep(srcTag, 'Stim Start', StimStartLabel);
+            bst_process('CallProcess', 'process_evt_rename', sInputs(iFile), [], ...
+                'src',  srcTag, ...
+                'dest', destTag);
+        end
+        
+        % ===== Update 'Stim Stop' label (only event) =====
+        if isUpdateStimStopLabel
+            % Update event
+            iStimStop  = find(strncmp({EventMat.Events.label}, 'Stim Stop', 9));
+            srcTag = EventMat.Events(iStimStop).label;
+            destTag = strrep(srcTag, 'Stim Stop', StimStopLabel);
+            bst_process('CallProcess', 'process_evt_rename', sInputs(iFile), [], ...
+                'src',  srcTag, ...
+                'dest', destTag);
+        end
+        
+        % ===== Add stimulation site info to the stimulation trigger event label =====
+        % Extract stimulation site information (e.g. 'SB O6-O7 4.0 (#1)' > 'O6-O7 4.0 #1')
+        tokens = regexp(sInputs(iFile).Comment, sprintf('^%s\\s+(.*?)\\s+\\((#\\d+)\\)$', StimStartLabel), 'tokens', 'once');
+        stimSiteInfo = sprintf('%s %s', tokens{1}, tokens{2});
+        % Append stimulation site information to the trigger event label        
+        if ~isempty(NewStimEventLabel)
+            % e.g. 'STIM' > 'STIM O6-O7 4.0 #1'
+            destTag = sprintf('%s %s', NewStimEventLabel, stimSiteInfo);
+        else
+            % e.g. 'DC10' > 'DC10 O6-O7 4.0 #1'
+            destTag = sprintf('%s %s', StimEventLabel, stimSiteInfo);
+        end
+        % Process: Rename event
+        bst_process('CallProcess', 'process_evt_rename', sInputs(iFile), [], ...
+            'src',  StimEventLabel, ...
+            'dest', destTag);
+        
+        % ===== Add alternating monophasic events to stimulation blocks ('ODD' and 'EVEN') =====
+        if AddOddEvenEvents                       
+            EventMat = in_bst_data(sInputs(iFile).FileName, 'Events');
+            % Update color for the stimulation trigger event
+            EventMat.Events(end).color = [0.8, 0.8, 0.8]; % Gray
+            % Create 'ODD' event from odd-numbered stimulation trigger pulses
+            sEventOdd = db_template('event');
+            sEventOdd.label  = sprintf('ODD %s', stimSiteInfo);
+            sEventOdd.times = EventMat.Events(end).times(1:2:end);
+            sEventOdd.epochs = EventMat.Events(end).epochs(1:2:end);
+            sEventOdd.color = [0.9, 0, 0]; % Red
+            EventMat.Events(end+1) = sEventOdd;
+            % Create 'EVEN' event from even-numbered stimulation trigger pulses
+            sEventEven = db_template('event');
+            sEventEven.label  = sprintf('EVEN %s', stimSiteInfo);
+            sEventEven.times = EventMat.Events(end-1).times(2:2:end);
+            sEventEven.epochs = EventMat.Events(end-1).epochs(2:2:end);
+            sEventEven.color = [ 0, 0, 0.9]; % Blue
+            EventMat.Events(end+1) = sEventEven;            
+            % Save changes
+            bst_save(file_fullpath(sInputs(iFile).FileName), EventMat, 'v7', 1);
+        end
+
+        % Add the modified file to the output list
+        OutputFiles{end+1} = sInputs(iFile).FileName;
+    end
+end


### PR DESCRIPTION
Based on our discussion in PR https://github.com/brainstorm-tools/brainstorm3/pull/911.

This PR is the first part required for [Fastgraph](https://pubmed.ncbi.nlm.nih.gov/32086098/). It involves customizing the imported SPES blocks.

# Customize SPES blocks (Nihon Kohden)
Linked to `process_customize_spes_nk`.

## The GUI
<img width="342" height="300" alt="image" src="https://github.com/user-attachments/assets/8b4c8044-caa3-49a3-bc86-d10d77bdc1db" />

## Inputs
- `Update 'Stim Start' label` and `Update 'Stim Stop' label`: Gives an option to the user to rename the `Stim Start` and `Stim Stop` labels in the imported NK events if they want to. In this case, we are shortening the labels to `SB` and `SE` respectively. Came as a requirement from UTH as the channel names can get very long, thereby making the overall stimulation event label very long.
- `Stimulation trigger event label`: The stimulation trigger channel in the recordings (here, `DC10`)
- `Update stimulation trigger event label`: Gives an option to the user to rename the stimulation trigger event label (here `DC10`) in the imported NK events if they want to (here, change to `STIM`). Came from UTH, but maybe some other centers might have their own way of naming, so good to have this option.
- `Add ''ODD'' and ''EVEN'' events`: If we check this, then it creates alternating monophasic stimulations from the original stimulation event. This is useful in downstream analysis as the odd and even pulses may produce different responses. We will be using this approach for plotting Fastgraph (3rd PR).

## Steps to use
1. Load in the updated [example test protocol](https://drive.google.com/file/d/1FRylzuAFLCMs584ol9011KdNx3p5XGRE/view?usp=sharing) [ **NOTE:** This preprocessed protocol involves running CAT12 segmentation to get all the anatomical information, the implantation done using Brainstorm, and then loading in the raw data and adding the locations from the implantation to it. These steps will be part of the main tutorial and the tutorial script].

2. Detect all the stimulation triggers (here, `DC10`). Drag the `Baseline > Link to raw file` to the `Process1` tab and clock on `Run > Events > Detect analog triggers`. Use values in the GUI as under and click `Run`.
<img width="336" height="457" alt="image" src="https://github.com/user-attachments/assets/26aa7959-8472-4086-bb4c-1a93c21b7538" /><br>

3. We then get the `DC10` trigger events added to the raw data as under.
<img width="384" height="280" alt="Screenshot 2026-04-27 192319" src="https://github.com/user-attachments/assets/51fa5930-6241-4f6c-bee3-3f1887b32acd" /><br>

4. Drag the `Baseline > Link to raw file` to the `Process1` tab and click on `Run > Import > Import recordings > Import MEG/EEG: Events`. Use values in the GUI as under and click `Run`. For this sample data, we will be importing all `Stim Start` events with epoch of 40s (30s block with a buffer of 5s around the stimulation block so that it contains the full stimulation segment plus some context before and after it). 
<img width="338" height="475" alt="image" src="https://github.com/user-attachments/assets/bf725633-3bed-44f6-b919-cd2170c2673a" /><br>

5. Then we get all the desired stimulation blocks imported as under.
 <img width="383" height="260" alt="image" src="https://github.com/user-attachments/assets/2951f2e3-a397-4660-a810-0a1f49dab8ee" /><br>

6. Next step is to customize the stimulation block names and event labels based on how the user wants it. Drag all the stimulation blocks to `Process1` tab and click on `Run > Stimulation > Customize SPES blocks (Nihon Kohden)`. Use values as in `the GUI` section above and click `Run`. Each of the stimulation blocks get updated as under.
<img width="383" height="260" alt="image" src="https://github.com/user-attachments/assets/42ee1a1e-e6b4-481e-8aee-7920b9db381b" /><br>

**NOTE:** `STIM`, `ODD` and `EVEN` event labels are appended with the stim site information (e.g. `A11-A12 4 #1` in the figure above where  `A11-A12 4` means stimulation was delivered between contacts A11 and A12 at 4 milliamps and the `#1` means the first session. You can see in the image there is also a 2nd session which is the block  `SB A11-A12 4 (#2)`. Analyzing each of these sessions separately is required during the downstream analysis which will be clearer in the 3rd PR.

## Associated PRs
 1. https://github.com/brainstorm-tools/brainstorm3/pull/912
 2.  Plot Fastgraphs (3rd PR) - **TO BE ADDED**

@jcmosher  @Nastaranlotfi  @yashvakilna 