### PR TITLE
Modifications to display row table names

### DIFF
--- a/toolbox/gui/view_matrix.m
+++ b/toolbox/gui/view_matrix.m
@@ -156,10 +156,16 @@ switch lower(DisplayMode)
     case 'table'
         % Progress bar
         bst_progress('start', 'View data as table', 'Loading data...');
-        % Values as cell of char verctors
+        % Reload to have access to all the fields
+        sMatRaw = in_bst_matrix(MatFile);
+        % Values as cell of char vectors
         ValueCell = reshape(cellstr(num2str(Value(:))), size(Value,1), size(Value,2));
-        % Define column headers
-        if (size(sMat.Description,2) == size(Value,2))
+        
+        % Define column headers (Priority to ColNames, otherwise Description, otherwise Time)
+        if isfield(sMatRaw, 'ColNames') && ~isempty(sMatRaw.ColNames)
+            headers = sMatRaw.ColNames(:)';
+            firstHeader = ' ';
+        elseif (size(sMat.Description,2) == size(Value,2))
             headers = sMat.Description(1,:);
             firstHeader = ' ';
         elseif (length(sMat.Time) == size(Value,2))
@@ -168,14 +174,23 @@ switch lower(DisplayMode)
         else
             headers = [];
         end
-        % Add row descriptions as first column
-        isRowTitle = (size(sMat.Description,1) == size(Value,1));
-        if isRowTitle
-            ValueCell = cat(2, sMat.Description(:,1), ValueCell);
+        
+        % Dealing with row names
+        rowTitles = [];
+        if isfield(sMatRaw, 'RowNames') && ~isempty(sMatRaw.RowNames) && (length(sMatRaw.RowNames) == size(Value,1))
+            rowTitles = sMatRaw.RowNames(:);
+        elseif (size(sMat.Description,1) == size(Value,1))
+            rowTitles = sMat.Description(:,1);
+        end
+        
+        % Add row titles as first column if they exist
+        if ~isempty(rowTitles)
+            ValueCell = cat(2, rowTitles, ValueCell);
             if ~isempty(headers)
                 headers = cat(2, firstHeader, headers);
             end
         end
+        
         % View table
         view_table(ValueCell, headers, MatFile);
         bst_progress('stop');

--- a/toolbox/gui/view_matrix.m
+++ b/toolbox/gui/view_matrix.m
@@ -156,16 +156,10 @@ switch lower(DisplayMode)
     case 'table'
         % Progress bar
         bst_progress('start', 'View data as table', 'Loading data...');
-        % Reload to have access to all the fields
-        sMatRaw = in_bst_matrix(MatFile);
-        % Values as cell of char vectors
+        % Values as cell of char verctors
         ValueCell = reshape(cellstr(num2str(Value(:))), size(Value,1), size(Value,2));
-        
-        % Define column headers (Priority to ColNames, otherwise Description, otherwise Time)
-        if isfield(sMatRaw, 'ColNames') && ~isempty(sMatRaw.ColNames)
-            headers = sMatRaw.ColNames(:)';
-            firstHeader = ' ';
-        elseif (size(sMat.Description,2) == size(Value,2))
+        % Define column headers
+        if (size(sMat.Description,2) == size(Value,2))
             headers = sMat.Description(1,:);
             firstHeader = ' ';
         elseif (length(sMat.Time) == size(Value,2))
@@ -174,23 +168,14 @@ switch lower(DisplayMode)
         else
             headers = [];
         end
-        
-        % Dealing with row names
-        rowTitles = [];
-        if isfield(sMatRaw, 'RowNames') && ~isempty(sMatRaw.RowNames) && (length(sMatRaw.RowNames) == size(Value,1))
-            rowTitles = sMatRaw.RowNames(:);
-        elseif (size(sMat.Description,1) == size(Value,1))
-            rowTitles = sMat.Description(:,1);
-        end
-        
-        % Add row titles as first column if they exist
-        if ~isempty(rowTitles)
-            ValueCell = cat(2, rowTitles, ValueCell);
+        % Add row descriptions as first column
+        isRowTitle = (size(sMat.Description,1) == size(Value,1));
+        if isRowTitle
+            ValueCell = cat(2, sMat.Description(:,1), ValueCell);
             if ~isempty(headers)
                 headers = cat(2, firstHeader, headers);
             end
         end
-        
         % View table
         view_table(ValueCell, headers, MatFile);
         bst_progress('stop');

--- a/toolbox/gui/view_table.m
+++ b/toolbox/gui/view_table.m
@@ -66,26 +66,24 @@ jTable.getTableHeader.setReorderingAllowed(0);
 for iHeader = 1:length(Headers)
     jTable.getColumnModel().getColumn(iHeader-1).setHeaderValue(Headers{iHeader});
 end
-
-% Fix the width of the cell to the largest element of the column
+% Set column with to the widest element of the column
 for iCol = 0:(jTable.getColumnCount() - 1)
     colModel = jTable.getColumnModel().getColumn(iCol);
-    
+    % Header width
     headerRenderer = jTable.getTableHeader().getDefaultRenderer();
     headerValue = colModel.getHeaderValue();
     headerComp = headerRenderer.getTableCellRendererComponent(jTable, headerValue, false, false, -1, iCol);
     maxSize = headerComp.getPreferredSize().width;
-    
+    % Max width across rows
     for iRow = 0:(jTable.getRowCount() - 1)
         cellRenderer = jTable.getCellRenderer(iRow, iCol);
         cellValue = jTable.getValueAt(iRow, iCol);
         cellComp = cellRenderer.getTableCellRendererComponent(jTable, cellValue, false, false, iRow, iCol);
         maxSize = max(maxSize, cellComp.getPreferredSize().width);
     end
-    
+    % Set column width
     colModel.setPreferredWidth(maxSize + 15);
 end
-
 % Create scroll panel
 jScroll = JScrollPane(jTable);
 jScroll.setBorder([]);

--- a/toolbox/gui/view_table.m
+++ b/toolbox/gui/view_table.m
@@ -66,6 +66,26 @@ jTable.getTableHeader.setReorderingAllowed(0);
 for iHeader = 1:length(Headers)
     jTable.getColumnModel().getColumn(iHeader-1).setHeaderValue(Headers{iHeader});
 end
+
+% Fix the width of the cell to the largest element of the column
+for iCol = 0:(jTable.getColumnCount() - 1)
+    colModel = jTable.getColumnModel().getColumn(iCol);
+    
+    headerRenderer = jTable.getTableHeader().getDefaultRenderer();
+    headerValue = colModel.getHeaderValue();
+    headerComp = headerRenderer.getTableCellRendererComponent(jTable, headerValue, false, false, -1, iCol);
+    maxSize = headerComp.getPreferredSize().width;
+    
+    for iRow = 0:(jTable.getRowCount() - 1)
+        cellRenderer = jTable.getCellRenderer(iRow, iCol);
+        cellValue = jTable.getValueAt(iRow, iCol);
+        cellComp = cellRenderer.getTableCellRendererComponent(jTable, cellValue, false, false, iRow, iCol);
+        maxSize = max(maxSize, cellComp.getPreferredSize().width);
+    end
+    
+    colModel.setPreferredWidth(maxSize + 15);
+end
+
 % Create scroll panel
 jScroll = JScrollPane(jTable);
 jScroll.setBorder([]);


### PR DESCRIPTION
Hello, 

i'm currently working with @Edouard2laire in Christophe Grova's Lab. I've been facing issues on saving metric results as tables : https://neuroimage.usc.edu/forums/t/issue-with-tables/57522 

This code has been done in order to improve the visualization of tables in Brainstorm : 
1) Row names are now displayed in brainstorm (view_matrix.m file : sMatRaw.RowNames)
2) The width of each column is set to the largest element of the column (view_table.m file)

Thanks a lot, 
Jean-Eudes