### PR TITLE
On volume contact sheet, show each dipole only on nearest slice

### DIFF
--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -519,6 +519,13 @@ function FigureMouseMoveCallback(hFig, varargin)
                         panel_surface('PlotMri', hFig, posXYZ, 1);
                         % Update sliders in surface panel
                         panel_surface('UpdateSurfaceProperties');
+                        if gui_brainstorm('isTabVisible', 'Dipoles')
+                            % Update dipoles if constrained to current slice
+                            DipolesInfo = panel_dipoles('GetDipolesForFigure', hFig);
+                            if DipolesInfo.DisplayCurrentSlice
+                                panel_dipoles('DisplayDipolesInSlices', hFig, 'current');
+                            end
+                        end
                     end
                 end
             end

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -2584,7 +2584,6 @@ function varargout = PlotSurface( hFig, faces, verts, surfaceColor, transparency
     end
 end
 
-
 %% ===== PLOT FIBERS =====
 function varargout = PlotFibers(hFig, FibPoints, Colors)
     dims = size(Colors);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -2577,6 +2577,57 @@ function varargout = PlotSurface( hFig, faces, verts, surfaceColor, transparency
     end
 end
 
+%% ===== SET SLICED DIPOLES VISIBILITY =====
+% Show only the dipoles that belong to the current MRI slice, for the volume contact
+% sheet (view_contactsheet). Without this, every dipole is drawn on every tile because
+% the slice loop only moves the MRI cut plane. Each dipole is assigned to its single
+% nearest slice, so it appears on exactly one tile (never smeared across all slices,
+% and never duplicated onto two adjacent slices).
+%   hFig      : 3D figure showing MRI slices
+%   dim       : slice dimension (1=sagittal, 2=coronal, 3=axial)
+%   allSlices : slice positions sampled by the contact sheet (voxel indices along dim)
+%   iCurSlice : index into allSlices of the slice currently displayed;
+%               pass 0 to restore full visibility of all dipoles (after the contact sheet)
+function SetSlicedDipolesVisibility(hFig, dim, allSlices, iCurSlice) %#ok<DEFNU>
+    hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
+    if isempty(hAxes)
+        return;
+    end
+    hPoint = [findobj(hAxes, 'Tag', 'DipolesLoc'); findobj(hAxes, 'Tag', 'DipolesOrient')];
+    if isempty(hPoint)
+        return;
+    end
+    % Restore mode: make all dipoles visible again
+    if (iCurSlice <= 0)
+        set(hPoint, 'Visible', 'on');
+        return;
+    end
+    sMri = panel_surface('GetSurfaceMri', hFig);
+    if isempty(sMri)
+        return;
+    end
+    allSlices = allSlices(:)';
+    % Outer tolerance: half the largest gap between sampled slices (in voxels). Dipoles
+    % farther than this from every slice (e.g. in the skipped border region) stay hidden.
+    if (numel(allSlices) > 1)
+        sliceTol = max(abs(diff(allSlices))) / 2;
+    else
+        sliceTol = Inf;
+    end
+    % Nearest-slice assignment: each dipole is shown on its single closest slice
+    for i = 1:numel(hPoint)
+        xd = get(hPoint(i), 'XData');  yd = get(hPoint(i), 'YData');  zd = get(hPoint(i), 'ZData');
+        v = cs_convert(sMri, 'scs', 'voxel', [xd(1), yd(1), zd(1)]);
+        [minDist, iNearest] = min(abs(allSlices - v(dim)));
+        if (iNearest == iCurSlice) && (minDist <= sliceTol)
+            set(hPoint(i), 'Visible', 'on');
+        else
+            set(hPoint(i), 'Visible', 'off');
+        end
+    end
+end
+
+
 %% ===== PLOT FIBERS =====
 function varargout = PlotFibers(hFig, FibPoints, Colors)
     dims = size(Colors);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -2577,56 +2577,6 @@ function varargout = PlotSurface( hFig, faces, verts, surfaceColor, transparency
     end
 end
 
-%% ===== SET SLICED DIPOLES VISIBILITY =====
-% Show only the dipoles that belong to the current MRI slice, for the volume contact
-% sheet (view_contactsheet). Without this, every dipole is drawn on every tile because
-% the slice loop only moves the MRI cut plane. Each dipole is assigned to its single
-% nearest slice, so it appears on exactly one tile (never smeared across all slices,
-% and never duplicated onto two adjacent slices).
-%   hFig      : 3D figure showing MRI slices
-%   dim       : slice dimension (1=sagittal, 2=coronal, 3=axial)
-%   allSlices : slice positions sampled by the contact sheet (voxel indices along dim)
-%   iCurSlice : index into allSlices of the slice currently displayed;
-%               pass 0 to restore full visibility of all dipoles (after the contact sheet)
-function SetSlicedDipolesVisibility(hFig, dim, allSlices, iCurSlice) %#ok<DEFNU>
-    hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
-    if isempty(hAxes)
-        return;
-    end
-    hPoint = [findobj(hAxes, 'Tag', 'DipolesLoc'); findobj(hAxes, 'Tag', 'DipolesOrient')];
-    if isempty(hPoint)
-        return;
-    end
-    % Restore mode: make all dipoles visible again
-    if (iCurSlice <= 0)
-        set(hPoint, 'Visible', 'on');
-        return;
-    end
-    sMri = panel_surface('GetSurfaceMri', hFig);
-    if isempty(sMri)
-        return;
-    end
-    allSlices = allSlices(:)';
-    % Outer tolerance: half the largest gap between sampled slices (in voxels). Dipoles
-    % farther than this from every slice (e.g. in the skipped border region) stay hidden.
-    if (numel(allSlices) > 1)
-        sliceTol = max(abs(diff(allSlices))) / 2;
-    else
-        sliceTol = Inf;
-    end
-    % Nearest-slice assignment: each dipole is shown on its single closest slice
-    for i = 1:numel(hPoint)
-        xd = get(hPoint(i), 'XData');  yd = get(hPoint(i), 'YData');  zd = get(hPoint(i), 'ZData');
-        v = cs_convert(sMri, 'scs', 'voxel', [xd(1), yd(1), zd(1)]);
-        [minDist, iNearest] = min(abs(allSlices - v(dim)));
-        if (iNearest == iCurSlice) && (minDist <= sliceTol)
-            set(hPoint(i), 'Visible', 'on');
-        else
-            set(hPoint(i), 'Visible', 'off');
-        end
-    end
-end
-
 
 %% ===== PLOT FIBERS =====
 function varargout = PlotFibers(hFig, FibPoints, Colors)

--- a/toolbox/gui/panel_dipoles.m
+++ b/toolbox/gui/panel_dipoles.m
@@ -137,6 +137,8 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
         jToggleAllTimes.setSelected(1);
         jButtonSetSel = gui_component('Button', jPanelOptions, '', 'Set', Insets(1,5,1,5), 'Set the current time as the preferred time for the loaded group(s)', @SetSelectedTime_Callback);
         jButtonSetSel.setFocusable(0);
+        jToggleCurSlices = gui_component('Checkbox', jPanelOptions, 'br', 'Show only on current slices', [], 'Show only dipoles on the current slices', @(h,ev)FireUpdateDisplayOptions);
+        jToggleCurSlices.setSelected(0);
     jPanelNew.add(jPanelOptions);
     
     % ===== PANEL: COLOR =====
@@ -197,6 +199,7 @@ function bstPanelNew = CreatePanel() %#ok<DEFNU>
                                   'jSliderConfVol',        jSliderConfVol, ...
                                   'jToggleSelTimes',       jToggleSelTimes, ...
                                   'jButtonSetSel',         jButtonSetSel, ...
+                                  'jToggleCurSlices',      jToggleCurSlices, ...
                                   'jTitleDipSize',         jTitleDipSize, ...
                                   'jSliderDipSize',        jSliderDipSize, ...
                                   'jTitleTailWidth',       jTitleTailWidth, ...
@@ -393,6 +396,7 @@ function DipolesInfo = GetDipolesForFigure(hFig)
     DipolesInfo.DisplayAllTime = 0;
     DipolesInfo.DisplayMaxGoodness = 0;
     DipolesInfo.DisplaySelTimes = 0;
+    DipolesInfo.DisplayCurrentSlice = 0;
     
     % Get Dipoles description in figure
     DipolesApp = getappdata(hFig, 'Dipoles');
@@ -475,6 +479,17 @@ function DipolesInfo = GetDipolesForFigure(hFig)
     % Show maximum goodness of selected dipoles
     if ctrl.jToggleMaxGoodness.isSelected()
         DipolesInfo.DisplayMaxGoodness = 1;
+    end
+    % Shows only dipoles on current slices
+    sMri = panel_surface('GetSurfaceMri', hFig);
+    if ~isempty(sMri)
+        ctrl.jToggleCurSlices.setVisible(1);
+        if ctrl.jToggleCurSlices.isSelected()
+            DipolesInfo.DisplayCurrentSlice = 1;
+        end
+    else
+        ctrl.jToggleCurSlices.setSelected(0);
+        ctrl.jToggleCurSlices.setVisible(0);
     end
 end
 
@@ -879,6 +894,10 @@ function PlotSelectedDipoles(hFig)
                     'Parent',     hAxes);
             end
         end
+    end
+    % Display only dipoles on current slices
+    if DipolesInfo.DisplayCurrentSlice
+        DisplayDipolesInSlices(hFig, 'current');
     end
     % Force updating this figure before upd
     drawnow

--- a/toolbox/gui/panel_dipoles.m
+++ b/toolbox/gui/panel_dipoles.m
@@ -1024,3 +1024,91 @@ end
 
 
 
+%% ===== DISPLAY DIPOLES IN TARGET SLICES =====
+% DisplayDipolesInSlices(hFig, slices, refSlices)
+% Show only the dipoles that belong to the target MRI slice
+%   hFig      : 3D figure showing MRI slices
+%   slices    : 'all',     show all dipoles regardless the current slide (Default)
+%               'current', show only dipoles that belong to the current slices
+%               [X, Y, Z], show only dipoles that belong to these slices, set dimension to NaN to ignore it
+%               []         hide all dipoles regardless the current slide
+%   refSlices : dipoles will be shown in the referece slices that are closest to 'slices'
+%               If absent, refSlices are all the slices in the volume
+function DisplayDipolesInSlices(hFig, slices, refSlices)
+    % Only for 3D figures with MRI
+    FigureId = getappdata(hFig, 'FigureId');
+    [sMri, TessInfo, iTess] = panel_surface('GetSurfaceMri', hFig);
+    if ~strcmpi(FigureId.Type, '3DViz') || isempty(sMri)
+        return
+    end
+    % Parse 'slices'
+    isValidSlice = isnumeric(slices) || ischar(slices);
+    if nargin < 2 || ~isValidSlice
+        slices = 'all';
+    end
+    % Reference slices
+    if nargin < 3 || isempty(refSlices)
+        mriSize = size(sMri.Cube);
+        for iDim = 1 : 3
+            tmp = [1:mriSize(iDim)];
+            if (iDim == 2) || (iDim == 3)
+                tmp = bst_flip(tmp,2);
+            end
+            refSlices{iDim} = tmp;
+        end
+    end
+    if ~iscell(refSlices)
+        refSlices = {refSlices};
+    end
+    % Get dipole graphic elements
+    hAxes = findobj(hFig, '-depth', 1, 'Tag', 'Axes3D');
+    hPoints = [findobj(hAxes, 'Tag', 'DipolesLoc'); findobj(hAxes, 'Tag', 'DipolesOrient')];
+    if isempty(hPoints)
+        return
+    end
+    % Handle char slices input
+    if ischar(slices)
+        % Restore mode: make all dipoles visible again
+        if strcmpi(slices, 'all')
+            set(hPoints, 'Visible', 'on');
+            return
+        % Get current
+        elseif strcmpi(slices, 'current')
+            slices = TessInfo(iTess).CutsPosition;
+        % Ignore
+        else
+            return
+        end
+    end
+    % Hide all dipoles
+    set(hPoints, 'Visible', 'off');
+    % Handle '[]' input
+    if isnumeric(slices) && isempty(slices)
+        return
+    end
+
+    % Get all graphics positions in voxels
+    x = get(hPoints, 'XData');
+    y = get(hPoints, 'YData');
+    z = get(hPoints, 'ZData');
+    if ~iscell(x)
+        x = {x}; y = {y}; z = {z};
+    end
+    locs = [cellfun(@(v) v(1), x), cellfun(@(v) v(1), y), cellfun(@(v) v(1), z)];
+    locs = cs_convert(sMri, 'scs', 'voxel', locs);
+
+    % Dimensions to check
+    dims = find(~isnan(slices));
+    refSlices = refSlices(dims);
+    locs = locs(:,dims);
+
+    % Check distance for each dimension
+    isObjVisible = false(length(hPoints), length(dims));
+    for iDim = 1 : length(dims)
+        iClosestSlide = bst_closest(locs(:, iDim)', refSlices{iDim});
+        isObjVisible(:, iDim) = refSlices{iDim}(iClosestSlide) == slices(iDim);
+    end
+    % Set to visible selected objects
+    isObjVisible = any(isObjVisible, 2);
+    set(hPoints(isObjVisible), 'Visible', 'on');
+end

--- a/toolbox/gui/panel_dipoles.m
+++ b/toolbox/gui/panel_dipoles.m
@@ -1118,6 +1118,7 @@ function DisplayDipolesInSlices(hFig, slices, refSlices)
 
     % Dimensions to check
     dims = find(~isnan(slices));
+    slices = slices(dims);
     refSlices = refSlices(dims);
     locs = locs(:,dims);
 

--- a/toolbox/gui/view_contactsheet.m
+++ b/toolbox/gui/view_contactsheet.m
@@ -309,6 +309,8 @@ for iSample = 1:nImages
             slicesPos = [NaN NaN NaN];
             slicesPos(dim) = Samples(iSample);
             panel_surface('PlotMri', hFig, slicesPos);
+            % Show only the dipoles that belong to this slice (not on every tile)
+            figure_3d('SetSlicedDipolesVisibility', hFig, dim, Samples, iSample);
     end
     % Get screen capture
     switch lower(inctype)
@@ -329,6 +331,8 @@ switch lower(inctype)
         TessInfo(iTess).CutsPosition = initPos;
         setappdata(hFig, 'Surface', TessInfo);
         figure_3d('UpdateMriDisplay', hFig, dim, TessInfo, iTess);
+        % Restore full dipole visibility after the contact sheet
+        figure_3d('SetSlicedDipolesVisibility', hFig, dim, Samples, 0);
 end
 % Backup current view
 if is3D && dim ~= 0

--- a/toolbox/gui/view_contactsheet.m
+++ b/toolbox/gui/view_contactsheet.m
@@ -309,8 +309,9 @@ for iSample = 1:nImages
             slicesPos = [NaN NaN NaN];
             slicesPos(dim) = Samples(iSample);
             panel_surface('PlotMri', hFig, slicesPos);
-            % Show only the dipoles that belong to this slice (not on every tile)
-            figure_3d('SetSlicedDipolesVisibility', hFig, dim, Samples, iSample);
+            % Show only the dipoles that belong to this slice
+            refSlices = {[], [], []}; refSlices{dim} = Samples;
+            panel_dipoles('DisplayDipolesInSlices', hFig, slicesPos, refSlices);
     end
     % Get screen capture
     switch lower(inctype)
@@ -332,7 +333,7 @@ switch lower(inctype)
         setappdata(hFig, 'Surface', TessInfo);
         figure_3d('UpdateMriDisplay', hFig, dim, TessInfo, iTess);
         % Restore full dipole visibility after the contact sheet
-        figure_3d('SetSlicedDipolesVisibility', hFig, dim, Samples, 0);
+        panel_dipoles('DisplayDipolesInSlices', hFig, 'all');
 end
 % Backup current view
 if is3D && dim ~= 0


### PR DESCRIPTION
Previously dipoles were on every slice which was difficult to interpret.

The issue was mentioned here:
https://neuroimage.usc.edu/forums/t/dipole-mri-viewer-contact-sheet-error/47730

Before:
<img width="600" alt="before_axial" src="https://github.com/user-attachments/assets/b2004064-8caa-4efe-a781-f0c61ace3b11" />

After:
<img width="600" alt="after_axial" src="https://github.com/user-attachments/assets/2f9a54fd-8580-440d-b817-c7a7b687facd" />