### PR TITLE
WarningFix: Index should be integers

### DIFF
--- a/toolbox/process/functions/process_evt_detect_analog.m
+++ b/toolbox/process/functions/process_evt_detect_analog.m
@@ -372,15 +372,13 @@ function evt = Compute(F, TimeVector, EventSamps, OPTIONS, Fmask)
 
     % Standard deviation
     if ~isempty(Fmask)
-        Fsig = F(Fmask);
-        % ignore the first and last 5% of the signal (incase of artifacts)
-        Fsig = Fsig(length(Fsig)*0.05:end-(length(Fsig)*0.05));
-        stdF = std(Fsig);
+        Fsig = F(Fmask);        
     else
         Fsig = F;
-        Fsig = Fsig(length(Fsig)*0.05:end-(length(Fsig)*0.05));
-        stdF = std(Fsig);
     end
+    % Ignore the first and last 5% of the signal (incase of artifacts)
+    Fsig = Fsig(round(length(Fsig)*0.05):end-round(length(Fsig)*0.05));
+    stdF = std(Fsig);
     
     % ===== DETERMINE THRESHOLD =====
     % Theshold, in number of times the std


### PR DESCRIPTION
Observed during `Detect analog triggers`. Get the warning as under.

<img width="622" height="214" alt="Screenshot 2026-04-27 201949" src="https://github.com/user-attachments/assets/8da1b519-d5d9-44f4-af63-af27f1ea9363" />

