### PR TITLE
bugfix: correctly identify event that needs channel information

### DIFF
--- a/toolbox/process/functions/process_combine_recordings.m
+++ b/toolbox/process/functions/process_combine_recordings.m
@@ -177,7 +177,7 @@ function OutputFiles = Run(sProcess, sInputs)
         tmpEvents = poolEvents(poolEventsIx == iInput);
         for iEvent = 1 : length(tmpEvents)
             tmpEvent = tmpEvents(iEvent);
-            if poolEventsFx(iEvent)
+            if ~poolEventsFx(iEvent)
                 % Add channel info
                 addedChannelNames = {NewChannelMat.Channel(sIdxChNew{iInput}).Name};
                 nOccurences = size(tmpEvent.times, 2);


### PR DESCRIPTION
right now, it was adding channel information to event even if the event was present only in one file (MEG for example)