### PR TITLE
Fix GUI warning on matlab2026a

### DIFF
--- a/toolbox/gui/gui_show.m
+++ b/toolbox/gui/gui_show.m
@@ -148,7 +148,7 @@ switch (contType)
             end
         end
         % Show window: KEEP IT WITH AWTINVOKE
-        awtinvoke(jWindow, 'setVisible(Z)', 1);
+        javaMethodEDT('setVisible', jWindow, true);
         % Returned variable
         panelContainer.type   = 'JavaWindow';
         panelContainer.handle = {jWindow};


### PR DESCRIPTION
Fix the following warning in matlab2026a
In gui_brainstorm>@(h,ev)bst_call(@ProcessRun_Callback) (line 301) Warning: 'awtinvoke' is unsupported and might have been changed or removed without notice. With appropriate code changes, use javaMethodEDT instead.
> In awtinvoke (line 53)
In gui_show (line 151)
In db_edit_subject (line 59)
In tree_callbacks>@(h,ev)db_edit_subject (line 524)