### PR TITLE
GUI: Refactor: Show modal JavaWindows without blocking Matlab thread

### DIFF
--- a/toolbox/db/db_edit_subject.m
+++ b/toolbox/db/db_edit_subject.m
@@ -53,15 +53,20 @@ panelSubjectEditor = panel_subject_editor('CreatePanel');
 % Get handles to panel objects
 ctrl = get(panelSubjectEditor, 'sControls');
 
+% Title for panel: start with the first subject of the list to edit
+iSubject = iSubjectsList(1);
+panelTitle = sprintf('Edit subject #%d',iSubject);
+if (iSubject > nbSubjects)
+    panelTitle = sprintf('Create subject #%d',iSubject);
+end
+
+% Update values in panel
+UpdatePanel();
+
 % Set the 'Save' button callback
 java_setcb(ctrl.jButtonSave, 'ActionPerformedCallback', @updateSubjectModifications);
 % Show panel
-panelContainer = gui_show(panelSubjectEditor, 'JavaWindow', 'Edit subject', [], 1, 0, 0);
-
-% Start with the first subject of the list to edit
-iSubject = iSubjectsList(1);
-UpdatePanel();
-
+gui_show(panelSubjectEditor, 'JavaWindow', panelTitle, [], 1, 0, 0);
 
 
 %% =================================================================================
@@ -76,12 +81,10 @@ UpdatePanel();
         
         % EDITING EXISTING SUBJECT
         if ~isNewSubject
-            panelTitle = sprintf('Edit subject #%d',iSubject);
             % Get subject
             sSubject = bst_get('Subject', iSubject, 1);
         % NEW SUBJECT
         else
-            panelTitle = sprintf('Create subject #%d',iSubject);
             % Create new subject subject
             sSubject = db_template('Subject');
             sSubject.Name     = sprintf('Subject%02d', iSubject);
@@ -91,8 +94,6 @@ UpdatePanel();
             sSubject.UseDefaultChannel = ProtocolInfo.UseDefaultChannel;
         end
 
-        % Window title
-        panelContainer.handle{1}.setTitle(panelTitle);
         % Subject description
         ctrl.jTextSubjectName.setText(sSubject.Name);
         ctrl.jTextSubjectComments.setText(sSubject.Comments);

--- a/toolbox/gui/gui_edit_protocol.m
+++ b/toolbox/gui/gui_edit_protocol.m
@@ -108,16 +108,16 @@ end
 
 % Set the 'Save' button callback
 java_setcb(ctrl.jButtonSave, 'ActionPerformedCallback', @updateProtocolModificiations);
-% Show panel
-panelContainer = gui_show(panelProtocolEditor, 'JavaWindow', panelTitle, [], 1, 0, 0);
-drawnow;
-% Check that panel is not wider that 450px
+% Check that panel preferred size is not wider that 450px
+jHandle = get(panelProtocolEditor, 'jHandle');
 InterfaceScaling = bst_get('InterfaceScaling');
 MAX_WIDTH = round(450 * InterfaceScaling / 100);
-if (panelContainer.handle{1}.getSize().getWidth() > MAX_WIDTH)
-    newDim = java.awt.Dimension(MAX_WIDTH, panelContainer.handle{1}.getSize().getHeight());
-    panelContainer.handle{1}.setSize(newDim);   
+if (jHandle.getPreferredSize().getWidth() > MAX_WIDTH)
+    newDim = java.awt.Dimension(MAX_WIDTH, jHandle.getPreferredSize().getHeight());
+    jHandle.setPreferredSize(newDim);
 end
+% Show panel
+gui_show(panelProtocolEditor, 'JavaWindow', panelTitle, [], 1, 0, 0);
 
 
 %% =================================================================================

--- a/toolbox/gui/gui_show.m
+++ b/toolbox/gui/gui_show.m
@@ -147,8 +147,6 @@ switch (contType)
                 jWindow.setLocation(winPos(1),winPos(2));
             end
         end
-        % Show window: KEEP IT WITH AWTINVOKE
-        awtinvoke(jWindow, 'setVisible(Z)', 1);
         % Returned variable
         panelContainer.type   = 'JavaWindow';
         panelContainer.handle = {jWindow};
@@ -224,6 +222,12 @@ if isempty(GlobalData.Program.GUI.panels)
 else
     % Add the new panel to the panel list
     GlobalData.Program.GUI.panels(end+1) = bstPanel;
+end
+
+
+%% ===== SHOW JAVA WINDOWS =====
+if strcmpi(contType, 'JavaWindow')
+    java_call(jWindow, 'setVisible', 'Z', 1);
 end
 
 

--- a/toolbox/gui/gui_show_dialog.m
+++ b/toolbox/gui/gui_show_dialog.m
@@ -64,8 +64,13 @@ isAlwaysOnTop = 1;
 isMaximized = 0;
 gui_show(bstPanel, 'JavaWindow', panelTitle, [], isModal, isAlwaysOnTop, isMaximized, winPos);
 
-% Wait for the end of execution
-bst_mutex('waitfor', panelName);
+% Wait the panel to be closed
+if isModal
+    % Wait is done through the modal container
+else
+    % Wait for the end of execution (mutex release)
+    bst_mutex('waitfor', panelName);
+end
 
 % Restore progress bar
 if isProgressBarHidden
@@ -87,6 +92,7 @@ else
     % User closed panel
     panelContents = [];
 end
+
 
 
 

--- a/toolbox/timefreq/panel_timefreq_options.m
+++ b/toolbox/timefreq/panel_timefreq_options.m
@@ -443,8 +443,14 @@ function [bstPanelNew, panelName] = CreatePanel(sProcess, sFiles)  %#ok<DEFNU>
         if ~isempty(hFigWavelet) && ishandle(hFigWavelet)
             close(hFigWavelet);
         end
-        % Release mutex and keep the panel opened
+        % Release mutex
         bst_mutex('release', panelName);
+        % Unblock thread if container is a modal JavaWindow
+        bstPanel = bst_get('Panel', panelName);
+        jContainer = get(bstPanel, 'container');
+        if strcmpi(jContainer.type, 'JavaWindow') && isjava(jContainer.handle{1}) && jContainer.handle{1}.isModal == 1
+            java_call(jContainer.handle{1}, 'setVisible', 'Z', 0);
+        end
     end
 
 %% ===== UPDATE PANEL =====


### PR DESCRIPTION
This PR changes the call to `awtinvoke` to `java_call` (which preferentially uses `javaMethodEDT`).

The change has as goal to remove the reliance in `awtinvoke` as per the following warning (introduced in R2026a, and reported by @jeanborn and @Edouard2laire).

> Warning: 'awtinvoke' is unsupported and might have been changed or removed without notice. With appropriate code changes, use javaMethodEDT instead.

In the current (before this PR code), calling `awtinvoke` does not block the Matlab thread even when the `JavaWindow` is modal, so all the Matlab code continue. In the case of modal windows there are two approaches:

1. The panel gives the impression that the Matlab thread is blocked, as the Matlab code after creating the modal window just do minor changes in the panel (no further commands) e.g. `panel_protocol_editor`. So, only the callbacks of the panel remained to be executed. 

2. Where a real block of the Matlab thread is needed, the function `bst_mutex()` is used in the creation of the panel. And the `[OK]` button callback releases this mutex.

Now, by changing `awtinvoke` to `java_call` there is a block of the Matlab thread when the modal `JavaWindow` is shown. So there is the need of refactor in both cases of modal windows:

1. In this case, just perform all the panel modifications and set its callbacks before showing the modal `JavaWindow`(Commit 9edd66af532b2ed199819452ba5c07f65f70b17d). Only the callbacks of the panel need to be executed.

2. Panels with `bst_mutex`, e.g. `panel_timefreq_options`. Here, the Matlab thread is blocked by the modal window, thus its `[OK]` button callback does not work (it just releases the mutex). Ideally, when this panels are called, in modal mode, there is no need of the mutex, as the block will come from `java_call`.
