### PR TITLE
[docker] Improve image identification (?)

### DIFF
--- a/toolbox/core/bst_containers.m
+++ b/toolbox/core/bst_containers.m
@@ -185,6 +185,19 @@ function [errMsg, imageSha] = ImportImage(imageSource, imageTag)
         case 'docker'
             switch imageType
                 case 'reference'
+                    [status, cmdout] = system([' docker manifest inspect ' imageSource]);
+                    if status == 0
+                        image_info = jsondecode(cmdout);
+                        image_size_go = sum([image_info.layers.size]) / 1e9;
+                        % Ask for confirmation
+                        if ~java_dialog('confirm', sprintf('Brainstorm will download %s of size %.2f Go. Do you want to continue ?', imageSource, round(image_size_go, 2)),  'Download docker image')
+                            return;
+                        end
+                    else
+                        errMsg = 'Unable to get image information.';
+                        return;
+                    end
+
                     [status, cmdout] = system(['docker pull ' imageSource]);
                     if status == 0
                         % If new or existent image, SHA256 is returned in output

--- a/toolbox/core/bst_containers.m
+++ b/toolbox/core/bst_containers.m
@@ -188,7 +188,10 @@ function [errMsg, imageSha] = ImportImage(imageSource, imageTag)
                     [status, cmdout] = system(['docker pull ' imageSource]);
                     if status == 0
                         % If new or existent image, SHA256 is returned in output
-                        imageSha = regexp(cmdout, 'sha256:[a-f0-9]+', 'match', 'once');
+                        % imageSha = regexp(cmdout, 'sha256:[a-f0-9]+', 'match', 'once');
+                            [~, imageListNew] = GetImages();
+                            image_name = strsplit(imageSource, '/');
+                            imageSha = imageListNew{strcmpi(imageListNew(:,1), image_name{end}), 2};
                     end
 
                 case 'file'

--- a/toolbox/core/bst_containers.m
+++ b/toolbox/core/bst_containers.m
@@ -204,7 +204,7 @@ function [errMsg, imageSha] = ImportImage(imageSource, imageTag)
                         % imageSha = regexp(cmdout, 'sha256:[a-f0-9]+', 'match', 'once');
                             [~, imageListNew] = GetImages();
                             image_name = strsplit(imageSource, '/');
-                            imageSha = imageListNew{strcmpi(imageListNew(:,1), image_name{end}), 2};
+                            imageSha = imageListNew{contains(imageListNew(:,1), image_name{end}), 2};
                     end
 
                 case 'file'


### PR DESCRIPTION
it seems that the sha returned during pull doesnt correspond to the ID of the docker image that needs to be used later. 