### PR TITLE
[Project sources] Allow to specify target study

### DIFF
--- a/toolbox/math/bst_project_sources.m
+++ b/toolbox/math/bst_project_sources.m
@@ -38,7 +38,6 @@ end
 if (nargin < 3) || isempty(isAbsoluteValues)
     isAbsoluteValues = 0;
 end
-
 if (nargin < 4) || isempty(destStudyName) || ~ischar(destStudyName)
     destStudyName = '';
 end

--- a/toolbox/math/bst_project_sources.m
+++ b/toolbox/math/bst_project_sources.m
@@ -1,7 +1,7 @@
-function OutputFiles = bst_project_sources( ResultsFile, destSurfFile, isAbsoluteValues, isInteractive )
+function OutputFiles = bst_project_sources( ResultsFile, destSurfFile, isAbsoluteValues, isInteractive, iDestStudy )
 % BST_PROJECT_SOURCES: Project source files on a different surface (currents or timefreq).
 %
-% USAGE:  OutputFiles = bst_project_sources( ResultsFile, DestSurfFile, isAbsoluteValues=0, isInteractive=1 )
+% USAGE:  OutputFiles = bst_project_sources( ResultsFile, DestSurfFile, isAbsoluteValues=0, isInteractive=1, iDestStudy = [auto] )
 % 
 % INPUT:
 %    - ResultsFile      : Relative path to sources file to reproject
@@ -9,6 +9,7 @@ function OutputFiles = bst_project_sources( ResultsFile, destSurfFile, isAbsolut
 %    - isAbsoluteValues : If 1, interpolate absolute values of the sources instead of relative values
 %    - isInteractive    : If 1, displays questions and dialog boxes
 %                         If 0, consider that it is running from the process interface
+%    - iDestStudy    : Destination study (must be in the same subject as destSurfFile)
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -36,6 +37,10 @@ if (nargin < 4) || isempty(isInteractive)
 end
 if (nargin < 3) || isempty(isAbsoluteValues)
     isAbsoluteValues = 0;
+end
+
+if (nargin < 4) || isempty(iDestStudy)
+    iDestStudy = [];
 end
 
 %% ===== GROUP BY SURFACES =====
@@ -195,8 +200,11 @@ for iGroup = 1:nGroup
         % ===== OUTPUT STUDY =====
         % Get source study
         [sSrcStudy, iSrcStudy] = bst_get('AnyFile', ResultsFile);
+        %If target study is provided
+        if ~isempty(iDestStudy)
+            sDestStudy = bst_get('Study', iDestStudy);
         % If result has to be save in "group analysis" subject
-        if ~isSameSubject
+        elseif ~isSameSubject
             % New condition name
             NewCondition = strrep(sSrcStudy.Condition{1}, '@raw', '');
             % Get condition

--- a/toolbox/math/bst_project_sources.m
+++ b/toolbox/math/bst_project_sources.m
@@ -1,7 +1,7 @@
-function OutputFiles = bst_project_sources( ResultsFile, destSurfFile, isAbsoluteValues, isInteractive, iDestStudy )
+function OutputFiles = bst_project_sources( ResultsFile, destSurfFile, isAbsoluteValues, isInteractive, destStudyName )
 % BST_PROJECT_SOURCES: Project source files on a different surface (currents or timefreq).
 %
-% USAGE:  OutputFiles = bst_project_sources( ResultsFile, DestSurfFile, isAbsoluteValues=0, isInteractive=1, iDestStudy = [auto] )
+% USAGE:  OutputFiles = bst_project_sources( ResultsFile, DestSurfFile, isAbsoluteValues=0, isInteractive=1, destStudyName=[] )
 % 
 % INPUT:
 %    - ResultsFile      : Relative path to sources file to reproject
@@ -9,7 +9,7 @@ function OutputFiles = bst_project_sources( ResultsFile, destSurfFile, isAbsolut
 %    - isAbsoluteValues : If 1, interpolate absolute values of the sources instead of relative values
 %    - isInteractive    : If 1, displays questions and dialog boxes
 %                         If 0, consider that it is running from the process interface
-%    - iDestStudy    : Destination study (must be in the same subject as destSurfFile)
+%    - destStudyName    : Destination study Name. If empty use the Name of the ResultsFile Study. Subject = destSurfFile Subject
 
 % @=============================================================================
 % This function is part of the Brainstorm software:
@@ -39,8 +39,8 @@ if (nargin < 3) || isempty(isAbsoluteValues)
     isAbsoluteValues = 0;
 end
 
-if (nargin < 4) || isempty(iDestStudy)
-    iDestStudy = [];
+if (nargin < 4) || isempty(destStudyName) || ~ischar(destStudyName)
+    destStudyName = '';
 end
 
 %% ===== GROUP BY SURFACES =====
@@ -181,6 +181,8 @@ for iGroup = 1:nGroup
             sDestSubj = bst_get('NormalizedSubject');
             sDestSubj.Name = bst_get('NormalizedSubjectName');
         end
+    else
+        sDestSubj = sSrcSubj;
     end
     
     % ===== PROCESS EACH FILE =====
@@ -200,27 +202,29 @@ for iGroup = 1:nGroup
         % ===== OUTPUT STUDY =====
         % Get source study
         [sSrcStudy, iSrcStudy] = bst_get('AnyFile', ResultsFile);
-        %If target study is provided
-        if ~isempty(iDestStudy)
-            sDestStudy = bst_get('Study', iDestStudy);
-        % If result has to be save in "group analysis" subject
-        elseif ~isSameSubject
-            % New condition name
-            NewCondition = strrep(sSrcStudy.Condition{1}, '@raw', '');
+        iDestStudy = [];
+        if isempty(destStudyName)
+            % Use the source study as output study
+            if isSameSubject
+                sDestStudy = sSrcStudy;
+                iDestStudy = iSrcStudy;
+            % Same Name as srcStudy (w/o ^@raw)
+            else
+                destStudyName = regexprep(sSrcStudy.Condition{1}, '^@raw', '');
+            end
+        end
+        % Get or create destination Study
+        if isempty(iDestStudy)
             % Get condition
-            [sDestStudy, iDestStudy] = bst_get('StudyWithCondition', [sDestSubj.Name '/' NewCondition]);
+            [sDestStudy, iDestStudy] = bst_get('StudyWithCondition', [sDestSubj.Name '/' destStudyName]);
             % Create condition if doesnt exist
             if isempty(iDestStudy)
-                iDestStudy = db_add_condition(sDestSubj.Name, NewCondition, 0);
+                iDestStudy = db_add_condition(sDestSubj.Name, destStudyName, 0);
                 if isempty(iDestStudy)
-                    error(['Cannot create condition: "' normSubjName '/' NewCondition '".']);
+                    error(['Cannot create condition: "' sDestSubj.Name '/' destStudyName '".']);
                 end
                 sDestStudy = bst_get('Study', iDestStudy);
             end
-        % Else: use the source study as output study
-        else
-            sDestStudy = sSrcStudy;
-            iDestStudy = iSrcStudy;
         end
 
         % ===== LOAD INPUT FILE =====


### PR DESCRIPTION
Hello, 

This PR is here to allow specifying the target study when using bst_project_source from a script. 

Here is an example script we did today that could benefit from that. A map is imported in a group subject, then projected to another subject using bst_project_source. The modification allows nicely specifying the condition the map appears to.


```matlab
left_map    = 'L.func.gii';
right_map   = 'R.func.gii';

target_subject      = 'PXXXX';
target_condition    = 'hubness-zscore';

DisplayUnits = 'zscore';


% 0. Get Map name
[~, name, ext]  = fileparts(left_map);
name            = strrep(name, 'L.func', 'LR.func');

% Step 1. Import both texture to group
sSubject = bst_get('Subject', 'Group');
FSLR_5k = sSubject.Surface(strcmp({sSubject.Surface.Comment}, 'fsLR-5k.LR.surf'));

iStudies = db_add_condition('Group', sprintf('sub-%s',target_subject));
[OutputFile, errorMsg] = import_sources(iStudies, FSLR_5k.FileName, left_map, right_map, 'GII', name, DisplayUnits);

% Step 2. Project to subject
sSubject = bst_get('Subject', target_subject);
sCortex = sSubject.Surface(strcmp({sSubject.Surface.Comment}, 'mid_8002V'));


iStudies = db_add_condition(target_subject, target_condition);
sMaps = bst_project_sources( {OutputFile}, sCortex.FileName, 0, 0, iStudies);

```

  
  
   
---------------

Hs: it might be nice to be able to do the import directly from GUI. Right now, import_source cannot identify the left-/right maps because micapipe output name them XXX.L.YYY.gii; for example: "fsLR-5k.L.inflated.surf.gii" and "fsLR-5k.R.inflated.surf.gii"

would it be possible to include such naming schemes in https://github.com/brainstorm-tools/brainstorm3/blob/master/toolbox/io/import_sources.m#L117-L118 ? 


cc: @adascal1 