### PR TITLE
[simulate reccording] Allow to choose the channel used for simulation

### DIFF
--- a/toolbox/math/bst_simulation.m
+++ b/toolbox/math/bst_simulation.m
@@ -9,7 +9,7 @@ function newDataFile = bst_simulation(ResultsFile, iVertices, Comment, isVolumeA
 %     - ResultsFile : Full or relative path to a brainstorm sources file
 %     - iVertices   : Indices of the sources to use to simulate the recordings
 %     - Comment     : Comment inserted in the created file
-%     - iStudy      : Output study
+%     - iStudy      : Study that contains the headmodel (fwd model) to be used
 % OUTPUT:
 %     - newDataFile : Full path to the simulated recordings file created and saved in the database
 
@@ -38,9 +38,8 @@ global GlobalData;
 
 % If target study is empty, we use the study of the source map
 if (nargin < 5) || isempty(iStudy)
-    [sStudy, iStudy] = bst_get('ResultsFile', ResultsFile);
+    [~, iStudy] = bst_get('ResultsFile', ResultsFile);
 end
-
 % Is iVertices obtained on a volume atlas
 if (nargin < 4) || isempty(isVolumeAtlas)
     isVolumeAtlas = 0;
@@ -236,10 +235,8 @@ bst_save(newDataFile, DataMat, 'v6');
 % ===== UPDATE DATABASE =====
 % Unloading dataset
 bst_memory('UnloadDataSets', iDS);
-% Get study
-[sStudy, iStudy, iResult] = bst_get('ResultsFile', ResultsFile);
 % Add to database
-[sStudy, iNewData] = db_add_data(iStudy, newDataFile, DataMat);
+[~, iNewData] = db_add_data(iStudy, newDataFile, DataMat);
 % Update links
 db_links('Study', iStudy);
 % Update display

--- a/toolbox/math/bst_simulation.m
+++ b/toolbox/math/bst_simulation.m
@@ -9,7 +9,7 @@ function newDataFile = bst_simulation(ResultsFile, iVertices, Comment, isVolumeA
 %     - ResultsFile : Full or relative path to a brainstorm sources file
 %     - iVertices   : Indices of the sources to use to simulate the recordings
 %     - Comment     : Comment inserted in the created file
-%     - iStudy      : Study that contains the headmodel (fwd model) to be used
+%     - iStudy      : Study with headmodel (fwd model) to be used. Default, use ResultsFile study
 % OUTPUT:
 %     - newDataFile : Full path to the simulated recordings file created and saved in the database
 
@@ -124,7 +124,6 @@ end
 
 % ===== LOAD GAIN MATRIX =====
 bst_progress('text', 'Loading head model...');
-
 % Get default headmodel for this study
 sHeadModel = bst_get('HeadModelForStudy', iStudy);
 if isempty(sHeadModel)

--- a/toolbox/math/bst_simulation.m
+++ b/toolbox/math/bst_simulation.m
@@ -1,7 +1,7 @@
-function newDataFile = bst_simulation(ResultsFile, iVertices, Comment, isVolumeAtlas)
+function newDataFile = bst_simulation(ResultsFile, iVertices, Comment, isVolumeAtlas, iStudy)
 % BST_SIMULATION:  Create a pseudo-recordings file by multiplying the forward model with the sources.
 %
-% USAGE:  newDataFile = bst_simulation(ResultsFile, iVertices, Comment='', isVolumeAtlas=0)
+% USAGE:  newDataFile = bst_simulation(ResultsFile, iVertices, Comment='', isVolumeAtlas=0, iStudy = [])
 %         newDataFile = bst_simulation(ResultsFile, iVertices)  : Use only the selected vertices
 %         newDataFile = bst_simulation(ResultsFile)             : Use all the vertices
 %
@@ -9,6 +9,7 @@ function newDataFile = bst_simulation(ResultsFile, iVertices, Comment, isVolumeA
 %     - ResultsFile : Full or relative path to a brainstorm sources file
 %     - iVertices   : Indices of the sources to use to simulate the recordings
 %     - Comment     : Comment inserted in the created file
+%     - iStudy      : Output study
 % OUTPUT:
 %     - newDataFile : Full path to the simulated recordings file created and saved in the database
 
@@ -34,6 +35,12 @@ function newDataFile = bst_simulation(ResultsFile, iVertices, Comment, isVolumeA
 
 %% ===== PARSE INPUTS =====
 global GlobalData;
+
+% If target study is empty, we use the study of the source map
+if (nargin < 5) || isempty(iStudy)
+    [sStudy, iStudy] = bst_get('ResultsFile', ResultsFile);
+end
+
 % Is iVertices obtained on a volume atlas
 if (nargin < 4) || isempty(isVolumeAtlas)
     isVolumeAtlas = 0;
@@ -118,8 +125,7 @@ end
 
 % ===== LOAD GAIN MATRIX =====
 bst_progress('text', 'Loading head model...');
-% Get study
-[sStudy, iStudy] = bst_get('ResultsFile', ResultsFile);
+
 % Get default headmodel for this study
 sHeadModel = bst_get('HeadModelForStudy', iStudy);
 if isempty(sHeadModel)

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1897,8 +1897,8 @@ switch (lower(action))
                 if ~bst_get('ReadOnly') && ~isRaw && ~ismember(iStudy, iDefStudy) && ~isStat    % && ~isempty(strfind(filenameRelative, '_wMNE')) && ~strcmpi(sStudy.Result(iResult).HeadModelType, 'mixed')
                     jMenuModality = gui_component('Menu', jPopup, [], 'Model evaluation', IconLoader.ICON_RESULTS, [], []);
                     gui_component('MenuItem', jMenuModality, [], 'Simulate recordings', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)bst_simulation(filenameRelative));
-                    gui_component('MenuItem', jMenuModality, [], 'Simulate recordings on a different montage', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)fcnPopupSimulateRecording(filenameRelative));
-
+                    gui_component('MenuItem', jMenuModality, [], 'Simulate recordings for other folders...', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)SimulateDataOtherStudy(sStudy.BrainStormSubject, iStudy, filenameRelative));
+                    AddSeparator(jMenuModality);
                     if ~isempty(DataFile)
                         gui_component('MenuItem', jMenuModality, [], 'Save whitened recordings', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)SaveWhitenedData(filenameRelative));
                     end
@@ -4004,20 +4004,29 @@ function SimulateSimmeeg(iStudy)
     bst_simmeeg('GUI', iStudy);
 end
 
-%% 
 
-function fcnPopupSimulateRecording(filenameRelative)
-
-    % Load study list
-    filename_split = strsplit(filenameRelative, '/');
-    sSubject = bst_get('Subject', filename_split{1});
-    [sSubjStudies, ~] = bst_get('StudyWithSubject', sSubject.FileName,'intra_subject', 'default_study');
-
+%% ===== SIMULATE RECORDINGS OTHER FOLDERS =====
+function SimulateDataOtherStudy(SubjectFilename, iStudy, FilenameRelative)
+    % Find other Studies with head models for same Subject
+    [sStudies, iStudies] = bst_get('StudyWithSubject', SubjectFilename, 'intra_subject', 'default_study');
+    iValid = logical([]);
+    for ix = 1 : length(iStudies)
+        sHeadModel = bst_get('HeadModelForStudy', iStudies(ix));
+        iValid(end+1) = ~isempty(sHeadModel) && iStudies(ix) ~= iStudy;
+    end
+    sStudies = sStudies(iValid);
+    iStudies = iStudies(iValid);
+    if isempty(sStudies)
+        disp('BST> Error: There are not other folders with a head model file for this Subject.');
+        return
+    end
+    % Names to show
+    StudyNames = arrayfun(@(x) x.Condition{1}, sStudies, 'UniformOutput', 0);
     % Ask which subject to use
-    StudyName = java_dialog('combo', '<HTML>Select the destination study:<BR><BR>', 'Project sources', [], {sSubjStudies.Name});
+    StudyName = java_dialog('combo', '<HTML>Select the destination folder:<BR><BR>', 'Simulate recordings', [], StudyNames);
     if isempty(StudyName)
         return
     end
-    iStudy = find(strcmpi(StudyName, {sSubjStudies.Name}));
-    bst_simulation(filenameRelative, [], [], [], iStudy);
+    ix = strcmpi(StudyName, StudyNames);
+    bst_simulation(FilenameRelative, [], [], [], iStudies(ix));
 end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -4022,7 +4022,7 @@ function SimulateDataOtherStudy(SubjectFilename, iStudy, FilenameRelative)
     end
     % Names to show
     StudyNames = arrayfun(@(x) x.Condition{1}, sStudies, 'UniformOutput', 0);
-    % Ask which subject to use
+    % Ask which study to use
     StudyName = java_dialog('combo', '<HTML>Select the destination folder:<BR><BR>', 'Simulate recordings', [], StudyNames);
     if isempty(StudyName)
         return

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1897,6 +1897,8 @@ switch (lower(action))
                 if ~bst_get('ReadOnly') && ~isRaw && ~ismember(iStudy, iDefStudy) && ~isStat    % && ~isempty(strfind(filenameRelative, '_wMNE')) && ~strcmpi(sStudy.Result(iResult).HeadModelType, 'mixed')
                     jMenuModality = gui_component('Menu', jPopup, [], 'Model evaluation', IconLoader.ICON_RESULTS, [], []);
                     gui_component('MenuItem', jMenuModality, [], 'Simulate recordings', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)bst_simulation(filenameRelative));
+                    gui_component('MenuItem', jMenuModality, [], 'Simulate recordings on a different montage', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)fcnPopupSimulateRecording(filenameRelative));
+
                     if ~isempty(DataFile)
                         gui_component('MenuItem', jMenuModality, [], 'Save whitened recordings', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)SaveWhitenedData(filenameRelative));
                     end
@@ -4000,4 +4002,22 @@ function SimulateSimmeeg(iStudy)
     end
     % Call SimMEEG
     bst_simmeeg('GUI', iStudy);
+end
+
+%% 
+
+function fcnPopupSimulateRecording(filenameRelative)
+
+    % Load study list
+    filename_split = strsplit(filenameRelative, '/');
+    sSubject = bst_get('Subject', filename_split{1});
+    [sSubjStudies, ~] = bst_get('StudyWithSubject', sSubject.FileName,'intra_subject', 'default_study');
+
+    % Ask which subject to use
+    StudyName = java_dialog('combo', '<HTML>Select the destination study:<BR><BR>', 'Project sources', [], {sSubjStudies.Name});
+    if isempty(StudyName)
+        return
+    end
+    iStudy = find(strcmpi(StudyName, {sSubjStudies.Name}));
+    bst_simulation(filenameRelative, [], [], [], iStudy);
 end


### PR DESCRIPTION
Hello, 

This PR is here to allow users to choose the output study used to simulate recording from a source map instead of simulating within the same study. 


One use case that was presented in the forum is: you do source localization from EEG/MEG and then simulate the recording in SEEG from the source map: https://neuroimage.usc.edu/forums/t/ieeg-simulation-with-meg-data/56513

Before, the user would have to copy the source map to the study that contains the SEEG channel. With this, the copy is no longer necessary, which is good when doing simulations, as it avoids copying many maps. 


Edouard
