### PR TITLE
process_import_data_time: keep unit display

### DIFF
--- a/toolbox/io/in_fread.m
+++ b/toolbox/io/in_fread.m
@@ -204,6 +204,9 @@ switch (sFile.format)
         F = in_fread_spm(sFile, SamplesBounds, iChannels);
     case 'BST-BIN'
         F = in_fread_bst(sFile, sfid, SamplesBounds, ChannelRange);
+        if isfield(sFile, 'DisplayUnits') && ~isempty(sFile.DisplayUnits)
+            DisplayUnits = sFile.DisplayUnits;
+        end
     case 'BST-DATA'
         if ~isempty(SamplesBounds)
             fileSamples = round(sFile.prop.times * sFile.prop.sfreq);

--- a/toolbox/process/functions/process_import_data_time.m
+++ b/toolbox/process/functions/process_import_data_time.m
@@ -251,8 +251,9 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
             isRaw = (length(FileNames{iFile}) > 9) && ~isempty(strfind(FileNames{iFile}, 'data_0raw'));
             if isRaw
                 % Get sFile structure
-                FileMat = in_bst_data(FileNames{iFile}, 'F');
+                FileMat = in_bst_data(FileNames{iFile}, 'F', 'DisplayUnits');
                 sFile = FileMat.F;
+                sFile.DisplayUnits = FileMat.DisplayUnits;
                 % Read channel file
                 ChannelFile = bst_get('ChannelFileForStudy', FileNames{iFile});
                 ChannelMat = in_bst_channel(ChannelFile);


### PR DESCRIPTION
This is here to keep the file unit when converting a file from raw to epoch.